### PR TITLE
fix disable_service

### DIFF
--- a/pcsd/pcs.rb
+++ b/pcsd/pcs.rb
@@ -1995,14 +1995,14 @@ def enable_service(service)
 end
 
 def disable_service(service)
-  if ISSYSTEMCTL
-    # returns success even if the service is not installed
-    cmd = ['systemctl', 'disable', "#{service}.service"]
-  else
-    if not is_service_installed?(service)
+  # fails when the service is not installed, so we need to check it beforehand
+  if not is_service_installed?(service)
       return true
     end
-    # fails when the service is not installed, so we need to check it beforehand
+    
+  if ISSYSTEMCTL
+    cmd = ['systemctl', 'disable', "#{service}.service"]
+  else
     cmd = ['chkconfig', service, 'off']
   end
   _, _, retcode = run_cmd(PCSAuth.getSuperuserAuth(), *cmd)


### PR DESCRIPTION
When try to add new node to cluster with Ubuntu Server 16.04.1:

```
# pcs cluster node add ubuntu-4 --enable --start
Disabling SBD service...
Error: debian-4: Disabling SBD failed
```

because the current version of systemctl fails when you try to disable nonexistent service:

```
ubuntu-4 # systemctl disable sbl.service
Failed to execute operation: No such file or directory
ubuntu-4 # echo $?
1
```

We need to check if service exist also for systemctl.