### PR TITLE
update information about default token timeout in CMAN clusters.

### DIFF
--- a/pcs/pcs.8
+++ b/pcs/pcs.8
@@ -213,7 +213,7 @@ Configure corosync and sync configuration out to listed nodes. \fB\-\-local\fR w
 
 \fB\-\-ipv6\fR will configure corosync to use ipv6 (instead of ipv4).  This option is not supported on CMAN clusters.
 
-\fB\-\-token\fR <timeout> sets time in milliseconds until a token loss is declared after not receiving a token (default 1000 ms)
+\fB\-\-token\fR <timeout> sets time in milliseconds until a token loss is declared after not receiving a token (default 1000 ms; 10000 ms for CMAN clusters)
 
 \fB\-\-token_coefficient\fR <timeout> sets time in milliseconds used for clusters with at least 3 nodes as a coefficient for real token timeout calculation (token + (number_of_nodes - 2) * token_coefficient) (default 650 ms)  This option is not supported on CMAN clusters.
 

--- a/pcs/usage.py
+++ b/pcs/usage.py
@@ -614,7 +614,8 @@ Commands:
         --ipv6 will configure corosync to use ipv6 (instead of ipv4). This
             option is not supported on CMAN clusters.
         --token <timeout> sets time in milliseconds until a token loss is
-            declared after not receiving a token (default 1000 ms)
+            declared after not receiving a token (default 1000 ms;
+            10000 ms for CMAN clusters)
         --token_coefficient <timeout> sets time in milliseconds used for
             clusters with at least 3 nodes as a coefficient for real token
             timeout calculation


### PR DESCRIPTION
This is just a documentation fix.

In CMAN clusters it is 10s while elsewhere it is 1s.
This is relevant for CentOS/RHEL 6.X.
When cluster is created in CentOS/RHEL 6.X without specifying token timeout then 10 seconds is used and can be verified with command below.

~~~
# corosync-objctl |grep totem.token
cluster.totem.token=10000
totem.token=10000
~~~