### PR TITLE
pcsd.service files: fix bogus ExecStart specification

### DIFF
--- a/pcs/snmp/pcs_snmp_agent.service
+++ b/pcs/snmp/pcs_snmp_agent.service
@@ -4,7 +4,7 @@ Requires=snmpd.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/pcs_snmp_agent
-ExecStart=/usr/lib/pcs/pcs_snmp_agent > /dev/null
+ExecStart=/usr/lib/pcs/pcs_snmp_agent
 Type=simple
 TimeoutSec=500
 

--- a/pcsd/pcsd.service
+++ b/pcsd/pcsd.service
@@ -6,7 +6,7 @@ Documentation=man:pcs(8)
 [Service]
 EnvironmentFile=/etc/sysconfig/pcsd
 Environment=GEM_HOME=/usr/lib/pcsd/vendor/bundle/ruby
-ExecStart=/usr/lib/pcsd/pcsd > /dev/null &
+ExecStart=/usr/lib/pcsd/pcsd
 Type=notify
 
 [Install]

--- a/pcsd/pcsd.service.debian
+++ b/pcsd/pcsd.service.debian
@@ -5,7 +5,7 @@ Documentation=man:pcs(8)
 
 [Service]
 EnvironmentFile=/etc/default/pcsd
-ExecStart=/usr/bin/ruby -C/var/lib/pcsd -I/usr/share/pcsd -- /usr/share/pcsd/ssl.rb & > /dev/null &
+ExecStart=/usr/bin/ruby -C/var/lib/pcsd -I/usr/share/pcsd -- /usr/share/pcsd/ssl.rb
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Command Lines section of systemd.service(5) makes it clear that

  redirection [...], running programs in the background using "&"
  [...] elements of shell syntax are not supported

for Exec family of unit file directives.

Backgrouding is simply a non-sense while ">/dev/null" may be achieved
with StandardOutput=null[*], otherwise such output is forwarded to
journal, or whatever is configured as a system-wide default.
In my testing, nothing is produced on standard output (nor standard
error output, stderr, for that matter) till it gets internally (along
with stderr) redirected to pcsd native log file (/var/log/pcsd/pcsd.log)
later in the startup sequence.  Hence do nothing special about it.

Fortunately, the starting script did not react on anything passed as
arguments (e.g. as happened to "&" token), leaving this sanitization
merely for good measure.

[*] /dev/null redirection would get overridden later on as mentioned,
    regardless

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>