### PR TITLE
Fix: "find" should run only in specific directories

### DIFF
--- a/pcs/cluster.py
+++ b/pcs/cluster.py
@@ -1926,7 +1926,7 @@ def cluster_destroy(argv):
         state_files = ["cib.xml*", "cib-*", "core.*", "hostcache", "cts.*",
                 "pe*.bz2","cib.*"]
         for name in state_files:
-            os.system("find /var/lib -name '"+name+"' -exec rm -f \{\} \;")
+            os.system("find /var/lib/{pacemaker,corosync} -name '"+name+"' -exec rm -f \{\} \;")
         try:
             qdevice_net.client_destroy()
         except:


### PR DESCRIPTION
Some users reported that running find over "/var/lib" for cleanup
purposes can take too long depending on what you have installed.
A particular example was having "lxcfs" fuse mounted in /var/lib.
That can make the search for cluster leftovers to take quite some
time, making user to believe the process has hang.