### PR TITLE
Add support for --force in cib-push

### DIFF
--- a/pcs/usage.py
+++ b/pcs/usage.py
@@ -820,7 +820,8 @@ Commands:
         the saved CIB using pcs (pcs -f <command>).
 
     cib-push <filename> [--wait[=<n>]]
-            [diff-against=<filename_original> | scope=<scope> | --config]
+            [diff-against=<filename_original> | scope=<scope> | --config |
+            --force]
         Push the raw xml from <filename> to the CIB (Cluster Information Base).
         You can obtain the CIB by running the 'pcs cluster cib' command, which
         is recommended first step when you want to perform desired
@@ -832,7 +833,8 @@ Commands:
         crm_config, rsc_defaults, op_defaults.  --config is the same as
         scope=configuration.  Use of --config is recommended.  Do not specify
         a scope if you need to push the whole CIB or be warned in the case
-        of outdated CIB.
+        of outdated CIB.  If --force is specified, increase the admin_epoch and
+        then push.
         If --wait is specified wait up to 'n' seconds for changes to be applied.
         WARNING: the selected scope of the CIB will be overwritten by the
         current content of the specified file.


### PR DESCRIPTION
This patch adds the ```--force``` option to the ```pcs cluster cib-push <xml>```.
```--force``` increases ```admin_epoch``` in <xml> and then pushes.

I manage my resource settings with a script of pcs commands that are easier to
read than XML,
 * e.g. xxx.sh
```
cibadmin --empty > xxx.xml

pcs -f xxx.xml resource create dummy1 ocf:pacemaker:Dummy
pcs -f xxx.xml resource create dummy2 ocf:pacemaker:Dummy
 :
```
and generate .xml from .sh on push.
```
# ./xxx.sh
# pcs cluster cib-push xxx.xml
CIB updated
```

Therefore, when I change the resource settings, I want to change the .sh first
and then push the .xml generated from the changed .sh, but an error will occur
if the epoch of the active CIB is larger than the .xml one.
```
# $EDITOR xxx.sh
# ./xxx.sh
# pcs cluster cib-push xxx.xml
Error: unable to push cib
Call cib_replace failed (-205): Update was older than existing configuration

# pcs cluster cib | head -n1
<cib crm_feature_set="3.2.0" validate-with="pacemaker-3.2" epoch="24" num_updates="53" admin_epoch="8" (snip)

# head -n1 xxx.xml
<cib crm_feature_set="3.2.0" validate-with="pacemaker-3.2" epoch="15" num_updates="0" admin_epoch="0">
```

So, when ```--force``` is specified, increase admin_epoch in .xml (e.g. change
admin_epoch in .xml to "9", which is larger than "8" of active CIB) and then
push (pass it to cibadmin --replace --xml-file).
```
# pcs cluster cib-push xxx.xml --force
CIB updated
```