### PR TITLE
fix time-dependant tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -457,7 +457,6 @@ PCS_PKG_CHECK_VAR([SBDEXECPREFIX], [sbd], [exec_prefix], [/usr])
 
 PCS_PKG_CHECK_VAR([FASEXECPREFIX], [fence-agents], [exec_prefix], [/usr])
 
-PCS_PKG_CHECK_VAR([OCFROOT], [resource-agents], [ocfrootdir], [/usr/lib/ocf])
 PCS_PKG_CHECK_VAR([RA_API_DTD], [resource-agents], [ra_api_dtd], [/usr/share/resource-agents/ra-api-1.dtd])
 PCS_PKG_CHECK_VAR([RA_TMP_DIR], [resource-agents], [ra_tmp_dir], [/run/resource-agents])
 

--- a/pcs_test/settings.py.in
+++ b/pcs_test/settings.py.in
@@ -1,2 +1,1 @@
 pacemaker_version_rng = "@PCMK_SCHEMA_DIR@/versions.rng"
-ocf_root = "@OCFROOT@"

--- a/pcs_test/tier1/test_booth.py
+++ b/pcs_test/tier1/test_booth.py
@@ -1,31 +1,22 @@
 import os
 from textwrap import dedent
-from unittest import mock, skipUnless, TestCase
+from unittest import mock, TestCase
 
 from pcs.cli.booth import command as booth_cmd
 
-from pcs_test import settings
 from pcs_test.tools.assertions import AssertPcsMixin
 from pcs_test.tools.misc import (
     get_test_resource as rc,
     get_tmp_dir,
     get_tmp_file,
     outdent,
+    skip_unless_booth_resource_agent_installed,
     write_file_to_tmpfile,
 )
 from pcs_test.tools.pcs_runner import PcsRunner
 
 
 EMPTY_CIB = rc("cib-empty.xml")
-
-BOOTH_RESOURCE_AGENT_INSTALLED = os.path.exists(
-    os.path.join(settings.ocf_root, "pacemaker/booth-site")
-)
-need_booth_resource_agent = skipUnless(
-    BOOTH_RESOURCE_AGENT_INSTALLED,
-    "test requires resource agent ocf:pacemaker:booth-site"
-    " which is not installed",
-)
 
 
 class BoothMixinNoFiles(AssertPcsMixin):
@@ -350,7 +341,7 @@ class RemoveTicketTest(DeleteRemoveTicketMixin, BoothTest):
     command = "remove"
 
 
-@need_booth_resource_agent
+@skip_unless_booth_resource_agent_installed()
 class CreateTest(BoothMixinNoFiles, TestCase):
     def test_not_enough_args(self):
         self.assert_pcs_fail(
@@ -421,12 +412,12 @@ class DeleteRemoveTestMixin(AssertPcsMixin):
         )
 
 
-@need_booth_resource_agent
+@skip_unless_booth_resource_agent_installed()
 class DeleteTest(DeleteRemoveTestMixin, TestCase):
     command = "delete"
 
 
-@need_booth_resource_agent
+@skip_unless_booth_resource_agent_installed()
 class RemoveTest(DeleteRemoveTestMixin, TestCase):
     command = "remove"
 

--- a/pcs_test/tools/misc.py
+++ b/pcs_test/tools/misc.py
@@ -280,6 +280,26 @@ def skip_unless_root():
     return skipUnless(os.getuid() == 0, "Root user required")
 
 
+@lru_cache()
+def _is_booth_resource_agent_installed():
+    output, dummy_stderr, dummy_retval = runner.run(
+        [
+            os.path.join(settings.pacemaker_binaries, "crm_resource"),
+            "--list-agents",
+            "ocf:pacemaker",
+        ]
+    )
+    return "booth-site" in output
+
+
+def skip_unless_booth_resource_agent_installed():
+    return skipUnless(
+        _is_booth_resource_agent_installed(),
+        "test requires resource agent ocf:pacemaker:booth-site"
+        " which is not installed",
+    )
+
+
 def create_patcher(target_prefix_or_module):
     """
     Return function for patching tests with preconfigured target prefix

--- a/pcsd/test/test_cfgsync.rb
+++ b/pcsd/test/test_cfgsync.rb
@@ -318,20 +318,26 @@ class TestConfigSyncControll < Test::Unit::TestCase
     assert(!Cfgsync::ConfigSyncControl.sync_thread_disabled?())
     assert(Cfgsync::ConfigSyncControl.sync_thread_allowed?())
 
-    assert(Cfgsync::ConfigSyncControl.sync_thread_pause(2))
+    start = Time::now().to_i
+    assert(Cfgsync::ConfigSyncControl.sync_thread_pause(10))
     assert(Cfgsync::ConfigSyncControl.sync_thread_paused?())
     assert(!Cfgsync::ConfigSyncControl.sync_thread_disabled?())
     assert(!Cfgsync::ConfigSyncControl.sync_thread_allowed?())
-    sleep(4)
+    now = Time::now().to_i
+    # sleep for the rest of the pause time and a bit more
+    sleep(10 - (start - now) + 3)
     assert(!Cfgsync::ConfigSyncControl.sync_thread_paused?())
     assert(!Cfgsync::ConfigSyncControl.sync_thread_disabled?())
     assert(Cfgsync::ConfigSyncControl.sync_thread_allowed?())
 
-    assert(Cfgsync::ConfigSyncControl.sync_thread_pause('2'))
+    start = Time::now().to_i
+    assert(Cfgsync::ConfigSyncControl.sync_thread_pause('10'))
     assert(Cfgsync::ConfigSyncControl.sync_thread_paused?())
     assert(!Cfgsync::ConfigSyncControl.sync_thread_disabled?())
     assert(!Cfgsync::ConfigSyncControl.sync_thread_allowed?())
-    sleep(4)
+    now = Time::now().to_i
+    # sleep for the rest of the pause time and a bit more
+    sleep(10 - (start - now) + 3)
     assert(!Cfgsync::ConfigSyncControl.sync_thread_paused?())
     assert(!Cfgsync::ConfigSyncControl.sync_thread_disabled?())
     assert(Cfgsync::ConfigSyncControl.sync_thread_allowed?())


### PR DESCRIPTION
Use a longer timeout to make tests less likely to fail
on heavily loaded machines.