### PR TITLE
Makefile: replace echo -e with printf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ pcsd_fonts = \
 
 install:
 	# make Python interpreter execution sane (via -Es flags)
-	echo -e "[build]\nexecutable = $(PYTHON) -Es\n" > setup.cfg
+	printf "[build]\nexecutable = $(PYTHON) -Es\n" > setup.cfg
 	$(PYTHON) setup.py install --root=$(or ${DESTDIR}, /) ${EXTRA_SETUP_OPTS}
 	# fix excessive script interpreting "executable" quoting with old setuptools:
 	# https://github.com/pypa/setuptools/issues/188


### PR DESCRIPTION
Fixes build error with dash (does not support echo -e):

    # make Python interpreter execution sane (via -Es flags)
    echo -e "[build]\nexecutable = /usr/bin/python -Es\n" > setup.cfg
    /usr/bin/python setup.py install --root=/<<PKGBUILDDIR>>/debian/tmp "--install-layout=deb"
    Traceback (most recent call last):
      File "setup.py", line 39, in <module>
        'clean': CleanCommand,
      File "/usr/lib/python2.7/distutils/core.py", line 124, in setup
        dist.parse_config_files()
      File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 355, in parse_config_files
        _Distribution.parse_config_files(self, filenames=filenames)
      File "/usr/lib/python2.7/distutils/dist.py", line 390, in parse_config_files
        parser.read(filename)
      File "/usr/lib/python2.7/ConfigParser.py", line 305, in read
        self._read(fp, filename)
      File "/usr/lib/python2.7/ConfigParser.py", line 512, in _read
        raise MissingSectionHeaderError(fpname, lineno, line)
    ConfigParser.MissingSectionHeaderError: File contains no section headers.
    file: setup.cfg, line: 1
    '-e [build]\n'
    Makefile:102: recipe for target 'install' failed