### PR TITLE
Make resource update idempotent with remote-node

### DIFF
--- a/pcs/resource.py
+++ b/pcs/resource.py
@@ -709,11 +709,6 @@ def resource_update(res_id,args, deal_with_guest_change=True):
 
 # Extract operation arguments
     ra_values, op_values, meta_values = parse_resource_options(args)
-    if deal_with_guest_change:
-        _detect_guest_change(
-            prepare_options(meta_values),
-            "--force" in utils.pcs_options,
-        )
 
     wait = False
     wait_timeout = None
@@ -797,6 +792,16 @@ def resource_update(res_id,args, deal_with_guest_change=True):
             instance_attributes.appendChild(ia)
 
     remote_node_name = utils.dom_get_resource_remote_node_name(resource)
+
+    if remote_node_name == guest_node.get_guest_option_value(prepare_options(meta_values)):
+        deal_with_guest_change = False
+
+    if deal_with_guest_change:
+        _detect_guest_change(
+            prepare_options(meta_values),
+            "--force" in utils.pcs_options,
+        )
+
     utils.dom_update_meta_attr(
         resource,
         utils.convert_args_to_tuples(meta_values)

--- a/pcs/test/test_cluster_pcmk_remote.py
+++ b/pcs/test/test_cluster_pcmk_remote.py
@@ -299,6 +299,16 @@ class NodeAddGuest(ResourceTest):
             output=fixture_nolive_add_report
         )
 
+    def test_success_when_guest_node_matches_with_existing_guest(self):
+        self.create_resource()
+        self.assert_pcs_success(
+            "cluster node add-guest node-host G",
+            fixture_nolive_add_report
+        )
+        self.assert_pcs_success(
+            "resource update G meta remote-node=node-host",
+        )
+
     def test_success_with_options(self):
         self.create_resource()
         self.assert_effect(


### PR DESCRIPTION
If the remote-node name argument is already defined for the resource,
do not deal with guest change.

Fix issue #145.