### PR TITLE
Coloring pcs status

### DIFF
--- a/pcs/app.py
+++ b/pcs/app.py
@@ -100,6 +100,8 @@ def main(argv=None):
             "remote", "watchdog=",
             #in pcs status - do not display resorce status on inactive node
             "hide-inactive",
+            # Add coloring to pcs status output
+            "color",
         ]
         # pull out negative number arguments and add them back after getopt
         prev_arg = ""

--- a/pcs/status.py
+++ b/pcs/status.py
@@ -7,6 +7,7 @@ from __future__ import (
 
 import sys
 import os
+import re
 
 from pcs import (
     resource,
@@ -99,6 +100,17 @@ def full_status():
         utils.corosyncPacemakerNodeCheck()
     ):
         print("WARNING: corosync and pacemaker node names do not match (IPs used in setup?)")
+
+    if "--color" in utils.pcs_options:
+        output = re.sub("Stopped", "\033[1;31mStopped\033[0m", output)
+        output = re.sub("Offline", "\033[1;31mOffline\033[0m", output)
+        output = re.sub("Started", "\033[1;32mStarted\033[0m", output)
+        output = re.sub("Online",  "\033[1;32mOnline\033[0m",  output)
+        output = re.sub("Masters", "\033[1;32mMasters\033[0m", output)
+        output = re.sub("Slaves",  "\033[1;36mSlaves\033[0m",  output)
+        output = re.sub("standby", "\033[1;34mstandby\033[0m", output)
+        output = re.sub("OFFLINE", "\033[1;31;5mOFFLINE\033[0m", output)
+        output = re.sub("Failed Actions",  "\033[1;31;5mFailed Actions\033[0m", output)
 
     print(output)
 

--- a/pcs/usage.py
+++ b/pcs/usage.py
@@ -1102,9 +1102,10 @@ def status(args = [], pout = True):
 Usage: pcs status [commands]...
 View current cluster and resource status
 Commands:
-    [status] [--full | --hide-inactive]
+    [status] [--full | --hide-inactive] [--color]
         View all information about the cluster and resources (--full provides
-        more details, --hide-inactive hides inactive resources).
+        more details, --hide-inactive hides inactive resources,
+        --color highlights status of nodes and services).
 
     resources
         View current status of cluster resources.


### PR DESCRIPTION
Hi,

here is a patch which adds fancy colors and effects to `pcs status` output.
It is expected, that it will enhance usability.

New form of output will be available by `pcs status --color`.