### PR TITLE
Fixed to be able to use the '=' in the 'value' of nvpair.

### DIFF
--- a/pcs/resource.py
+++ b/pcs/resource.py
@@ -790,8 +790,8 @@ def convert_args_to_instance_variables(ra_values, ra_id):
 def convert_args_to_tuples(ra_values):
     ret = []
     for ra_val in ra_values:
-        if ra_val.count("=") == 1:
-            split_val = ra_val.split("=")
+        if ra_val.count("=") != 0:
+            split_val = ra_val.split("=", 1)
             ret.append((split_val[0],split_val[1]))
     return ret
 


### PR DESCRIPTION
We want to use this primitive resource

   pcs -f pcsCIB resource create prmFsPostgreSQLDB1 ocf:heartbeat:Filesystem \
                   fstype="ext4" \
                   run_fsck="force" \
                   device="/dev/vda2" \
                   options="barrier=0" \
                   directory="/dbfp/pgdata" \
           op start interval="0s" timeout="60s" on-fail="restart" \
           op monitor interval="10s" timeout="60s" on-fail="restart" \
           op stop interval="0s" timeout="60s" on-fail="fence"

But the params "options="barrier=0"" was ignored.
The result was this.

```
    <primitive class="ocf" id="prmFsPostgreSQLDB1" provider="heartbeat" type="Filesystem">
      <instance_attributes id="prmFsPostgreSQLDB1-instance_attributes">
        <nvpair id="prmFsPostgreSQLDB1-instance_attributes-fstype" name="fstype" value="ext4"/>
        <nvpair id="prmFsPostgreSQLDB1-instance_attributes-run_fsck" name="run_fsck" value="force"/>
        <nvpair id="prmFsPostgreSQLDB1-instance_attributes-device" name="device" value="/dev/vda2"/>
        <nvpair id="prmFsPostgreSQLDB1-instance_attributes-directory" name="directory" value="/dbfp/pgdata"/>
      </instance_attributes>
      <operations>
        <op id="prmFsPostgreSQLDB1-start-interval-0s" interval="0s" name="start" on-fail="restart" timeout="60s"/>
        <op id="prmFsPostgreSQLDB1-monitor-interval-10s" interval="10s" name="monitor" on-fail="restart" timeout="60s"/>
        <op id="prmFsPostgreSQLDB1-stop-interval-0s" interval="0s" name="stop" on-fail="fence" timeout="60s"/>
      </operations>
    </primitive>
```

So I fixed the function convert_args_to_tuples() in resource.py.
Fixed function separates a word by only First "=".
