### PR TITLE
Allow Ubuntu to be supported in Makfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ endif
 ifeq ($(PYTHON_SITELIB), /usr/lib/python2.6/dist-packages)
   EXTRA_SETUP_OPTS="--install-layout=deb"
 endif
+ifeq ($(PYTHON_SITELIB), /usr/lib/python2.7/dist-packages)
+  EXTRA_SETUP_OPTS="--install-layout=deb"
+endif
 
 MANDIR=/usr/share/man
 


### PR DESCRIPTION
As noted in https://github.com/feist/pcs/issues/11, This allows versions of Debian, and Ubuntu to work properly with Makefile.  (May not be the cleanest, but makefile syntax doesn't seem to support logical and/or)
