### PR TITLE
fix: some reports and output may still appear on stdout

### DIFF
--- a/pcs/cli/common/routing.py
+++ b/pcs/cli/common/routing.py
@@ -34,7 +34,7 @@ def create_router(
         except CmdLineInputError as e:
             if not usage_sub_cmd:
                 raise
-            return utils.exit_on_cmdline_input_errror(
+            return utils.exit_on_cmdline_input_error(
                 e, usage_sub_cmd[0], (usage_sub_cmd[1:] + [sub_cmd])
             )
 

--- a/pcs/cli/reports/output.py
+++ b/pcs/cli/reports/output.py
@@ -44,7 +44,7 @@ def process_library_reports(report_item_list: ReportItemList) -> None:
             continue
 
         if severity != ReportItemSeverity.ERROR:
-            print(msg)
+            print_to_stderr(msg)
             continue
 
         error(

--- a/pcs/cli/routing/acl.py
+++ b/pcs/cli/routing/acl.py
@@ -7,7 +7,7 @@ from pcs.cli.common.routing import create_router
 
 acl_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.acl(argv),
+        "help": lambda lib, argv, modifiers: print(usage.acl(argv)),
         # TODO remove, deprecated command
         # replaced with 'config'
         "show": acl.show_acl_config,

--- a/pcs/cli/routing/alert.py
+++ b/pcs/cli/routing/alert.py
@@ -7,7 +7,7 @@ from pcs.cli.common.routing import create_router
 
 alert_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.alert(argv),
+        "help": lambda lib, argv, modifiers: print(usage.alert(argv)),
         "create": alert.alert_add,
         "update": alert.alert_update,
         "delete": alert.alert_remove,
@@ -18,7 +18,9 @@ alert_cmd = create_router(
         "show": alert.print_alert_show,
         "recipient": create_router(
             {
-                "help": lambda lib, argv, modifiers: usage.alert(["recipient"]),
+                "help": lambda lib, argv, modifiers: print(
+                    usage.alert(["recipient"])
+                ),
                 "add": alert.recipient_add,
                 "update": alert.recipient_update,
                 "delete": alert.recipient_remove,

--- a/pcs/cli/routing/booth.py
+++ b/pcs/cli/routing/booth.py
@@ -6,13 +6,15 @@ from pcs.resource import resource_remove, resource_restart
 
 booth_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.booth(argv),
+        "help": lambda lib, argv, modifiers: print(usage.booth(argv)),
         "config": command.config_show,
         "setup": command.config_setup,
         "destroy": command.config_destroy,
         "ticket": create_router(
             {
-                "help": lambda lib, argv, modifiers: usage.booth(["ticket"]),
+                "help": lambda lib, argv, modifiers: print(
+                    usage.booth(["ticket"])
+                ),
                 "add": command.config_ticket_add,
                 "delete": command.config_ticket_remove,
                 "remove": command.config_ticket_remove,

--- a/pcs/cli/routing/client.py
+++ b/pcs/cli/routing/client.py
@@ -1,9 +1,10 @@
-from pcs import client
+from pcs import client, usage
 from pcs.cli.common.routing import create_router
 
 
 client_cmd = create_router(
     {
+        "help": lambda lib, argv, modifiers: print(usage.client(argv)),
         "local-auth": client.local_auth_cmd,
     },
     ["client"],

--- a/pcs/cli/routing/cluster.py
+++ b/pcs/cli/routing/cluster.py
@@ -18,7 +18,7 @@ from pcs.cli.common.errors import (
 from pcs.cli.common.parse_args import InputModifiers
 from pcs.cli.common.routing import create_router
 from pcs.cli.reports.output import warn
-from pcs.utils import exit_on_cmdline_input_errror
+from pcs.utils import exit_on_cmdline_input_error
 
 
 def certkey(lib: Any, argv: Sequence[str], modifiers: InputModifiers) -> None:
@@ -29,7 +29,7 @@ def certkey(lib: Any, argv: Sequence[str], modifiers: InputModifiers) -> None:
     try:
         return pcsd.pcsd_certkey_cmd(lib, argv, modifiers)
     except CmdLineInputError as e:
-        return exit_on_cmdline_input_errror(e, "pcsd", ["certkey"])
+        return exit_on_cmdline_input_error(e, "pcsd", ["certkey"])
 
 
 def pcsd_status(
@@ -42,12 +42,12 @@ def pcsd_status(
     try:
         return pcsd.pcsd_status_cmd(lib, argv, modifiers)
     except CmdLineInputError as e:
-        return exit_on_cmdline_input_errror(e, "pcsd", ["status"])
+        return exit_on_cmdline_input_error(e, "pcsd", ["status"])
 
 
 cluster_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.cluster(argv),
+        "help": lambda lib, argv, modifiers: print(usage.cluster(argv)),
         "setup": cluster.cluster_setup,
         "config": create_router(
             {

--- a/pcs/cli/routing/config.py
+++ b/pcs/cli/routing/config.py
@@ -7,7 +7,7 @@ from pcs.cli.common.routing import create_router
 
 config_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.config(argv),
+        "help": lambda lib, argv, modifiers: print(usage.config(argv)),
         "show": config.config_show,
         "backup": config.config_backup,
         "restore": config.config_restore,

--- a/pcs/cli/routing/constraint.py
+++ b/pcs/cli/routing/constraint.py
@@ -9,7 +9,7 @@ from pcs.cli.constraint_ticket import command as ticket_command
 
 constraint_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.constraint(argv),
+        "help": lambda lib, argv, modifiers: print(usage.constraint(argv)),
         "location": constraint.constraint_location_cmd,
         "order": constraint.constraint_order_cmd,
         "ticket": create_router(

--- a/pcs/cli/routing/dr.py
+++ b/pcs/cli/routing/dr.py
@@ -4,12 +4,11 @@ from pcs.cli.common.routing import create_router
 
 dr_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.dr(argv),
+        "help": lambda lib, argv, modifiers: print(usage.dr(argv)),
         "config": dr.config,
         "destroy": dr.destroy,
         "set-recovery-site": dr.set_recovery_site,
         "status": dr.status,
     },
     ["dr"],
-    default_cmd="help",
 )

--- a/pcs/cli/routing/host.py
+++ b/pcs/cli/routing/host.py
@@ -7,7 +7,7 @@ from pcs.cli.common.routing import create_router
 
 host_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.host(argv),
+        "help": lambda lib, argv, modifiers: print(usage.host(argv)),
         "auth": host.auth_cmd,
         "deauth": host.deauth_cmd,
     },

--- a/pcs/cli/routing/node.py
+++ b/pcs/cli/routing/node.py
@@ -9,7 +9,7 @@ from pcs.cli.common.routing import create_router
 
 node_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.node(argv),
+        "help": lambda lib, argv, modifiers: print(usage.node(argv)),
         "maintenance": partial(node.node_maintenance_cmd, enable=True),
         "unmaintenance": partial(node.node_maintenance_cmd, enable=False),
         "standby": partial(node.node_standby_cmd, enable=True),

--- a/pcs/cli/routing/pcsd.py
+++ b/pcs/cli/routing/pcsd.py
@@ -8,7 +8,7 @@ from pcs.cli.common.routing import create_router
 
 pcsd_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.pcsd(argv),
+        "help": lambda lib, argv, modifiers: print(usage.pcsd(argv)),
         "accept_token": pcsd.accept_token_cmd,
         "deauth": pcsd.pcsd_deauth,
         "certkey": pcsd.pcsd_certkey_cmd,

--- a/pcs/cli/routing/prop.py
+++ b/pcs/cli/routing/prop.py
@@ -7,7 +7,7 @@ from pcs.cli.common.routing import create_router
 
 property_cmd = create_router(
     {
-        "help": lambda _lib, _argv, _modifiers: usage.property(_argv),
+        "help": lambda _lib, _argv, _modifiers: print(usage.property(_argv)),
         "set": prop.set_property,
         "unset": prop.unset_property,
         # TODO remove, deprecated command

--- a/pcs/cli/routing/qdevice.py
+++ b/pcs/cli/routing/qdevice.py
@@ -7,7 +7,7 @@ from pcs.cli.common.routing import create_router
 
 qdevice_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.qdevice(argv),
+        "help": lambda lib, argv, modifiers: print(usage.qdevice(argv)),
         "status": qdevice.qdevice_status_cmd,
         "setup": qdevice.qdevice_setup_cmd,
         "destroy": qdevice.qdevice_destroy_cmd,

--- a/pcs/cli/routing/quorum.py
+++ b/pcs/cli/routing/quorum.py
@@ -7,7 +7,7 @@ from pcs.cli.common.routing import create_router
 
 quorum_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.quorum(argv),
+        "help": lambda lib, argv, modifiers: print(usage.quorum(argv)),
         "config": quorum.quorum_config_cmd,
         "expected-votes": quorum.quorum_expected_votes_cmd,
         "status": quorum.quorum_status_cmd,

--- a/pcs/cli/routing/resource.py
+++ b/pcs/cli/routing/resource.py
@@ -85,7 +85,7 @@ def resource_op_defaults_cmd(
 
 resource_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.resource(argv),
+        "help": lambda lib, argv, modifiers: print(usage.resource(argv)),
         "list": resource.resource_list_available,
         "describe": resource.resource_list_options,
         "create": resource.resource_create,

--- a/pcs/cli/routing/status.py
+++ b/pcs/cli/routing/status.py
@@ -13,7 +13,7 @@ from pcs.cli.booth.command import status as booth_status_cmd
 
 status_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.status(argv),
+        "help": lambda lib, argv, modifiers: print(usage.status(argv)),
         "booth": booth_status_cmd,
         "corosync": status.corosync_status,
         "cluster": status.cluster_status,

--- a/pcs/cli/routing/stonith.py
+++ b/pcs/cli/routing/stonith.py
@@ -8,7 +8,7 @@ from pcs.cli.common.routing import create_router
 
 stonith_cmd = create_router(
     {
-        "help": lambda lib, argv, modifiers: usage.stonith(argv),
+        "help": lambda lib, argv, modifiers: print(usage.stonith(argv)),
         "list": stonith.stonith_list_available,
         "describe": stonith.stonith_list_options,
         "create": stonith.stonith_create,

--- a/pcs/cli/routing/tag.py
+++ b/pcs/cli/routing/tag.py
@@ -7,7 +7,7 @@ tag_cmd = create_router(
         "config": tag.tag_config,
         "create": tag.tag_create,
         "delete": tag.tag_remove,
-        "help": lambda lib, argv, modifiers: usage.tag(argv),
+        "help": lambda lib, argv, modifiers: print(usage.tag(argv)),
         # TODO remove, deprecated command
         # replaced with 'config'
         "list": tag.tag_list_cmd,

--- a/pcs/cli/tag/command.py
+++ b/pcs/cli/tag/command.py
@@ -4,7 +4,7 @@ from typing import (
 )
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.common.parse_args import group_by_keywords, InputModifiers
-from pcs.cli.reports.output import warn
+from pcs.cli.reports.output import warn, print_to_stderr
 from pcs.common.str_tools import indent
 
 
@@ -52,7 +52,7 @@ def tag_config(
     modifiers.ensure_only_supported("-f")
     tag_list = lib.tag.config(argv)
     if not tag_list:
-        print(" No tags defined")
+        print_to_stderr(" No tags defined")
         return
     lines = []
     for tag in tag_list:

--- a/pcs/config.py
+++ b/pcs/config.py
@@ -31,6 +31,7 @@ from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.constraint import command as constraint_command
 from pcs.cli.nvset import nvset_dto_list_to_lines
 from pcs.cli.reports import process_library_reports
+from pcs.cli.reports.output import print_to_stderr, warn
 from pcs.common.reports import constraints as constraints_reports
 from pcs.common.str_tools import indent
 from pcs.lib.commands import quorum as lib_quorum
@@ -210,8 +211,7 @@ def config_backup(lib, argv, modifiers):
     del lib
     modifiers.ensure_only_supported("--force")
     if len(argv) > 1:
-        usage.config(["backup"])
-        sys.exit(1)
+        raise CmdLineInputError()
 
     outfile_name = None
     if argv:
@@ -266,8 +266,7 @@ def config_restore(lib, argv, modifiers):
     del lib
     modifiers.ensure_only_supported("--local", "--request-timeout")
     if len(argv) > 1:
-        usage.config(["restore"])
-        sys.exit(1)
+        raise CmdLineInputError()
 
     infile_name = infile_obj = None
     if argv:
@@ -607,15 +606,13 @@ def config_backup_check_version(version):
         supported_version = config_backup_version()
         if version_number > supported_version:
             utils.err(
-                "Unsupported version of the backup, "
-                "supported version is %d, backup version is %d"
-                % (supported_version, version_number)
+                f"Unsupported version of the backup, supported version is "
+                f"{supported_version}, backup version is {version_number}"
             )
         if version_number < supported_version:
-            print(
-                "Warning: restoring from the backup version %d, "
-                "current supported version is %s"
-                % (version_number, supported_version)
+            warn(
+                f"Restoring from the backup version {version_number}, current "
+                f"supported version is {supported_version}"
             )
     except TypeError:
         utils.err("Cannot determine version of the backup")
@@ -664,7 +661,7 @@ def config_checkpoint_list(lib, argv, modifiers):
             pass
     cib_list.sort()
     if not cib_list:
-        print("No checkpoints available")
+        print_to_stderr("No checkpoints available")
         return
     for cib_info in cib_list:
         print(
@@ -704,7 +701,7 @@ def config_checkpoint_view(lib, argv, modifiers):
     """
     modifiers.ensure_only_supported()
     if len(argv) != 1:
-        usage.config(["checkpoint view"])
+        print_to_stderr(usage.config(["checkpoint view"]))
         sys.exit(1)
 
     loaded, lines = _checkpoint_to_lines(lib, argv[0])
@@ -720,7 +717,7 @@ def config_checkpoint_diff(lib, argv, modifiers):
     """
     modifiers.ensure_only_supported("-f")
     if len(argv) != 2:
-        usage.config(["checkpoint diff"])
+        print_to_stderr(usage.config(["checkpoint diff"]))
         sys.exit(1)
 
     if argv[0] == argv[1]:
@@ -778,7 +775,7 @@ def config_checkpoint_restore(lib, argv, modifiers):
     del lib
     modifiers.ensure_only_supported("-f")
     if len(argv) != 1:
-        usage.config(["checkpoint restore"])
+        print_to_stderr(usage.config(["checkpoint restore"]))
         sys.exit(1)
 
     cib_path = os.path.join(settings.cib_dir, "cib-%s.raw" % argv[0])

--- a/pcs/pcsd.py
+++ b/pcs/pcsd.py
@@ -10,6 +10,7 @@ from pcs import settings, utils
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.common.parse_args import InputModifiers
 from pcs.cli.reports import process_library_reports
+from pcs.cli.reports.output import print_to_stderr
 from pcs.common import reports
 from pcs.common.reports.item import ReportItem
 import pcs.common.ssl
@@ -84,7 +85,7 @@ def pcsd_certkey_cmd(lib, argv, modifiers):
     except IOError as e:
         utils.err(e)
 
-    print(
+    print_to_stderr(
         "Certificate and key updated, you may need to restart pcsd for new "
         "settings to take effect"
     )

--- a/pcs/resource.py
+++ b/pcs/resource.py
@@ -14,11 +14,7 @@ from typing import (
     Sequence,
 )
 
-from pcs import (
-    usage,
-    utils,
-    constraint,
-)
+from pcs import constraint, utils
 from pcs.common.interface.dto import to_dict
 from pcs.common import (
     const,
@@ -1247,8 +1243,7 @@ def resource_operation_add(
       * --force
     """
     if not argv:
-        usage.resource(["op"])
-        sys.exit(1)
+        raise CmdLineInputError()
 
     res_el = utils.dom_get_resource(dom, res_id)
     if not res_el:

--- a/pcs/rule.py
+++ b/pcs/rule.py
@@ -49,9 +49,10 @@ def dom_rule_add(dom_element, options, rule_argv, cib_schema_version):
         utils.err("can not specify both score and score-attribute")
     if options.get("score") and not utils.is_score(options["score"]):
         # preserving legacy behaviour
-        print(
-            "Warning: invalid score '%s', setting score-attribute=pingd instead"
-            % options["score"]
+        warn(
+            "invalid score '{}', setting score-attribute=pingd instead".format(
+                options["score"]
+            )
         )
         warn(
             "Converting invalid score to score-attribute=pingd is deprecated "

--- a/pcs/status.py
+++ b/pcs/status.py
@@ -4,6 +4,7 @@ import os
 from pcs import utils
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.reports import process_library_reports
+from pcs.cli.reports.output import error
 from pcs.lib.node import get_existing_nodes_names
 from pcs.lib.errors import LibraryError
 from pcs.lib.pacemaker.live import get_cluster_status_dom
@@ -256,4 +257,4 @@ def print_pcsd_daemon_status(lib, modifiers):
         if exitcode == 0:
             print(std_out)
         else:
-            print("Unable to get PCSD status")
+            raise error("Unable to get PCSD status")

--- a/pcs/stonith.py
+++ b/pcs/stonith.py
@@ -8,7 +8,7 @@ from pcs.cli.common import parse_args
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.fencing_topology import target_type_map_cli_to_lib
 from pcs.cli.reports import process_library_reports
-from pcs.cli.reports.output import error, warn
+from pcs.cli.reports.output import error, print_to_stderr, warn
 from pcs.cli.resource.parse_args import parse_create_simple as parse_create_args
 from pcs.common import reports
 from pcs.common.fencing_topology import (
@@ -489,7 +489,7 @@ def stonith_fence(lib, argv, modifiers):
     if retval != 0:
         utils.err("unable to fence '%s'\n" % node + output)
     else:
-        print("Node: %s fenced" % node)
+        print_to_stderr(f"Node: {node} fenced")
 
 
 def stonith_confirm(lib, argv, modifiers):
@@ -560,7 +560,7 @@ def sbd_watchdog_list(lib, argv, modifiers):
         for watchdog in sorted(available_watchdogs.keys()):
             print("  {}".format(watchdog))
     else:
-        print("No available watchdog")
+        print_to_stderr("No available watchdog")
 
 
 def sbd_watchdog_list_json(lib, argv, modifiers):
@@ -859,7 +859,7 @@ def stonith_history_cleanup_cmd(lib, argv, modifiers):
         raise CmdLineInputError()
 
     node = argv[0] if argv else None
-    print(lib.stonith.history_cleanup(node))
+    print_to_stderr(lib.stonith.history_cleanup(node))
 
 
 def stonith_history_update_cmd(lib, argv, modifiers):
@@ -870,7 +870,7 @@ def stonith_history_update_cmd(lib, argv, modifiers):
     if argv:
         raise CmdLineInputError()
 
-    print(lib.stonith.history_update())
+    print_to_stderr(lib.stonith.history_update())
 
 
 def stonith_update_scsi_devices(lib, argv, modifiers):

--- a/pcs/usage.py
+++ b/pcs/usage.py
@@ -1,5 +1,7 @@
 import re
 
+from pcs.cli.reports.output import print_to_stderr
+
 # pylint: disable=too-many-lines, too-many-branches, global-statement
 
 examples = ""
@@ -7,25 +9,25 @@ examples = ""
 
 def full_usage():
     out = ""
-    out += main(False)
-    out += strip_extras(resource([], False))
-    out += strip_extras(cluster([], False))
-    out += strip_extras(stonith([], False))
-    out += strip_extras(property([], False))
-    out += strip_extras(constraint([], False))
-    out += strip_extras(node([], False))
-    out += strip_extras(acl([], False))
-    out += strip_extras(qdevice([], False))
-    out += strip_extras(quorum([], False))
-    out += strip_extras(booth([], False))
-    out += strip_extras(status([], False))
-    out += strip_extras(config([], False))
-    out += strip_extras(pcsd([], False))
-    out += strip_extras(host([], False))
-    out += strip_extras(alert([], False))
-    out += strip_extras(client([], False))
-    out += strip_extras(dr([], False))
-    out += strip_extras(tag([], False))
+    out += main()
+    out += strip_extras(resource([]))
+    out += strip_extras(cluster([]))
+    out += strip_extras(stonith([]))
+    out += strip_extras(property([]))
+    out += strip_extras(constraint([]))
+    out += strip_extras(node([]))
+    out += strip_extras(acl([]))
+    out += strip_extras(qdevice([]))
+    out += strip_extras(quorum([]))
+    out += strip_extras(booth([]))
+    out += strip_extras(status([]))
+    out += strip_extras(config([]))
+    out += strip_extras(pcsd([]))
+    out += strip_extras(host([]))
+    out += strip_extras(alert([]))
+    out += strip_extras(client([]))
+    out += strip_extras(dr([]))
+    out += strip_extras(tag([]))
     print(out.strip())
     print("Examples:\n" + examples.replace(r" \ ", ""))
 
@@ -115,24 +117,24 @@ def dict_depth(d, depth=0):
 
 def generate_completion_tree_from_usage():
     tree = {}
-    tree["resource"] = generate_tree(resource([], False))
-    tree["cluster"] = generate_tree(cluster([], False))
-    tree["stonith"] = generate_tree(stonith([], False))
-    tree["property"] = generate_tree(property([], False))
-    tree["acl"] = generate_tree(acl([], False))
-    tree["constraint"] = generate_tree(constraint([], False))
-    tree["qdevice"] = generate_tree(qdevice([], False))
-    tree["quorum"] = generate_tree(quorum([], False))
-    tree["status"] = generate_tree(status([], False))
-    tree["config"] = generate_tree(config([], False))
-    tree["pcsd"] = generate_tree(pcsd([], False))
-    tree["host"] = generate_tree(host([], False))
-    tree["node"] = generate_tree(node([], False))
-    tree["alert"] = generate_tree(alert([], False))
-    tree["booth"] = generate_tree(booth([], False))
-    tree["client"] = generate_tree(client([], False))
-    tree["dr"] = generate_tree(dr([], False))
-    tree["tag"] = generate_tree(tag([], False))
+    tree["resource"] = generate_tree(resource([]))
+    tree["cluster"] = generate_tree(cluster([]))
+    tree["stonith"] = generate_tree(stonith([]))
+    tree["property"] = generate_tree(property([]))
+    tree["acl"] = generate_tree(acl([]))
+    tree["constraint"] = generate_tree(constraint([]))
+    tree["qdevice"] = generate_tree(qdevice([]))
+    tree["quorum"] = generate_tree(quorum([]))
+    tree["status"] = generate_tree(status([]))
+    tree["config"] = generate_tree(config([]))
+    tree["pcsd"] = generate_tree(pcsd([]))
+    tree["host"] = generate_tree(host([]))
+    tree["node"] = generate_tree(node([]))
+    tree["alert"] = generate_tree(alert([]))
+    tree["booth"] = generate_tree(booth([]))
+    tree["client"] = generate_tree(client([]))
+    tree["dr"] = generate_tree(dr([]))
+    tree["tag"] = generate_tree(tag([]))
     return tree
 
 
@@ -165,7 +167,7 @@ def generate_tree(usage_txt):
     return ret_hash
 
 
-def main(pout=True):
+def main():
     output = """
 Usage: pcs [-f file] [-h] [commands]...
 Control and configure pacemaker and corosync.
@@ -210,13 +212,10 @@ Commands:
 """
     # Advanced usage to possibly add later
     #  --corosync_conf=<corosync file> Specify alternative corosync.conf file
-    if pout:
-        print(output)
-        return None
     return output
 
 
-def resource(args=(), pout=True):
+def resource(args=()):
     output = """
 Usage: pcs resource [commands]...
 Manage pacemaker resources
@@ -853,13 +852,10 @@ Notes:
     resources in a cluster.
 
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def cluster(args=(), pout=True):
+def cluster(args=()):
     output = """
 Usage: pcs cluster [commands]...
 Configure cluster for use with pacemaker
@@ -1266,13 +1262,10 @@ Commands:
         problems.  If --from and --to are not used, the report will include
         the past 24 hours.
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def stonith(args=(), pout=True):
+def stonith(args=()):
     output = """
 Usage: pcs stonith [commands]...
 Configure fence devices for use with pacemaker
@@ -1510,13 +1503,10 @@ Commands:
         specified, available watchdog will be used if only one watchdog device
         is available on the local system.
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def property(args=(), pout=True):
+def property(args=()):
     # pylint: disable=redefined-builtin
     output = """
 Usage: pcs property [commands]...
@@ -1547,13 +1537,10 @@ Commands:
 Examples:
     pcs property set stonith-enabled=false
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def constraint(args=(), pout=True):
+def constraint(args=()):
     output = """
 Usage: pcs constraint [constraints]...
 Manage resource constraints
@@ -1736,13 +1723,10 @@ Commands:
         Remove a rule from its location constraint and if it's the last rule,
         the constraint will also be removed.
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def acl(args=(), pout=True):
+def acl(args=()):
     output = """
 Usage: pcs acl [commands]...
 View and modify current cluster access control lists
@@ -1862,13 +1846,10 @@ Commands:
         Remove the permission id specified (permission id's are listed in
         parenthesis after permissions in 'pcs acl' output).
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def status(args=(), pout=True):
+def status(args=()):
     output = """
 Usage: pcs status [commands]...
 View current cluster and resource status
@@ -1915,13 +1896,10 @@ Commands:
     xml
         View xml version of status (output from crm_mon -r -1 -X).
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def config(args=(), pout=True):
+def config(args=()):
     output = """
 Usage: pcs config [commands]...
 View and manage cluster configuration
@@ -1953,13 +1931,10 @@ Commands:
     checkpoint restore <checkpoint_number>
         Restore cluster configuration to specified checkpoint.
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def pcsd(args=(), pout=True):
+def pcsd(args=()):
     output = """
 Usage: pcs pcsd [commands]...
 Manage pcs daemon
@@ -1981,13 +1956,10 @@ Commands:
        tokens will be deleted. After this command is run other nodes will need
        to re-authenticate against this node to be able to connect to it.
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def host(args=(), pout=True):
+def host(args=()):
     output = """
 Usage: pcs host [commands]...
 Manage hosts known to pcs/pcsd
@@ -2008,13 +1980,10 @@ Commands:
        be deleted. After this command is run this node will need to
        re-authenticate against other nodes to be able to connect to them.
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def node(args=(), pout=True):
+def node(args=()):
     output = """
 Usage: pcs node <command>
 Manage cluster nodes
@@ -2075,13 +2044,10 @@ Commands:
         may be removed by setting an option without a value.
         Example: pcs node utilization node1 cpu=4 ram=
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def qdevice(args=(), pout=True):
+def qdevice(args=()):
     output = """
 Usage: pcs qdevice <command>
 Manage quorum device provider on the local host, currently only 'net' model is
@@ -2122,13 +2088,10 @@ Commands:
         Configure specified model of quorum device provider to not start
         on boot.
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def quorum(args=(), pout=True):
+def quorum(args=()):
     output = """
 Usage: pcs quorum <command>
 Manage cluster quorum settings.
@@ -2207,13 +2170,10 @@ Commands:
         Options are documented in corosync's votequorum(5) man page.  Requires
         the cluster to be stopped.
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def booth(args=(), pout=True):
+def booth(args=()):
     output = """
 Usage: pcs booth <command>
 Manage booth (cluster ticket manager)
@@ -2297,13 +2257,10 @@ Commands:
     stop
         Stop booth arbitrator service.
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def alert(args=(), pout=True):
+def alert(args=()):
     output = """
 Usage: pcs alert <command>
 Set pacemaker alerts.
@@ -2343,13 +2300,10 @@ Commands:
     recipient remove <recipient-id> ...
         Remove specified recipients.
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def client(args=(), pout=True):
+def client(args=()):
     output = """
 Usage: pcs client <command>
 Manage pcsd client configuration.
@@ -2360,13 +2314,10 @@ Commands:
         pcs commands which may require permissions of root user such as 'pcs
         cluster start'.
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def tag(args=(), pout=True):
+def tag(args=()):
     output = """
 Usage: pcs tag <command>
 Manage pacemaker tags.
@@ -2392,13 +2343,10 @@ Commands:
         adding ids to a tag they are already in and specifying --after or
         --before you can move the ids in the tag.
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
-def dr(args=(), pout=True):
+def dr(args=()):
     output = """
 Usage: pcs dr <command>
 Manage disaster recovery configuration.
@@ -2418,10 +2366,7 @@ Commands:
     destroy
         Permanently destroy disaster-recovery configuration on all sites.
 """
-    if pout:
-        print(sub_usage(args, output))
-        return None
-    return output
+    return sub_usage(args, output)
 
 
 def show(main_usage_name, rest_usage_names):
@@ -2451,4 +2396,4 @@ def show(main_usage_name, rest_usage_names):
                 main_usage_name, list(usage_map.keys())
             )
         )
-    usage_map[main_usage_name](rest_usage_names)
+    print_to_stderr(usage_map[main_usage_name](rest_usage_names))

--- a/pcs/utils.py
+++ b/pcs/utils.py
@@ -2900,17 +2900,17 @@ def get_library_wrapper():
     return Library(get_cli_env(), get_middleware_factory())
 
 
-def exit_on_cmdline_input_errror(
+def exit_on_cmdline_input_error(
     error: CmdLineInputError,
     main_name: str,
     usage_name: Sequence[str],
 ) -> None:
-    if not error or (not error.message or error.show_both_usage_and_message):
-        usage.show(main_name, usage_name)
     if error and error.message:
-        err(error.message, exit_after_error=False)
+        reports_output.error(error.message)
     if error and error.hint:
         print_to_stderr(f"Hint: {error.hint}")
+    if not error or (not error.message or error.show_both_usage_and_message):
+        usage.show(main_name, usage_name)
     sys.exit(1)
 
 

--- a/pcs_test/tier0/cli/tag/test_command.py
+++ b/pcs_test/tier0/cli/tag/test_command.py
@@ -62,11 +62,13 @@ class TagConfig(TestCase):
     def _call_cmd(self, argv):
         command.tag_config(self.lib, argv, dict_to_modifiers({}))
 
-    def test_no_args_no_tags(self, mock_print):
+    @mock.patch("pcs.cli.tag.command.print_to_stderr")
+    def test_no_args_no_tags(self, mock_stderr_print, mock_print):
         self.tag.config.return_value = []
         self._call_cmd([])
         self.tag.config.assert_called_once_with([])
-        mock_print.assert_called_once_with(" No tags defined")
+        mock_print.assert_not_called()
+        mock_stderr_print.assert_called_once_with(" No tags defined")
 
     def test_no_args_all_tags(self, mock_print):
         self.tag.config.return_value = self.tag_dicts

--- a/pcs_test/tier1/legacy/test_constraints.py
+++ b/pcs_test/tier1/legacy/test_constraints.py
@@ -141,8 +141,8 @@ class ConstraintTest(unittest.TestCase):
         )
         assert returnVal == 0
         assert output == (
-            "Warning: Converting invalid score to score-attribute=pingd is deprecated and will be removed.\n"
             "Warning: invalid score 'pingd', setting score-attribute=pingd instead\n"
+            "Warning: Converting invalid score to score-attribute=pingd is deprecated and will be removed.\n"
         ), [output]
 
         output, returnVal = pcs(
@@ -151,8 +151,8 @@ class ConstraintTest(unittest.TestCase):
         )
         assert returnVal == 0
         assert output == (
-            "Warning: Converting invalid score to score-attribute=pingd is deprecated and will be removed.\n"
             "Warning: invalid score 'pingd', setting score-attribute=pingd instead\n"
+            "Warning: Converting invalid score to score-attribute=pingd is deprecated and will be removed.\n"
         ), [output]
 
         output, returnVal = pcs(
@@ -1141,9 +1141,9 @@ Colocation Constraints:
             o,
             outdent(
                 """\
-            Deleting Resource - D5
             Removing D5 from set colocation_set_D5D6D7_set
             Removing D5 from set colocation_set_D5D6D7-1_set
+            Deleting Resource - D5
             """
             ),
         )
@@ -1154,10 +1154,10 @@ Colocation Constraints:
             o,
             outdent(
                 """\
-            Deleting Resource - D6
             Removing D6 from set colocation_set_D5D6D7_set
             Removing D6 from set colocation_set_D5D6D7-1_set
             Removing set colocation_set_D5D6D7-1_set
+            Deleting Resource - D6
             """
             ),
         )
@@ -1560,9 +1560,9 @@ Ordering Constraints:
             o,
             outdent(
                 """\
-            Deleting Resource - D5
             Removing D5 from set order_set_D5D6D7_set
             Removing D5 from set order_set_D5D6D7-1_set
+            Deleting Resource - D5
             """
             ),
         )
@@ -1573,10 +1573,10 @@ Ordering Constraints:
             o,
             outdent(
                 """\
-            Deleting Resource - D6
             Removing D6 from set order_set_D5D6D7_set
             Removing D6 from set order_set_D5D6D7-1_set
             Removing set order_set_D5D6D7-1_set
+            Deleting Resource - D6
             """
             ),
         )
@@ -2743,9 +2743,9 @@ Ticket Constraints:
             output,
             outdent(
                 """\
-            Deleting Resource - vm-guest1
             Removing Constraint - location-D1-guest1-200
             Removing Constraint - location-D2-guest1--400
+            Deleting Resource - vm-guest1
             """
             ),
         )
@@ -2893,10 +2893,10 @@ Ticket Constraints:
             output,
             outdent(
                 """\
-            Deleting Resource - vm-guest1
             Removing Constraint - location-vm-guest1-node1-INFINITY
             Removing Constraint - location-D1-guest1-200
             Removing Constraint - location-D2-guest1--400
+            Deleting Resource - vm-guest1
             """
             ),
         )
@@ -4946,7 +4946,7 @@ class ExpiredConstraints(ConstraintBaseTest):
         )
         self.assert_pcs_result(
             ["constraint"],
-            CRM_RULE_MISSING_MSG
+            f"Warning: {CRM_RULE_MISSING_MSG}\n"
             + outdent(
                 """\
                 Location Constraints:

--- a/pcs_test/tier1/legacy/test_resource.py
+++ b/pcs_test/tier1/legacy/test_resource.py
@@ -1307,8 +1307,8 @@ monitor interval=20 (A-monitor-interval-20)
             "resource delete ClusterIP3".split(),
             outdent(
                 """\
-            Deleting Resource (and group) - ClusterIP3
             Removing Constraint - location-ClusterIP3-rh7-1-INFINITY
+            Deleting Resource (and group) - ClusterIP3
             """
             ),
         )
@@ -1613,9 +1613,9 @@ monitor interval=20 (A-monitor-interval-20)
             "resource delete D1-clone".split(),
             outdent(
                 """\
-            Deleting Resource - D1
             Removing Constraint - location-D1-clone-rh7-1-INFINITY
             Removing Constraint - location-D1-rh7-1-INFINITY
+            Deleting Resource - D1
             """
             ),
         )
@@ -1697,9 +1697,9 @@ monitor interval=20 (A-monitor-interval-20)
             "resource delete Master".split(),
             outdent(
                 """\
-            Deleting Resource - ClusterIP5
             Removing Constraint - location-Master-rh7-2-INFINITY
             Removing Constraint - location-ClusterIP5-rh7-1-INFINITY
+            Deleting Resource - ClusterIP5
             """
             ),
         )
@@ -1728,9 +1728,9 @@ monitor interval=20 (A-monitor-interval-20)
             "resource delete ClusterIP5".split(),
             outdent(
                 """\
-            Deleting Resource - ClusterIP5
             Removing Constraint - location-ClusterIP5-rh7-1-INFINITY
             Removing Constraint - location-ClusterIP5-rh7-2-INFINITY
+            Deleting Resource - ClusterIP5
             """
             ),
         )
@@ -2817,8 +2817,8 @@ monitor interval=20 (A-monitor-interval-20)
             "resource delete D2".split(),
             outdent(
                 """\
-            Deleting Resource (and group) - D2
             Removing Constraint - cli-prefer-DGroup
+            Deleting Resource (and group) - D2
             """
             ),
         )
@@ -3085,8 +3085,8 @@ monitor interval=20 (A-monitor-interval-20)
             "resource delete A2".split(),
             outdent(
                 """\
-            Deleting Resource (and group and M/S) - A2
             Removing Constraint - location-AA-master-rh7-1-INFINITY
+            Deleting Resource (and group and M/S) - A2
             """
             ),
         )
@@ -4998,8 +4998,8 @@ class ResourceRemoveWithTicket(TestCase, AssertPcsMixin):
         self.assert_pcs_success(
             "resource delete A".split(),
             [
-                "Deleting Resource - A",
                 "Removing Constraint - ticket-T-A-Master",
+                "Deleting Resource - A",
             ],
         )
 

--- a/pcs_test/tier1/legacy/test_rule.py
+++ b/pcs_test/tier1/legacy/test_rule.py
@@ -2593,10 +2593,10 @@ Location Constraints:
         )
         ac(
             output,
-            "Warning: Converting invalid score to score-attribute=pingd is "
-            "deprecated and will be removed.\n"
             "Warning: invalid score 'pingd', setting score-attribute=pingd "
-            "instead\n",
+            "instead\n"
+            "Warning: Converting invalid score to score-attribute=pingd is "
+            "deprecated and will be removed.\n",
         )
         self.assertEqual(0, returnVal)
 


### PR DESCRIPTION
This patch fixes printing info and debug reports mostly from legacy pcs code.
Reports processed through `pcs.cli.reports.output.process_library_reports()`
were still printed to stdout instead of stderr.

The patch also fixes all of the remaining prints in legacy code not adressed
by the previous commit (d4383f6c).