### PR TITLE
move pcmk api_result from common to lib

### DIFF
--- a/pcs/Makefile.am
+++ b/pcs/Makefile.am
@@ -92,7 +92,6 @@ EXTRA_DIST		= \
 			  common/interface/dto.py \
 			  common/interface/__init__.py \
 			  common/node_communicator.py \
-			  common/pacemaker/api_result.py \
 			  common/pacemaker/__init__.py \
 			  common/pacemaker/nvset.py \
 			  common/pacemaker/resource/__init__.py \
@@ -258,6 +257,7 @@ EXTRA_DIST		= \
 			  lib/node_communication_format.py \
 			  lib/node_communication.py \
 			  lib/node.py \
+			  lib/pacemaker/api_result.py \
 			  lib/pacemaker/__init__.py \
 			  lib/pacemaker/live.py \
 			  lib/pacemaker/simulate.py \

--- a/pcs/lib/pacemaker/api_result.py
+++ b/pcs/lib/pacemaker/api_result.py
@@ -1,11 +1,9 @@
 from dataclasses import dataclass
 from typing import Sequence
 
-from pcs.common.interface.dto import DataTransferObject
-
 
 @dataclass(frozen=True)
-class StatusDto(DataTransferObject):
+class Status:
     code: int
     message: str
     errors: Sequence[str]

--- a/pcs/lib/pacemaker/live.py
+++ b/pcs/lib/pacemaker/live.py
@@ -13,7 +13,6 @@ from lxml.etree import _Element
 
 from pcs import settings
 from pcs.common import reports
-from pcs.common.pacemaker import api_result
 from pcs.common.reports import ReportProcessor
 from pcs.common.reports.item import ReportItem
 from pcs.common.str_tools import join_multilines
@@ -26,6 +25,7 @@ from pcs.common.types import CibRuleInEffectStatus
 from pcs.lib.cib.tools import get_pacemaker_version_by_which_cib_was_validated
 from pcs.lib.errors import LibraryError
 from pcs.lib.external import CommandRunner
+from pcs.lib.pacemaker import api_result
 from pcs.lib.pacemaker.state import ClusterState
 from pcs.lib.tools import write_tmpfile
 from pcs.lib.xml_tools import etree_to_str
@@ -807,7 +807,7 @@ def get_rule_in_effect_status(
     return translation_map.get(retval, CibRuleInEffectStatus.UNKNOWN)
 
 
-def get_status_from_api_result(dom: _Element) -> api_result.StatusDto:
+def get_status_from_api_result(dom: _Element) -> api_result.Status:
     errors = []
     status_el = cast(_Element, dom.find("./status"))
     errors_el = status_el.find("errors")
@@ -816,7 +816,7 @@ def get_status_from_api_result(dom: _Element) -> api_result.StatusDto:
             str((error_el.text or "")).strip()
             for error_el in errors_el.iterfind("error")
         ]
-    return api_result.StatusDto(
+    return api_result.Status(
         code=int(str(status_el.get("code"))),
         message=str(status_el.get("message")),
         errors=errors,

--- a/pcs_test/tier0/lib/pacemaker/test_live.py
+++ b/pcs_test/tier0/lib/pacemaker/test_live.py
@@ -16,11 +16,11 @@ from pcs_test.tools.misc import get_test_resource as rc
 from pcs_test.tools.xml import etree_to_str, XmlManipulation
 
 from pcs import settings
-from pcs.common.pacemaker.api_result import StatusDto
 from pcs.common.reports import ReportItemSeverity as Severity
 from pcs.common.reports import codes as report_codes
 from pcs.common.tools import Version
 from pcs.common.types import CibRuleInEffectStatus
+from pcs.lib.pacemaker import api_result
 import pcs.lib.pacemaker.live as lib
 from pcs.lib.external import CommandRunner
 
@@ -48,7 +48,7 @@ class GetStatusFromApiResult(TestCase):
                     )
                 )
             ),
-            StatusDto(123, "short message", ["error1", "error2"]),
+            api_result.Status(123, "short message", ["error1", "error2"]),
         )
 
     def test_no_errors(self):
@@ -58,7 +58,7 @@ class GetStatusFromApiResult(TestCase):
                     fixture_crm_mon.error_xml(123, "short message")
                 )
             ),
-            StatusDto(123, "short message", []),
+            api_result.Status(123, "short message", []),
         )
 
 


### PR DESCRIPTION
The module is only used in lib, so there is no need for it to be in the common package.