### PR TITLE
Fix tests for Python 3.6

### DIFF
--- a/pcs/lib/commands/test/test_booth.py
+++ b/pcs/lib/commands/test/test_booth.py
@@ -111,6 +111,7 @@ class ConfigDestroyTest(TestCase):
     @patch_commands("parse", mock.Mock(side_effect=LibraryError()))
     def test_raises_when_cannot_get_content_of_config(self):
         env = mock.MagicMock()
+        env.booth.name = "somename"
         assert_raise_library_error(
             lambda: commands.config_destroy(env),
             (
@@ -126,6 +127,7 @@ class ConfigDestroyTest(TestCase):
     @patch_commands("parse", mock.Mock(side_effect=LibraryError()))
     def test_remove_config_even_if_cannot_get_its_content_when_forced(self):
         env = mock.MagicMock()
+        env.booth.name = "somename"
         env.report_processor = MockLibraryReportProcessor()
         commands.config_destroy(env, ignore_config_load_problems=True)
         env.booth.remove_config.assert_called_once_with()


### PR DESCRIPTION
We need to set a proper value for `env.booth.name` in two more
tests, or Python chokes trying to `os.path.join()` a MagicMock.

I'm assuming this is a Python 3.6 thing, but didn't actually check; it's needed to make pcs build correctly (with tests passing) on current Fedora Rawhide. Without this change, the tests fail in `get_config_file_name`, because `name` is a MagicMock.