### PR TITLE
DESTDIR is not the same as PREFIX.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,20 @@
 ifndef PYTHON_SITELIB
   PYTHON_SITELIB=`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
 endif
+ifndef PREFIX
+  PREFIX=/usr
+endif
 
 install:
-	python setup.py install --prefix ${DESTDIR}/usr
-	mkdir -p ${DESTDIR}/usr/sbin/
-	chmod 755 ${DESTDIR}/${PYTHON_SITELIB}/pcs/pcs.py
-	ln -s ${PYTHON_SITELIB}/pcs/pcs.py ${DESTDIR}/usr/sbin/pcs
+	python setup.py install --prefix ${DESTDIR}${PREFIX}
+	mkdir -p ${DESTDIR}${PREFIX}/sbin/
+	chmod 755 ${DESTDIR}${PYTHON_SITELIB}/pcs/pcs.py
+	ln -s ${PYTHON_SITELIB}/pcs/pcs.py ${DESTDIR}${PREFIX}/sbin/pcs
+
+uninstall:
+	rm -f ${DESTDIR}${PREFIX}/sbin/pcs
+	rm -rf ${DESTDIR}${PYTHON_SITELIB}/pcs*
 
 tarball:
 	python setup.py sdist
+


### PR DESCRIPTION
DESTDIR: http://www.gnu.org/prep/standards/html_node/DESTDIR.html
PREFIX: http://www.gnu.org/prep/standards/html_node/Directory-Variables.html#Directory-Variables

When the system is not installed in '/' DESTDIR should be set to a value other than '/'.
PREFIX defines the directory where the binaries should be run from.

I added a simple uninstall to allow repeated installations.
