### PR TITLE
cli: skip superfluous text -> bytes conversion on clufter's output

### DIFF
--- a/pcs/config.py
+++ b/pcs/config.py
@@ -698,14 +698,14 @@ def config_import_cman(argv):
         config_backup_add_version_to_tarball(tarball)
         utils.tar_add_file_data(
             tarball,
-            clufter_args_obj.cib["passout"].encode("utf-8"),
+            clufter_args_obj.cib["passout"],
             "cib.xml",
             **file_list["cib.xml"]["attrs"]
         )
         if output_format == "cluster.conf":
             utils.tar_add_file_data(
                 tarball,
-                clufter_args_obj.ccs_pcmk["passout"].encode("utf-8"),
+                clufter_args_obj.ccs_pcmk["passout"],
                 "cluster.conf",
                 **file_list["cluster.conf"]["attrs"]
             )
@@ -726,7 +726,7 @@ def config_import_cman(argv):
             )("bytestring")
             utils.tar_add_file_data(
                 tarball,
-                corosync_conf_data.encode("utf-8"),
+                corosync_conf_data,
                 "corosync.conf",
                 **file_list["corosync.conf"]["attrs"]
             )
@@ -744,7 +744,7 @@ def config_import_cman(argv):
                 )("bytestring")
                 utils.tar_add_file_data(
                     tarball,
-                    uidgid_data.encode("utf-8"),
+                    uidgid_data,
                     "uidgid.d/" + filename,
                     **file_list["uidgid.d"]["attrs"]
                 )


### PR DESCRIPTION
Respective outputs are already represented with bytes (as 'bytestring'
protocol suggests), and moreover, such bytes cannot be "encoded" in
Python 3 otherwise leading to AttributeError (bytes object has no
attribute encode) exception.

Note that this is only relevant in Python 3 context, which pcs uses
by default in python3-charged distros (e.g. Fedora) and which is now
supported in clufter (which enabled a discovery of this discrepancy):
http://oss.clusterlabs.org/pipermail/users/2017-March/005323.html

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>