### PR TITLE
Self restart fails when using Debian init script

### DIFF
--- a/pcsd/pcs.rb
+++ b/pcsd/pcs.rb
@@ -949,9 +949,9 @@ def pcsd_restart()
   fork {
     sleep(10)
     if ISSYSTEMCTL
-      `systemctl restart pcsd`
+      exec("systemctl", "restart", "pcsd")
     else
-      `service pcsd restart`
+      exec("service", "pcsd", "restart")
     end
   }
 end


### PR DESCRIPTION
The child process created in pcsd_restart() still listens on the TCP port so the restart fails with:
   /usr/lib/ruby/2.3.0/socket.rb:205:in `bind': Address already in use - bind(2) for [::]:2224 (Errno::EADDRINUSE)

The fix is to call the restart commands via exec as this will close the listening socket automatically.