### PR TITLE
Fix: Regression on last commit for cluster destroy

### DIFF
--- a/pcs/cluster.py
+++ b/pcs/cluster.py
@@ -1926,7 +1926,7 @@ def cluster_destroy(argv):
         state_files = ["cib.xml*", "cib-*", "core.*", "hostcache", "cts.*",
                 "pe*.bz2","cib.*"]
         for name in state_files:
-            os.system("find /var/lib/{pacemaker,corosync} -name '"+name+"' -exec rm -f \{\} \;")
+            os.system("find /var/lib/pacemaker -name '"+name+"' -exec rm -f \{\} \;")
         try:
             qdevice_net.client_destroy()
         except:


### PR DESCRIPTION
commit c64ad9f2 created a regression when trying to fix the
cleanup part of "cluster destroy". The find syntax was tested
in a shell environment and os.system couldn't understand.
All files being searched are only contained in /var/lib/
pacemaker so this commit fixes that.