### PR TITLE
Use FIPS compliant methods

### DIFF
--- a/pcsd/bootstrap.rb
+++ b/pcsd/bootstrap.rb
@@ -1,4 +1,11 @@
-require 'digest/sha2'
+begin
+  require 'openssl'
+  Object.send(:remove_const, :Digest)
+  Digest = OpenSSL::Digest
+rescue LoadError
+  require 'digest/sha2'
+end
+
 require 'logger'
 require 'open4'
 require 'pathname'

--- a/pcsd/cfgsync.rb
+++ b/pcsd/cfgsync.rb
@@ -1,7 +1,13 @@
+begin
+  require 'openssl'
+  Object.send(:remove_const, :Digest)
+  Digest = OpenSSL::Digest
+rescue LoadError
+  require 'digest/sha1'
+end
+
 require 'fileutils'
 require 'rexml/document'
-require 'digest/sha1'
-
 require 'settings.rb'
 require 'config.rb'
 require 'corosyncconf.rb'


### PR DESCRIPTION
When ruby is built with openssl it uses openssl digests.
Calling Digest directly invokes alg##_Init which is disallowed in FIPs mode.
Reassign Digest to OpenSSL::Digest to use EVP interface