### PR TITLE
Include PCSD_DEFAULT_PORT in pcsd/settings.rb.debian

### DIFF
--- a/pcsd/settings.rb.debian
+++ b/pcsd/settings.rb.debian
@@ -1,6 +1,7 @@
 PCS_EXEC = '/usr/sbin/pcs'
 PCSD_EXEC_LOCATION = '/usr/share/pcsd/'
 PCSD_VAR_LOCATION = '/var/lib/pcsd/'
+PCSD_DEFAULT_PORT = 2224
 
 CRT_FILE = PCSD_VAR_LOCATION + 'pcsd.crt'
 KEY_FILE = PCSD_VAR_LOCATION + 'pcsd.key'


### PR DESCRIPTION
pcsd service fails to start without the default value.