### PR TITLE
Man: pcs.8: primarily refer to the new pacemaker-2.0 daemon man pages

### DIFF
--- a/pcs/pcs.8
+++ b/pcs/pcs.8
@@ -460,13 +460,16 @@ Remove the permission id specified (permission id's are listed in parenthesis af
 .SS "property"
 .TP
 [list|show [<property> | \fB\-\-all\fR | \fB\-\-defaults\fR]] | [\fB\-\-all\fR | \fB\-\-defaults\fR]
-List property settings (default: lists configured properties).  If \fB\-\-defaults\fR is specified will show all property defaults, if \fB\-\-all\fR is specified, current configured properties will be shown with unset properties and their defaults.  Run 'man pengine' and 'man crmd' to get a description of the properties.
+List property settings (default: lists configured properties).  If \fB\-\-defaults\fR is specified will show all property defaults, if \fB\-\-all\fR is specified, current configured properties will be shown with unset properties and their defaults.
+See \fBpacemaker-controld\fR(7) and \fBpacemaker-schedulerd\fR(7)  man pages for a description of the properties.
 .TP
 set [\fB\-\-force\fR | \fB\-\-node\fR <nodename>] <property>=[<value>] [<property>=[<value>] ...]
-Set specific pacemaker properties (if the value is blank then the property is removed from the configuration).  If a property is not recognized by pcs the property will not be created unless the \fB\-\-force\fR is used. If \fB\-\-node\fR is used a node attribute is set on the specified node.  Run 'man pengine' and 'man crmd' to get a description of the properties.
+Set specific pacemaker properties (if the value is blank then the property is removed from the configuration).  If a property is not recognized by pcs the property will not be created unless the \fB\-\-force\fR is used. If \fB\-\-node\fR is used a node attribute is set on the specified node.
+See \fBpacemaker-controld\fR(7) and \fBpacemaker-schedulerd\fR(7) man pages for a description of the properties.
 .TP
 unset [\fB\-\-node\fR <nodename>] <property>
-Remove property from configuration (or remove attribute from specified node if \fB\-\-node\fR is used).  Run 'man pengine' and 'man crmd' to get a description of the properties.
+Remove property from configuration (or remove attribute from specified node if \fB\-\-node\fR is used).
+See \fBpacemaker-controld\fR(7) and \fBpacemaker-schedulerd\fR(7) man pages for a description of the properties.
 .SS "constraint"
 .TP
 [list|show] \fB\-\-full\fR
@@ -836,7 +839,7 @@ no_proxy, https_proxy, all_proxy, NO_PROXY, HTTPS_PROXY, ALL_PROXY
 .SH SEE ALSO
 http://clusterlabs.org/doc/
 
-.BR pcsd (8)
+.BR pcsd (8),
 .BR pcs_snmp_agent (8)
 
 .BR corosync_overview (8),
@@ -847,14 +850,14 @@ http://clusterlabs.org/doc/
 .BR corosync\-qnetd (8),
 .BR corosync\-qnetd\-tool (8)
 
-.BR crmd (7),
-.BR pengine (7),
-.BR stonithd (7),
+.BR pacemaker-controld (7),
+.BR pacemaker-schedulerd (7),
+.BR pacemaker-fenced (7),
 .BR crm_mon (8),
 .BR crm_report (8),
 .BR crm_simulate (8)
 
-.BR boothd (8)
+.BR boothd (8),
 .BR sbd (8)
 
 .BR clufter (1)


### PR DESCRIPTION
Still, allow one to fall back to the original names conveniently,
which remains important for several years to come.

Also normalize the relevant punctuation.

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>