### PR TITLE
fix report processing in constraint location add

### DIFF
--- a/pcs/constraint.py
+++ b/pcs/constraint.py
@@ -1063,7 +1063,7 @@ def location_add(lib, argv, modifiers, skip_score_and_node_check=False):
                 corosync_conf=lib_env.get_corosync_conf(),
                 cib=lib_env.get_cib(),
             )
-            report_list = _verify_node_name(node, existing_nodes)
+            report_list += _verify_node_name(node, existing_nodes)
             if report_list:
                 process_library_reports(report_list)
         _verify_score(score)


### PR DESCRIPTION
If there were nodes with missing names in corosync.conf, these reports
could have been overwritten by failed node name validation reports.

No tests were added since we cannot check corosync.conf in tests.