### PR TITLE
Tests: handle change in an error message in lxml 3.7

### DIFF
--- a/pcs/lib/commands/test/test_resource_agent.py
+++ b/pcs/lib/commands/test/test_resource_agent.py
@@ -8,7 +8,7 @@ from __future__ import (
 import logging
 from lxml import etree
 
-from pcs.test.tools.assertions import assert_raise_library_error
+from pcs.test.tools.assertions import assert_raise_library_error, start_tag_error_text
 from pcs.test.tools.custom_mock import MockLibraryReportProcessor
 from pcs.test.tools.pcs_unittest import mock, TestCase
 
@@ -353,7 +353,7 @@ class TestDescribeAgent(TestCase):
                 report_codes.UNABLE_TO_GET_AGENT_METADATA,
                 {
                     "agent": "ocf:test:Dummy",
-                    "reason": "Start tag expected, '<' not found, line 1, column 1",
+                    "reason": start_tag_error_text(),
                 }
             )
         )

--- a/pcs/lib/commands/test/test_stonith_agent.py
+++ b/pcs/lib/commands/test/test_stonith_agent.py
@@ -8,7 +8,7 @@ from __future__ import (
 import logging
 from lxml import etree
 
-from pcs.test.tools.assertions import assert_raise_library_error
+from pcs.test.tools.assertions import assert_raise_library_error, start_tag_error_text
 from pcs.test.tools.custom_mock import MockLibraryReportProcessor
 from pcs.test.tools.pcs_unittest import mock, TestCase
 
@@ -204,7 +204,7 @@ class TestDescribeAgent(TestCase):
                 report_codes.UNABLE_TO_GET_AGENT_METADATA,
                 {
                     "agent": "fence_dummy",
-                    "reason": "Start tag expected, '<' not found, line 1, column 1",
+                    "reason": start_tag_error_text(),
                 }
             )
         )

--- a/pcs/lib/pacemaker/test/test_live.py
+++ b/pcs/lib/pacemaker/test/test_live.py
@@ -11,6 +11,7 @@ import os.path
 from pcs.test.tools.assertions import (
     assert_raise_library_error,
     assert_xml_equal,
+    start_tag_error_text,
 )
 from pcs.test.tools.misc import get_test_resource as rc
 from pcs.test.tools.pcs_unittest import TestCase, mock
@@ -399,7 +400,7 @@ class EnsureCibVersionTest(TestCase):
                 report_codes.CIB_UPGRADE_FAILED,
                 {
                     "reason":
-                        "Start tag expected, '<' not found, line 1, column 1",
+                        start_tag_error_text(),
                 }
             )
         )

--- a/pcs/lib/test/test_resource_agent.py
+++ b/pcs/lib/test/test_resource_agent.py
@@ -12,6 +12,7 @@ from pcs.test.tools.assertions import (
     ExtendedAssertionsMixin,
     assert_raise_library_error,
     assert_xml_equal,
+    start_tag_error_text,
 )
 from pcs.test.tools.misc import create_patcher
 from pcs.test.tools.pcs_unittest import TestCase, mock
@@ -1069,7 +1070,7 @@ class StonithdMetadataGetMetadataTest(TestCase, ExtendedAssertionsMixin):
             self.agent._get_metadata,
             {
                 "agent": "stonithd",
-                "message": "Start tag expected, '<' not found, line 1, column 1",
+                "message": start_tag_error_text(),
             }
         )
 
@@ -1196,7 +1197,7 @@ class CrmAgentMetadataGetMetadataTest(TestCase, ExtendedAssertionsMixin):
             self.agent._get_metadata,
             {
                 "agent": self.agent_name,
-                "message": "Start tag expected, '<' not found, line 1, column 1",
+                "message": start_tag_error_text(),
             }
         )
 

--- a/pcs/test/tools/assertions.py
+++ b/pcs/test/tools/assertions.py
@@ -7,9 +7,20 @@ from __future__ import (
 
 import doctest
 from lxml.doctestcompare import LXMLOutputChecker
+from lxml.etree import LXML_VERSION
 
 from pcs.lib.errors import LibraryError
 from pcs.test.tools.misc import prepare_diff
+
+def start_tag_error_text():
+    """lxml 3.7+ gives a longer 'start tag expected' error message,
+    handle it here so multiple tests can just get the appropriate
+    string from this function.
+    """
+    msg = "Start tag expected, '<' not found, line 1, column 1"
+    if LXML_VERSION >= (3, 7, 0, 0):
+        msg += " (<string>, line 1)"
+    return msg
 
 def console_report(*lines):
     #after lines append last new line


### PR DESCRIPTION
I guess we could also do this as a constant rather than a function...if you want me to change that, just yell. This is needed to make pcs build properly (with test suite passing) on Fedora Rawhide (and F24 and F25, now, as they also have lxml 3.7).