### PR TITLE
fix 'cib-push' exit code when the diff is empty

### DIFF
--- a/pcs/cluster.py
+++ b/pcs/cluster.py
@@ -1466,9 +1466,10 @@ def cluster_push(argv):
         if error.strip():
             utils.err("unable to diff the CIBs:\n" + error)
         if not patch.strip():
-            utils.err(
+            print(
                 "The new CIB is the same as the original CIB, nothing to push."
             )
+            sys.exit(0)
 
         command = ["cibadmin", "--patch", "--xml-pipe"]
         output, error, retval = runner.run(command, patch)


### PR DESCRIPTION
pcs cib-should not consider an empty diff as an error. Instead, we notice
the user and exit with 0.