### PR TITLE
Support starting and stopping corosync-notifyd

### DIFF
--- a/pcs/cli/routing/cluster.py
+++ b/pcs/cli/routing/cluster.py
@@ -83,6 +83,8 @@ cluster_cmd = create_router(
         "kill": cluster.kill_cluster,
         "enable": cluster.cluster_enable_cmd,
         "disable": cluster.cluster_disable_cmd,
+        "enable-corosync-notifyd": cluster.corosync_notifyd_enable_cmd,
+        "disable-corosync-notifyd": cluster.corosync_notifyd_disable_cmd,
         "cib": cluster.get_cib,
         "cib-push": cluster.cluster_push,
         "cib-upgrade": cluster.cluster_cib_upgrade_cmd,

--- a/pcs/lib/commands/status.py
+++ b/pcs/lib/commands/status.py
@@ -220,6 +220,7 @@ def _get_local_services_status(
     service_def = [
         # (service name, display even if not enabled nor running)
         ("corosync", True),
+        ("corosync-notifyd", True),
         ("pacemaker", True),
         ("pacemaker_remote", False),
         ("pcsd", True),

--- a/pcs/usage.py
+++ b/pcs/usage.py
@@ -1011,6 +1011,14 @@ Commands:
         is not specified then cluster is disabled on the local node. If --all
         is specified then cluster is disabled on all nodes.
 
+    enable-corosync-notifyd
+        Configure corosync-notifyd to also start when cluster starts.
+
+    disable-corosync-notifyd
+        Configure corosync-notifyd not to start when cluster starts.
+        By default (unless you run 'pcs cluster enable-corosync-notifyd'),
+        corosync-notifyd will not be start when cluster starts.
+
     auth [-u <username>] [-p <password>]
         Authenticate pcs/pcsd to pcsd on nodes configured in the local cluster.
 

--- a/pcsd/config.rb
+++ b/pcsd/config.rb
@@ -5,11 +5,12 @@ require 'permissions.rb'
 
 class PCSConfig
   CURRENT_FORMAT = 2
-  attr_accessor :clusters, :permissions_local, :format_version, :data_version
+  attr_accessor :clusters, :permissions_local, :format_version, :data_version, :corosync_notifyd_enabled
 
   def initialize(cfg_text)
     @format_version = 0
     @data_version = 0
+    @corosync_notifyd_enabled = 'false'
     @clusters = []
     @permissions_local = Permissions::PermissionsSet.new([])
 
@@ -75,6 +76,7 @@ class PCSConfig
 
       if @format_version >= 2
         @data_version = json["data_version"] || 0
+        @corosync_notifyd_enabled = json["corosync_notifyd_enabled"] || 'false'
         input_clusters = json["clusters"] || []
         input_permissions = json['permissions'] || {}
       elsif @format_version == 1
@@ -126,6 +128,7 @@ class PCSConfig
     out_hash = Hash.new
     out_hash['format_version'] = CURRENT_FORMAT
     out_hash['data_version'] = @data_version
+    out_hash['corosync_notifyd_enabled'] = @corosync_notifyd_enabled
     out_hash['clusters'] = []
     out_hash['permissions'] = Hash.new
     out_hash['permissions']['local_cluster'] = []


### PR DESCRIPTION
This patch allows corosync-notifyd to be started with ```pcs cluster start```.
Addressed issues pointed out at https://github.com/ClusterLabs/pcs/pull/296#issuecomment-858555922.