### PR TITLE
validate the lenght of a ocf resource definition

### DIFF
--- a/pcs/utils.py
+++ b/pcs/utils.py
@@ -640,6 +640,8 @@ def is_valid_resource(resource, caseInsensitiveCheck=False):
     stonith_resource = False
     if resource.startswith("ocf:"):
         resource_split = resource.split(":",3)
+        if len(resource_split) != 3:
+            err("ocf resource definition (" + resource + ") does not match the ocf:provider:name pattern")
         providers = [resource_split[1]]
         resource = resource_split[2]
     elif resource.startswith("stonith:"):


### PR DESCRIPTION
This prevents the following traceback:

```
[root@nmdev078 ~]# pcs resource create mysql_vip-3 ocf:IPaddr2 cidr_netmask=22 ip=172.31.110.68
Traceback (most recent call last):
  File "/usr/sbin/pcs", line 129, in <module>
    main(sys.argv[1:])
  File "/usr/sbin/pcs", line 108, in main
    resource.resource_cmd(argv)
  File "/usr/lib/python2.6/site-packages/pcs/resource.py", line 71, in resource_cmd
    resource_create(res_id, res_type, ra_values, op_values, meta_values, clone_opts)
  File "/usr/lib/python2.6/site-packages/pcs/resource.py", line 286, in resource_create
    new_ra_type = utils.is_valid_resource(ra_type, True)
  File "/usr/lib/python2.6/site-packages/pcs/utils.py", line 503, in is_valid_resource
    resource = resource_split[2]
```

it is only needed for ocf:resource because the startwith of the other resources alreay include : and they maximum 2 parts.
