### PR TITLE
Check if node name stored in corosync.conf

### DIFF
--- a/pcs/utils.py
+++ b/pcs/utils.py
@@ -1994,11 +1994,18 @@ def getCorosyncNodesID(allow_failure=False):
             node_list_node_mapping[m.group(1)] = m.group(2)
 
     for line in output.rstrip().split("\n"):
-        m = re.match("nodelist\.node\.(\d+)\.ring0_addr.*= (.*)", line)
-        # check if node id is in node_list_node_mapping - do not crash when
-        # node ids are not specified
+        # check if node name stored in corosync.conf under name in the nodelist
+        m = re.match("nodelist\.node\.(\d+)\.name.*= (.*)", line)
         if m and m.group(1) in node_list_node_mapping:
             cs_nodes[node_list_node_mapping[m.group(1)]] = m.group(2)
+            continue
+
+        # otherwise use ring0_addr as node name
+        m = re.match("nodelist\.node\.(\d+)\.ring0_addr.*= (.*)", line)
+        if (m and m.group(1) in node_list_node_mapping and
+                not node_list_node_mapping[m.group(1)] in cs_nodes):
+            cs_nodes[node_list_node_mapping[m.group(1)]] = m.group(2)
+
     return cs_nodes
 
 # Warning, if a node has never started the hostname may be '(null)'


### PR DESCRIPTION
According to https://clusterlabs.org/pacemaker/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/s-node-name.html Pacemaker Gets the Node Name value stored in corosync.conf under name in the nodelist if ring0_addr contain an IP address.

E.g.
```
nodelist {
    node {
        ring0_addr: 172.31.200.1
        nodeid: 1
        name: srv1
    }

    node {
        ring0_addr: 172.31.200.2
        nodeid: 2
        name: srv2
    }
}
```

It is very useful in multihomed network configuration or when you do not want to rely on /etc/hosts and/or DNS.

This patch eliminates "WARNING: corosync and pacemaker node names do not match (IPs used in setup?)" in this case.