### PR TITLE
add new severity for deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 -  Add add/remove cli syntax for command `pcs stonith update-scsi-devices`
    ([rhbz#1992668])
 
+
+### Changed
+- Deprecation warnings use a "Deprecation Warning:" prefix instead of 
+  "Warning:" on the command line
+  
+
 ### Fixed
 - Do not unfence newly added devices on fenced cluster nodes ([rhbz#1991654])
 - Fix displaying fencing levels with regular expression targets ([rhbz#1533090])

--- a/pcs/acl.py
+++ b/pcs/acl.py
@@ -3,7 +3,7 @@ from pcs import (
     utils,
 )
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.reports.output import warn
+from pcs.cli.reports.output import deprecation_warning
 from pcs.common.str_tools import indent
 from pcs.lib.pacemaker.values import is_true
 
@@ -17,7 +17,7 @@ def _print_list_of_objects(obj_list, transformation_fn):
 
 
 def show_acl_config(lib, argv, modifiers):
-    warn(
+    deprecation_warning(
         "This command is deprecated and will be removed. "
         "Please use 'pcs acl config' instead."
     )

--- a/pcs/alert.py
+++ b/pcs/alert.py
@@ -3,7 +3,7 @@ from functools import partial
 
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.common.parse_args import prepare_options, group_by_keywords
-from pcs.cli.reports.output import warn
+from pcs.cli.reports.output import deprecation_warning
 from pcs.common.str_tools import indent
 
 parse_cmd_sections = partial(group_by_keywords, implicit_first_group_key="main")
@@ -200,7 +200,7 @@ def _recipient_to_str(recipient):
 
 
 def print_alert_show(lib, argv, modifiers):
-    warn(
+    deprecation_warning(
         "This command is deprecated and will be removed. "
         "Please use 'pcs alert config' instead."
     )

--- a/pcs/app.py
+++ b/pcs/app.py
@@ -17,7 +17,7 @@ from pcs.cli.common import (
     routing,
 )
 from pcs.cli.reports import process_library_reports
-from pcs.cli.reports.output import error, print_to_stderr, warn
+from pcs.cli.reports.output import deprecation_warning, error, print_to_stderr
 from pcs.cli.routing import (
     acl,
     alert,
@@ -163,7 +163,7 @@ def main(argv=None):
             ) = parse_args.filter_out_non_option_negative_numbers(argv)
             if args_filtered_out:
                 options_str = "', '".join(args_filtered_out)
-                warn(
+                deprecation_warning(
                     f"Using '{options_str}' without '--' is deprecated, those "
                     "parameters will be considered position independent "
                     "options in future pcs versions"

--- a/pcs/cli/constraint_colocation/command.py
+++ b/pcs/cli/constraint_colocation/command.py
@@ -1,6 +1,6 @@
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.constraint import command
-from pcs.cli.reports.output import warn
+from pcs.cli.reports.output import deprecation_warning
 from pcs.common.reports import constraints
 
 
@@ -26,7 +26,7 @@ def create_with_set(lib, argv, modifiers):
 
 
 def show(lib, argv, modifiers):
-    warn(
+    deprecation_warning(
         "This command is deprecated and will be removed. "
         "Please use 'pcs constraint colocation config' instead."
     )

--- a/pcs/cli/constraint_order/command.py
+++ b/pcs/cli/constraint_order/command.py
@@ -1,6 +1,6 @@
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.constraint import command
-from pcs.cli.reports.output import warn
+from pcs.cli.reports.output import deprecation_warning
 from pcs.common.reports import constraints
 
 
@@ -24,7 +24,7 @@ def create_with_set(lib, argv, modifiers):
 
 
 def show(lib, argv, modifiers):
-    warn(
+    deprecation_warning(
         "This command is deprecated and will be removed. "
         "Please use 'pcs constraint order config' instead."
     )

--- a/pcs/cli/constraint_ticket/command.py
+++ b/pcs/cli/constraint_ticket/command.py
@@ -1,7 +1,7 @@
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.constraint import command
 from pcs.cli.constraint_ticket import parse_args
-from pcs.cli.reports.output import error, warn
+from pcs.cli.reports.output import deprecation_warning, error
 from pcs.common.reports import constraints
 
 
@@ -73,7 +73,7 @@ def remove(lib, argv, modifiers):
 
 
 def show(lib, argv, modifiers):
-    warn(
+    deprecation_warning(
         "This command is deprecated and will be removed. "
         "Please use 'pcs constraint ticket config' instead."
     )

--- a/pcs/cli/reports/output.py
+++ b/pcs/cli/reports/output.py
@@ -14,6 +14,10 @@ def warn(message: str) -> None:
     print_to_stderr(f"Warning: {message}")
 
 
+def deprecation_warning(message: str) -> None:
+    print_to_stderr(f"Deprecation Warning: {message}")
+
+
 def error(message: str) -> SystemExit:
     print_to_stderr(f"Error: {message}")
     return SystemExit(1)
@@ -41,6 +45,10 @@ def process_library_reports(report_item_list: ReportItemList) -> None:
 
         if severity == ReportItemSeverity.WARNING:
             warn(msg)
+            continue
+
+        if severity == ReportItemSeverity.DEPRECATION:
+            deprecation_warning(msg)
             continue
 
         if severity != ReportItemSeverity.ERROR:

--- a/pcs/cli/reports/processor.py
+++ b/pcs/cli/reports/processor.py
@@ -9,6 +9,7 @@ from pcs.cli.common.tools import print_to_stderr
 
 from .output import (
     error,
+    deprecation_warning,
     prepare_force_text,
     warn,
 )
@@ -43,6 +44,8 @@ class ReportProcessorToConsole(ReportProcessor):
             )
         elif severity == ReportItemSeverity.WARNING:
             warn(msg)
+        elif severity == ReportItemSeverity.DEPRECATION:
+            deprecation_warning(msg)
         elif msg and (self.debug or severity != ReportItemSeverity.DEBUG):
             print_to_stderr(msg)
 

--- a/pcs/cli/routing/cluster.py
+++ b/pcs/cli/routing/cluster.py
@@ -17,12 +17,12 @@ from pcs.cli.common.errors import (
 )
 from pcs.cli.common.parse_args import InputModifiers
 from pcs.cli.common.routing import create_router
-from pcs.cli.reports.output import warn
+from pcs.cli.reports.output import deprecation_warning
 from pcs.utils import exit_on_cmdline_input_error
 
 
 def certkey(lib: Any, argv: Sequence[str], modifiers: InputModifiers) -> None:
-    warn(
+    deprecation_warning(
         "This command is deprecated and will be removed. "
         "Please use 'pcs pcsd certkey' instead."
     )
@@ -35,7 +35,7 @@ def certkey(lib: Any, argv: Sequence[str], modifiers: InputModifiers) -> None:
 def pcsd_status(
     lib: Any, argv: Sequence[str], modifiers: InputModifiers
 ) -> None:
-    warn(
+    deprecation_warning(
         "This command is deprecated and will be removed. "
         "Please use 'pcs pcsd status' or 'pcs status pcsd' instead."
     )

--- a/pcs/cli/tag/command.py
+++ b/pcs/cli/tag/command.py
@@ -4,7 +4,7 @@ from typing import (
 )
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.common.parse_args import group_by_keywords, InputModifiers
-from pcs.cli.reports.output import warn, print_to_stderr
+from pcs.cli.reports.output import deprecation_warning, print_to_stderr
 from pcs.common.str_tools import indent
 
 
@@ -33,7 +33,7 @@ def tag_list_cmd(
     Options:
       * -f - CIB file
     """
-    warn(
+    deprecation_warning(
         "This command is deprecated and will be removed. "
         "Please use 'pcs tag config' instead."
     )

--- a/pcs/cluster.py
+++ b/pcs/cluster.py
@@ -65,7 +65,7 @@ from pcs.lib.corosync import (
     live as corosync_live,
     qdevice_net,
 )
-from pcs.cli.reports.output import warn
+from pcs.cli.reports.output import deprecation_warning, warn
 from pcs.lib.errors import LibraryError
 from pcs.lib.node import get_existing_nodes_names
 import pcs.lib.pacemaker.live as lib_pacemaker
@@ -1164,7 +1164,7 @@ def cluster_uidgid(lib, argv, modifiers, silent_list=False):
             utils.write_uid_gid_file(uid, gid)
         elif command in {"delete", "remove", "rm"}:
             if command == "rm":
-                warn(
+                deprecation_warning(
                     "'pcs cluster uidgid rm' has been deprecated, use 'pcs "
                     "cluster uidgid delete' or 'pcs cluster uidgid remove' "
                     "instead"

--- a/pcs/common/reports/item.py
+++ b/pcs/common/reports/item.py
@@ -29,6 +29,7 @@ class ReportItemSeverity(ImplementsToDto, ImplementsFromDto):
     # pylint: disable=invalid-name
     ERROR = SeverityLevel("ERROR")
     WARNING = SeverityLevel("WARNING")
+    DEPRECATION = SeverityLevel("DEPRECATION")
     INFO = SeverityLevel("INFO")
     DEBUG = SeverityLevel("DEBUG")
 
@@ -57,6 +58,10 @@ class ReportItemSeverity(ImplementsToDto, ImplementsFromDto):
     @classmethod
     def warning(cls) -> "ReportItemSeverity":
         return cls(level=cls.WARNING)
+
+    @classmethod
+    def deprecation(cls) -> "ReportItemSeverity":
+        return cls(level=cls.DEPRECATION)
 
     @classmethod
     def info(cls) -> "ReportItemSeverity":
@@ -149,6 +154,18 @@ class ReportItem(ImplementsToDto):
     ) -> "ReportItem":
         return cls(
             severity=ReportItemSeverity.warning(),
+            message=message,
+            context=context,
+        )
+
+    @classmethod
+    def deprecation(
+        cls,
+        message: ReportItemMessage,
+        context: Optional[ReportItemContext] = None,
+    ) -> "ReportItem":
+        return cls(
+            severity=ReportItemSeverity.deprecation(),
             message=message,
             context=context,
         )

--- a/pcs/constraint.py
+++ b/pcs/constraint.py
@@ -16,7 +16,12 @@ import pcs.cli.constraint_colocation.command as colocation_command
 import pcs.cli.constraint_order.command as order_command
 from pcs.cli.constraint_ticket import command as ticket_command
 from pcs.cli.reports import process_library_reports
-from pcs.cli.reports.output import print_to_stderr, warn, error
+from pcs.cli.reports.output import (
+    deprecation_warning,
+    error,
+    print_to_stderr,
+    warn,
+)
 from pcs.common import (
     const,
     pacemaker,
@@ -117,7 +122,7 @@ def constraint_order_cmd(lib, argv, modifiers):
 
 
 def constraint_show(lib, argv, modifiers):
-    warn(
+    deprecation_warning(
         "This command is deprecated and will be removed. "
         "Please use 'pcs constraint config' instead."
     )
@@ -589,7 +594,7 @@ def order_find_duplicates(dom, constraint_el):
 
 
 def location_show(lib, argv, modifiers):
-    warn(
+    deprecation_warning(
         "This command is deprecated and will be removed. "
         "Please use 'pcs constraint location config' instead."
     )

--- a/pcs/lib/cib/constraint/resource_set.py
+++ b/pcs/lib/cib/constraint/resource_set.py
@@ -47,7 +47,7 @@ def _validate_options(options) -> reports.ReportItemList:
                 const.PCMK_ROLE_PROMOTED_LEGACY: const.PCMK_ROLE_PROMOTED,
                 const.PCMK_ROLE_UNPROMOTED_LEGACY: const.PCMK_ROLE_UNPROMOTED,
             },
-            reports.ReportItemSeverity.warning(),
+            reports.ReportItemSeverity.deprecation(),
         ),
     ]
     return validate.ValidatorAll(validators).validate(options)

--- a/pcs/lib/cib/constraint/ticket.py
+++ b/pcs/lib/cib/constraint/ticket.py
@@ -117,7 +117,7 @@ def prepare_options_plain(
                 const.PCMK_ROLE_PROMOTED_LEGACY: const.PCMK_ROLE_PROMOTED,
                 const.PCMK_ROLE_UNPROMOTED_LEGACY: const.PCMK_ROLE_UNPROMOTED,
             },
-            reports.ReportItemSeverity.warning(),
+            reports.ReportItemSeverity.deprecation(),
             option_name_for_report="role",
         ),
     ]

--- a/pcs/lib/cib/resource/bundle.py
+++ b/pcs/lib/cib/resource/bundle.py
@@ -433,7 +433,7 @@ def _validate_generic_container_options(container_options, force_options=False):
     deprecation_reports = []
     if "masters" in container_options:
         deprecation_reports.append(
-            ReportItem.warning(
+            ReportItem.deprecation(
                 reports.messages.DeprecatedOption(
                     "masters",
                     ["promoted-max"],
@@ -516,7 +516,7 @@ def _validate_generic_container_options_update(
         # deprecated. They may be removing it because they just found out it is
         # deprecated.
         deprecation_reports.append(
-            ReportItem.warning(
+            ReportItem.deprecation(
                 reports.messages.DeprecatedOption(
                     "masters",
                     ["promoted-max"],

--- a/pcs/lib/cib/resource/operations.py
+++ b/pcs/lib/cib/resource/operations.py
@@ -185,7 +185,7 @@ def _validate_operation_list(
                 const.PCMK_ROLE_PROMOTED_LEGACY: const.PCMK_ROLE_PROMOTED,
                 const.PCMK_ROLE_UNPROMOTED_LEGACY: const.PCMK_ROLE_UNPROMOTED,
             },
-            reports.ReportItemSeverity.warning(),
+            reports.ReportItemSeverity.deprecation(),
         ),
         validate.ValueIn("on-fail", ON_FAIL_VALUES),
         validate.ValueIn("record-pending", _BOOLEAN_VALUES),

--- a/pcs/prop.py
+++ b/pcs/prop.py
@@ -4,7 +4,7 @@ import json
 from pcs import utils
 
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.reports.output import warn
+from pcs.cli.reports.output import deprecation_warning
 
 
 def set_property(lib, argv, modifiers):
@@ -94,7 +94,7 @@ def unset_property(lib, argv, modifiers):
 
 
 def list_property_deprecated(lib, argv, modifiers):
-    warn(
+    deprecation_warning(
         "This command is deprecated and will be removed. "
         "Please use 'pcs property config' instead."
     )

--- a/pcs/resource.py
+++ b/pcs/resource.py
@@ -38,7 +38,7 @@ from pcs.cli.common.tools import (
 )
 from pcs.cli.nvset import nvset_dto_list_to_lines
 from pcs.cli.reports import process_library_reports
-from pcs.cli.reports.output import error, warn
+from pcs.cli.reports.output import deprecation_warning, error, warn
 from pcs.cli.resource.parse_args import (
     parse_bundle_create_options,
     parse_bundle_reset_options,
@@ -349,7 +349,7 @@ def resource_defaults_legacy_cmd(
     """
     del modifiers
     if deprecated_syntax_used:
-        warn(
+        deprecation_warning(
             "This command is deprecated and will be removed. "
             "Please use 'pcs resource defaults update' instead."
         )
@@ -368,7 +368,7 @@ def resource_op_defaults_legacy_cmd(
     """
     del modifiers
     if deprecated_syntax_used:
-        warn(
+        deprecation_warning(
             "This command is deprecated and will be removed. "
             "Please use 'pcs resource op defaults update' instead."
         )
@@ -853,7 +853,7 @@ def resource_move(lib: Any, argv: List[str], modifiers: InputModifiers):
         raise CmdLineInputError()
 
     if modifiers.is_specified("--autodelete"):
-        warn(
+        deprecation_warning(
             "Option '--autodelete' is deprecated. There is no need to use it "
             "as its functionality is default now."
         )
@@ -2305,7 +2305,7 @@ def resource_show(lib, argv, modifiers, stonith=False):
         )
 
     if modifiers.get("--groups"):
-        warn(
+        deprecation_warning(
             "This command is deprecated and will be removed. "
             "Please use 'pcs resource group list' instead."
         )
@@ -2313,7 +2313,7 @@ def resource_show(lib, argv, modifiers, stonith=False):
         return
 
     if modifiers.get("--full") or argv:
-        warn(
+        deprecation_warning(
             "This command is deprecated and will be removed. "
             "Please use 'pcs {} config' instead.".format(
                 "stonith" if stonith else "resource"
@@ -2322,7 +2322,7 @@ def resource_show(lib, argv, modifiers, stonith=False):
         resource_config(lib, argv, modifiers.get_subset("-f"), stonith=stonith)
         return
 
-    warn(
+    deprecation_warning(
         "This command is deprecated and will be removed. "
         "Please use 'pcs {} status' instead.".format(
             "stonith" if stonith else "resource"
@@ -3224,7 +3224,7 @@ def resource_refresh(lib, argv, modifiers):
     # crm_resource actualy did.
     modifiers.ensure_only_supported("--force", "--full", "--strict")
     if modifiers.is_specified("--full"):
-        warn("'--full' has been deprecated")
+        deprecation_warning("'--full' has been deprecated")
     resource = argv.pop(0) if argv and "=" not in argv[0] else None
     parsed_options = prepare_options_allowed(argv, {"node"})
     print_to_stderr(

--- a/pcs/rule.py
+++ b/pcs/rule.py
@@ -4,7 +4,7 @@ import xml.dom.minidom
 from typing import List, Any, Optional
 
 from pcs import utils
-from pcs.cli.reports.output import warn
+from pcs.cli.reports.output import deprecation_warning, warn
 from pcs.common import (
     const,
     pacemaker,
@@ -54,7 +54,7 @@ def dom_rule_add(dom_element, options, rule_argv, cib_schema_version):
                 options["score"]
             )
         )
-        warn(
+        deprecation_warning(
             "Converting invalid score to score-attribute=pingd is deprecated "
             "and will be removed."
         )
@@ -111,8 +111,8 @@ def dom_rule_add(dom_element, options, rule_argv, cib_schema_version):
     except (ParserException, CibBuilderException) as e:
         utils.err("'%s' is not a valid rule expression" % " ".join(rule_argv))
 
-    for msg in preprocessor.warning_list:
-        warn(msg)
+    for msg in preprocessor.deprecation_warning_list:
+        deprecation_warning(msg)
 
     # add options into rule xml
     if not options.get("score") and not options.get("score-attribute"):
@@ -1050,17 +1050,17 @@ class InvalidSyntacticTree(CibBuilderException):
 
 class TokenPreprocessor:
     def __init__(self):
-        self._warning_list = []
+        self._deprecation_warning_list = []
 
     def run(self, token_list):
-        self._warning_list = []
+        self._deprecation_warning_list = []
         return self.convert_legacy_date(
             self.join_date_common(self.separate_parenthesis(token_list))
         )
 
     @property
-    def warning_list(self):
-        return self._warning_list
+    def deprecation_warning_list(self):
+        return self._deprecation_warning_list
 
     @staticmethod
     def separate_parenthesis(input_list):
@@ -1100,7 +1100,7 @@ class TokenPreprocessor:
                     token == "operation=date_spec"
                     and token_parts[0] == DateSpecValue.KEYWORD
                 ):
-                    self._warning_list.append(
+                    self._deprecation_warning_list.append(
                         "Syntax 'operation=date_spec' "
                         "is deprecated and will be removed. Please use "
                         "'date-spec <date-spec options>'."
@@ -1139,14 +1139,14 @@ class TokenPreprocessor:
                 else:
                     if token == "gt" and date_start and not date_end:
                         output_list.extend(["date", "gt", date_start])
-                        self._warning_list.append(
+                        self._deprecation_warning_list.append(
                             "Syntax 'date start=<date> gt' "
                             "is deprecated and will be removed. Please use "
                             "'date gt <date>'."
                         )
                     elif token == "lt" and not date_start and date_end:
                         output_list.extend(["date", "lt", date_end])
-                        self._warning_list.append(
+                        self._deprecation_warning_list.append(
                             "Syntax 'date end=<date> lt' "
                             "is deprecated and will be removed. Please use "
                             "'date lt <date>'."
@@ -1155,7 +1155,7 @@ class TokenPreprocessor:
                         output_list.extend(
                             ["date", "in_range", date_start, "to", date_end]
                         )
-                        self._warning_list.append(
+                        self._deprecation_warning_list.append(
                             "Syntax 'date start=<date> end=<date> in_range' "
                             "is deprecated and will be removed. Please use "
                             "'date in_range <date> to <date>'."

--- a/pcs/stonith.py
+++ b/pcs/stonith.py
@@ -8,7 +8,11 @@ from pcs.cli.common import parse_args
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.fencing_topology import target_type_map_cli_to_lib
 from pcs.cli.reports import process_library_reports
-from pcs.cli.reports.output import error, print_to_stderr, warn
+from pcs.cli.reports.output import (
+    deprecation_warning,
+    error,
+    print_to_stderr,
+)
 from pcs.cli.resource.parse_args import parse_create_simple as parse_create_args
 from pcs.common import reports
 from pcs.common.fencing_topology import (
@@ -251,7 +255,7 @@ def _stonith_level_normalize_devices(argv):
     # normalize devices - previously it was possible to delimit devices by both
     # a comma and a space
     if any("," in arg for arg in argv):
-        warn(
+        deprecation_warning(
             "Delimiting stonith devices with ',' is deprecated and will be "
             "removed. Please use a space to delimit stonith devices."
         )
@@ -317,7 +321,7 @@ def stonith_level_clear_cmd(lib, argv, modifiers):
     # code tried both. It deleted all levels having the first parameter as
     # either a node or a device list. Since it was only possible to specify
     # node as a target back then, this is enabled only in that case.
-    warn(
+    deprecation_warning(
         "Syntax 'pcs stonith level clear [<target> | <stonith id(s)>] is "
         "deprecated and will be removed. Please use 'pcs stonith level clear "
         "[target <target>] | [stonith <stonith id>...]'."
@@ -431,14 +435,14 @@ def stonith_level_remove_cmd(lib, argv, modifiers):
     else:
         # TODO remove, deprecated backward compatibility layer for old syntax
         if len(argv) > 1:
-            warn(
+            deprecation_warning(
                 "Syntax 'pcs stonith level delete | remove <level> [<target>] "
                 "[<stonith id>...]' is deprecated and will be removed. Please "
                 "use 'pcs stonith level delete | remove <level> "
                 "[target <target>] [stonith <stonith id>...]'."
             )
             if not parse_args.ARG_TYPE_DELIMITER in argv[1] and "," in argv[1]:
-                warn(
+                deprecation_warning(
                     "Delimiting stonith devices with ',' is deprecated and "
                     "will be removed. Please use a space to delimit stonith "
                     "devices."

--- a/pcs/utils.py
+++ b/pcs/utils.py
@@ -2955,7 +2955,7 @@ def get_user_and_pass():
 
 def get_input_modifiers() -> InputModifiers:
     if "--master" in pcs_options:
-        reports_output.warn(
+        reports_output.deprecation_warning(
             "Option '--master' is deprecated and has been replaced by option "
             "'--promoted' "
         )
@@ -2986,7 +2986,7 @@ def print_depracation_warning_for_legacy_roles(role: str) -> None:
     role_normalized = role.capitalize()
     if role_normalized in deprecation_map:
         replaced_by = deprecation_map[role_normalized]
-        reports_output.warn(
+        reports_output.deprecation_warning(
             f"Role value '{role}' is deprecated and should not be used, use "
             f"'{replaced_by}' instead"
         )

--- a/pcs_test/tier0/cli/test_resource.py
+++ b/pcs_test/tier0/cli/test_resource.py
@@ -481,23 +481,23 @@ class ResourceBan(ResourceMoveBanMixin, TestCase):
         self.no_args_error = "must specify a resource to ban"
 
 
-@mock.patch("pcs.resource.warn")
+@mock.patch("pcs.resource.deprecation_warning")
 class ResourceMove(TestCase):
     def setUp(self):
         self.lib = mock.Mock(spec_set=["resource"])
         self.resource = mock.Mock(spec_set=["move_autoclean"])
         self.lib.resource = self.resource
 
-    def test_no_args(self, mock_warn):
+    def test_no_args(self, mock_deprecation):
         with self.assertRaises(CmdLineInputError) as cm:
             resource.resource_move(self.lib, [], dict_to_modifiers(dict()))
         self.assertEqual(
             cm.exception.message, "must specify a resource to move"
         )
         self.resource.move_autoclean.assert_not_called()
-        mock_warn.assert_not_called()
+        mock_deprecation.assert_not_called()
 
-    def test_too_many_args(self, mock_warn):
+    def test_too_many_args(self, mock_deprecation):
         with self.assertRaises(CmdLineInputError) as cm:
             resource.resource_move(
                 self.lib,
@@ -506,25 +506,25 @@ class ResourceMove(TestCase):
             )
         self.assertIsNone(cm.exception.message)
         self.resource.move_autoclean.assert_not_called()
-        mock_warn.assert_not_called()
+        mock_deprecation.assert_not_called()
 
-    def test_succes(self, mock_warn):
+    def test_succes(self, mock_deprecation):
         resource.resource_move(
             self.lib, ["resource"], dict_to_modifiers(dict())
         )
         self.resource.move_autoclean.assert_called_once_with(
             "resource", node=None, master=False, wait_timeout=-1, strict=False
         )
-        mock_warn.assert_not_called()
+        mock_deprecation.assert_not_called()
 
-    def test_success_node(self, mock_warn):
+    def test_success_node(self, mock_deprecation):
         resource.resource_move(
             self.lib, ["resource", "node"], dict_to_modifiers(dict())
         )
         self.resource.move_autoclean.assert_called_once_with(
             "resource", node="node", master=False, wait_timeout=-1, strict=False
         )
-        mock_warn.assert_not_called()
+        mock_deprecation.assert_not_called()
 
     def test_success_wait(self, mock_warn):
         resource.resource_move(
@@ -535,7 +535,7 @@ class ResourceMove(TestCase):
         )
         mock_warn.assert_not_called()
 
-    def test_success_autodelete(self, mock_warn):
+    def test_success_autodelete(self, mock_deprecation):
         resource.resource_move(
             self.lib,
             ["resource", "node"],
@@ -544,7 +544,7 @@ class ResourceMove(TestCase):
         self.resource.move_autoclean.assert_called_once_with(
             "resource", node="node", master=False, wait_timeout=-1, strict=False
         )
-        mock_warn.assert_called_once_with(
+        mock_deprecation.assert_called_once_with(
             "Option '--autodelete' is deprecated. There is no need to use it "
             "as its functionality is default now."
         )

--- a/pcs_test/tier0/lib/cib/test_constraint_ticket.py
+++ b/pcs_test/tier0/lib/cib/test_constraint_ticket.py
@@ -48,7 +48,7 @@ class PrepareOptionsPlainTest(TestCase):
         )
         self.report_processor.assert_reports(
             [
-                fixture.warn(
+                fixture.deprecation(
                     report_codes.DEPRECATED_OPTION_VALUE,
                     option_name="role",
                     deprecated_value=role,
@@ -133,7 +133,7 @@ class PrepareOptionsPlainTest(TestCase):
                     option_names=["ticket"],
                     option_type=None,
                 ),
-                fixture.warn(
+                fixture.deprecation(
                     report_codes.DEPRECATED_OPTION_VALUE,
                     option_name="role",
                     deprecated_value=role,

--- a/pcs_test/tier0/lib/cib/test_resource_operations.py
+++ b/pcs_test/tier0/lib/cib/test_resource_operations.py
@@ -419,7 +419,7 @@ class ValidateOperation(TestCase):
                 "role": const.PCMK_ROLE_PROMOTED_LEGACY,
             },
             [
-                fixture.warn(
+                fixture.deprecation(
                     report_codes.DEPRECATED_OPTION_VALUE,
                     option_name="role",
                     deprecated_value=const.PCMK_ROLE_PROMOTED_LEGACY,

--- a/pcs_test/tier0/lib/commands/resource/bundle_common.py
+++ b/pcs_test/tier0/lib/commands/resource/bundle_common.py
@@ -140,7 +140,7 @@ class ParametrizedContainerMixin(SetUpMixin):
         self.env_assist.assert_reports(
             [
                 (
-                    severities.WARNING,
+                    severities.DEPRECATION,
                     report_codes.DEPRECATED_OPTION,
                     {
                         "option_name": "masters",
@@ -167,7 +167,7 @@ class ParametrizedContainerMixin(SetUpMixin):
         self.env_assist.assert_reports(
             [
                 (
-                    severities.WARNING,
+                    severities.DEPRECATION,
                     report_codes.DEPRECATED_OPTION,
                     {
                         "option_name": "masters",

--- a/pcs_test/tier0/lib/commands/resource/test_bundle_update.py
+++ b/pcs_test/tier0/lib/commands/resource/test_bundle_update.py
@@ -153,7 +153,7 @@ class ContainerParametrized(TestCase):
         )
 
     fixture_report_deprecated_masters = (
-        severities.WARNING,
+        severities.DEPRECATION,
         report_codes.DEPRECATED_OPTION,
         {
             "option_name": "masters",

--- a/pcs_test/tier0/lib/commands/resource/test_resource_create.py
+++ b/pcs_test/tier0/lib/commands/resource/test_resource_create.py
@@ -406,13 +406,13 @@ class CreateRolesNormalization(TestCase):
     ):
         self.env_assist.assert_reports(
             [
-                fixture.warn(
+                fixture.deprecation(
                     reports.codes.DEPRECATED_OPTION_VALUE,
                     option_name="role",
                     deprecated_value=promoted_deprecated,
                     replaced_by=const.PCMK_ROLE_PROMOTED,
                 ),
-                fixture.warn(
+                fixture.deprecation(
                     reports.codes.DEPRECATED_OPTION_VALUE,
                     option_name="role",
                     deprecated_value=unpromoted_deprecated,

--- a/pcs_test/tier0/lib/commands/test_constraint_common.py
+++ b/pcs_test/tier0/lib/commands/test_constraint_common.py
@@ -82,7 +82,7 @@ class CreateWithSetTest(TestCase):
         )
         self.env.report_processor.assert_reports(
             [
-                fixture.warn(
+                fixture.deprecation(
                     report_codes.DEPRECATED_OPTION_VALUE,
                     option_name="role",
                     deprecated_value=self.role,
@@ -138,7 +138,7 @@ class CreateWithSetTest(TestCase):
                 ),
             ]
             + [
-                fixture.warn(
+                fixture.deprecation(
                     report_codes.DEPRECATED_OPTION_VALUE,
                     option_name="role",
                     deprecated_value=self.role,

--- a/pcs_test/tier0/lib/commands/test_ticket.py
+++ b/pcs_test/tier0/lib/commands/test_ticket.py
@@ -52,7 +52,7 @@ class CreateTest(TestCase):
         )
         env_assist.assert_reports(
             [
-                fixture.warn(
+                fixture.deprecation(
                     report_codes.DEPRECATED_OPTION_VALUE,
                     option_name="role",
                     deprecated_value=role,

--- a/pcs_test/tier0/lib/test_validate.py
+++ b/pcs_test/tier0/lib/test_validate.py
@@ -999,7 +999,9 @@ class ValueDeprecated(TestCase):
     def test_no_deprecated(self):
         assert_report_item_list_equal(
             validate.ValueDeprecated(
-                "opt", dict(valB="valA"), reports.ReportItemSeverity.warning()
+                "opt",
+                dict(valB="valA"),
+                reports.ReportItemSeverity.deprecation(),
             ).validate(dict(other_opt="1")),
             [],
         )
@@ -1007,7 +1009,7 @@ class ValueDeprecated(TestCase):
     def test_empty_deprecation_map(self):
         assert_report_item_list_equal(
             validate.ValueDeprecated(
-                "opt", dict(), reports.ReportItemSeverity.warning()
+                "opt", dict(), reports.ReportItemSeverity.deprecation()
             ).validate(dict(opt="1")),
             [],
         )
@@ -1015,10 +1017,10 @@ class ValueDeprecated(TestCase):
     def test_deprecated_no_replacement(self):
         assert_report_item_list_equal(
             validate.ValueDeprecated(
-                "opt", dict(valA=None), reports.ReportItemSeverity.warning()
+                "opt", dict(valA=None), reports.ReportItemSeverity.deprecation()
             ).validate(dict(opt="valA")),
             [
-                fixture.warn(
+                fixture.deprecation(
                     reports.codes.DEPRECATED_OPTION_VALUE,
                     option_name="opt",
                     deprecated_value="valA",

--- a/pcs_test/tier1/cib_resource/test_bundle.py
+++ b/pcs_test/tier1/cib_resource/test_bundle.py
@@ -185,8 +185,8 @@ class BundleCreate(BundleCreateCommon):
                     </bundle>
                 </resources>
             """,
-            "Warning: container option 'masters' is deprecated and should not "
-            "be used, use 'promoted-max' instead\n",
+            "Deprecation Warning: container option 'masters' is deprecated and "
+            "should not be used, use 'promoted-max' instead\n",
         )
 
     def test_deprecated_masters_and_promoted_max(self):
@@ -197,8 +197,9 @@ class BundleCreate(BundleCreateCommon):
             """.split(),
             "Error: Only one of container options 'masters' and "
             "'promoted-max' can be used\n"
-            "Warning: container option 'masters' is deprecated and should "
-            "not be used, use 'promoted-max' instead\n" + ERRORS_HAVE_OCURRED,
+            "Deprecation Warning: container option 'masters' is deprecated and "
+            "should not be used, use 'promoted-max' instead\n"
+            + ERRORS_HAVE_OCURRED,
         )
 
     def test_fail_when_missing_args_1(self):
@@ -498,16 +499,16 @@ class BundleUpdate(BundleCreateCommon):
                     </bundle>
                 </resources>
             """,
-            "Warning: container option 'masters' is deprecated and should not "
-            "be used, use 'promoted-max' instead\n",
+            "Deprecation Warning: container option 'masters' is deprecated and "
+            "should not be used, use 'promoted-max' instead\n",
         )
 
     def test_delete_masters(self):
         self.fixture_bundle("B")
         self.assert_pcs_success(
             "resource bundle update B container masters=2".split(),
-            "Warning: container option 'masters' is deprecated and should not "
-            "be used, use 'promoted-max' instead\n",
+            "Deprecation Warning: container option 'masters' is deprecated and "
+            "should not be used, use 'promoted-max' instead\n",
         )
         self.assert_effect(
             "resource bundle update B container masters=".split(),
@@ -533,8 +534,8 @@ class BundleUpdate(BundleCreateCommon):
         )
         self.assert_pcs_fail(
             "resource bundle update B container masters=2".split(),
-            "Warning: container option 'masters' is deprecated and should "
-            "not be used, use 'promoted-max' instead\n"
+            "Deprecation Warning: container option 'masters' is deprecated "
+            "and should not be used, use 'promoted-max' instead\n"
             "Error: Cannot set container option 'masters' because container "
             "option 'promoted-max' is already set\n" + ERRORS_HAVE_OCURRED,
         )
@@ -553,16 +554,16 @@ class BundleUpdate(BundleCreateCommon):
                     </bundle>
                 </resources>
             """,
-            "Warning: container option 'masters' is deprecated and should not "
-            "be used, use 'promoted-max' instead\n",
+            "Deprecation Warning: container option 'masters' is deprecated and "
+            "should not be used, use 'promoted-max' instead\n",
         )
 
     def test_promoted_max_set_after_masters(self):
         self.fixture_bundle("B")
         self.assert_pcs_success(
             "resource bundle update B container masters=2".split(),
-            "Warning: container option 'masters' is deprecated and should not "
-            "be used, use 'promoted-max' instead\n",
+            "Deprecation Warning: container option 'masters' is deprecated and "
+            "should not be used, use 'promoted-max' instead\n",
         )
         self.assert_pcs_fail(
             "resource bundle update B container promoted-max=3".split(),
@@ -574,8 +575,8 @@ class BundleUpdate(BundleCreateCommon):
         self.fixture_bundle("B")
         self.assert_pcs_success(
             "resource bundle update B container masters=2".split(),
-            "Warning: container option 'masters' is deprecated and should not "
-            "be used, use 'promoted-max' instead\n",
+            "Deprecation Warning: container option 'masters' is deprecated and "
+            "should not be used, use 'promoted-max' instead\n",
         )
         self.assert_effect(
             "resource bundle update B container masters= promoted-max=3".split(),

--- a/pcs_test/tier1/cib_resource/test_stonith_create.py
+++ b/pcs_test/tier1/cib_resource/test_stonith_create.py
@@ -195,8 +195,8 @@ class PlainStonith(ResourceTest):
                     </operations>
                 </primitive>
             </resources>""",
-            "Warning: stonith option 'action' is deprecated and should not be"
-            " used, use 'pcmk_off_action', 'pcmk_reboot_action' instead\n",
+            "Warning: stonith option 'action' is deprecated and should not be "
+            "used, use 'pcmk_off_action', 'pcmk_reboot_action' instead\n",
         )
 
 

--- a/pcs_test/tier1/legacy/test_cluster.py
+++ b/pcs_test/tier1/legacy/test_cluster.py
@@ -82,8 +82,9 @@ class UidGidTest(TestCase):
         assert r == 1
         ac(
             o,
-            "Warning: 'pcs cluster uidgid rm' has been deprecated, use 'pcs "
-            "cluster uidgid delete' or 'pcs cluster uidgid remove' instead\n"
+            "Deprecation Warning: 'pcs cluster uidgid rm' has been deprecated, "
+            "use 'pcs cluster uidgid delete' or 'pcs cluster uidgid remove' "
+            "instead\n"
             "Error: no uidgid files with uid=testuid2 and gid=testgid found\n",
         )
 
@@ -118,8 +119,9 @@ class UidGidTest(TestCase):
         o, r = _pcs("cluster uidgid rm uid=testuid gid=testgid".split())
         ac(
             o,
-            "Warning: 'pcs cluster uidgid rm' has been deprecated, use 'pcs "
-            "cluster uidgid delete' or 'pcs cluster uidgid remove' instead\n",
+            "Deprecation Warning: 'pcs cluster uidgid rm' has been deprecated, "
+            "use 'pcs cluster uidgid delete' or 'pcs cluster uidgid remove' "
+            "instead\n",
         )
         assert r == 0
 

--- a/pcs_test/tier1/legacy/test_constraints.py
+++ b/pcs_test/tier1/legacy/test_constraints.py
@@ -142,7 +142,8 @@ class ConstraintTest(unittest.TestCase):
         assert returnVal == 0
         assert output == (
             "Warning: invalid score 'pingd', setting score-attribute=pingd instead\n"
-            "Warning: Converting invalid score to score-attribute=pingd is deprecated and will be removed.\n"
+            "Deprecation Warning: Converting invalid score to "
+            "score-attribute=pingd is deprecated and will be removed.\n"
         ), [output]
 
         output, returnVal = pcs(
@@ -152,7 +153,8 @@ class ConstraintTest(unittest.TestCase):
         assert returnVal == 0
         assert output == (
             "Warning: invalid score 'pingd', setting score-attribute=pingd instead\n"
-            "Warning: Converting invalid score to score-attribute=pingd is deprecated and will be removed.\n"
+            "Deprecation Warning: Converting invalid score to "
+            "score-attribute=pingd is deprecated and will be removed.\n"
         ), [output]
 
         output, returnVal = pcs(
@@ -164,7 +166,7 @@ class ConstraintTest(unittest.TestCase):
         )
         assert returnVal == 0
         assert output == (
-            "Warning: Syntax 'date start=<date> gt' is deprecated "
+            "Deprecation Warning: Syntax 'date start=<date> gt' is deprecated "
             "and will be removed. Please use 'date gt <date>'.\n"
         ), [output]
 
@@ -177,9 +179,9 @@ class ConstraintTest(unittest.TestCase):
         )
         assert returnVal == 0
         assert output == (
-            "Warning: Syntax 'date start=<date> end=<date> in_range' is "
-            "deprecated and will be removed. Please use 'date in_range <date> "
-            "to <date>'.\n"
+            "Deprecation Warning: Syntax 'date start=<date> end=<date> "
+            "in_range' is deprecated and will be removed. Please use 'date "
+            "in_range <date> to <date>'.\n"
         ), [output]
 
         output, returnVal = pcs(
@@ -190,8 +192,8 @@ class ConstraintTest(unittest.TestCase):
             ).split(),
         )
         assert output == (
-            "Warning: Syntax 'operation=date_spec' is deprecated and will be "
-            "removed. Please use 'date-spec <date-spec options>'.\n"
+            "Deprecation Warning: Syntax 'operation=date_spec' is deprecated "
+            "and will be removed. Please use 'date-spec <date-spec options>'.\n"
         ), [output]
         assert returnVal == 0
 
@@ -761,7 +763,8 @@ Ticket Constraints:
         )
         ac(
             o,
-            f"Warning: Role value '{role}' is deprecated and should not be used, use '{const.PCMK_ROLE_UNPROMOTED}' instead\n",
+            f"Deprecation Warning: Role value '{role}' is deprecated and "
+            f"should not be used, use '{const.PCMK_ROLE_UNPROMOTED}' instead\n",
         )
         assert r == 0
 
@@ -1517,7 +1520,8 @@ Colocation Constraints:
         ac(
             o,
             (
-                f"Warning: Value '{const.PCMK_ROLE_UNPROMOTED_LEGACY}' of option "
+                f"Deprecation Warning: Value "
+                f"'{const.PCMK_ROLE_UNPROMOTED_LEGACY}' of option "
                 "role is deprecated and should not be used, use "
                 f"'{const.PCMK_ROLE_UNPROMOTED}' value instead\n"
             ),
@@ -3798,9 +3802,9 @@ class TicketAdd(ConstraintBaseTest):
         self.assert_pcs_fail(
             f"constraint ticket add T {role} A loss-policy=fence".split(),
             [
-                f"Warning: Value '{role}' of option role is deprecated and "
-                f"should not be used, use '{const.PCMK_ROLE_UNPROMOTED}' value "
-                "instead\n"
+                f"Deprecation Warning: Value '{role}' of option role is "
+                f"deprecated and should not be used, use "
+                f"'{const.PCMK_ROLE_UNPROMOTED}' value instead\n"
                 "Duplicate constraints:",
                 f"  {const.PCMK_ROLE_UNPROMOTED} A loss-policy=fence ticket=T (id:ticket-T-A-{const.PCMK_ROLE_UNPROMOTED})",
                 "Error: duplicate constraint already exists, use --force to "
@@ -3814,9 +3818,9 @@ class TicketAdd(ConstraintBaseTest):
         self.assert_pcs_success(
             f"constraint ticket add T {role} A loss-policy=fence".split(),
             stdout_full=(
-                f"Warning: Value '{role}' of option role is deprecated and "
-                f"should not be used, use '{const.PCMK_ROLE_PROMOTED}' value "
-                "instead\n"
+                f"Deprecation Warning: Value '{role}' of option role is "
+                f"deprecated and should not be used, use "
+                f"'{const.PCMK_ROLE_PROMOTED}' value instead\n"
             ),
         )
         promoted_role = const.PCMK_ROLE_PROMOTED_PRIMARY
@@ -3929,9 +3933,9 @@ class TicketShow(ConstraintBaseTest):
         self.assert_pcs_success(
             f"constraint ticket add T {role} A loss-policy=fence".split(),
             stdout_full=(
-                f"Warning: Value '{role}' of option role is deprecated and "
-                f"should not be used, use '{const.PCMK_ROLE_PROMOTED}' value "
-                "instead\n"
+                f"Deprecation Warning: Value '{role}' of option role is "
+                f"deprecated and should not be used, use "
+                f"'{const.PCMK_ROLE_PROMOTED}' value instead\n"
             ),
         )
         self.assert_pcs_success(

--- a/pcs_test/tier1/legacy/test_resource.py
+++ b/pcs_test/tier1/legacy/test_resource.py
@@ -4983,9 +4983,9 @@ class ResourceRemoveWithTicket(TestCase, AssertPcsMixin):
         self.assert_pcs_success(
             f"constraint ticket add T {role} A loss-policy=fence".split(),
             stdout_full=(
-                f"Warning: Value '{role}' of option role is deprecated and "
-                f"should not be used, use '{const.PCMK_ROLE_PROMOTED}' value "
-                "instead\n"
+                f"Deprecation Warning: Value '{role}' of option role is "
+                f"deprecated and should not be used, use "
+                f"'{const.PCMK_ROLE_PROMOTED}' value instead\n"
             ),
         )
         self.assert_pcs_success(

--- a/pcs_test/tier1/legacy/test_rule.py
+++ b/pcs_test/tier1/legacy/test_rule.py
@@ -1681,23 +1681,23 @@ class TokenPreprocessorTest(TestCase):
 
     def testNoChanges(self):
         self.assertEqual([], self.preprocessor.run([]))
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["#uname", "eq", "node1"],
             self.preprocessor.run(["#uname", "eq", "node1"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
     def testDateSpec(self):
         self.assertEqual(["date-spec"], self.preprocessor.run(["date-spec"]))
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date-spec", "hours=14"],
             self.preprocessor.run(["date-spec", "hours=14"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date-spec", "hours weeks=6 months= moon=1"],
@@ -1705,19 +1705,19 @@ class TokenPreprocessorTest(TestCase):
                 ["date-spec", "hours", "weeks=6", "months=", "moon=1"]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date-spec", "foo", "hours=14"],
             self.preprocessor.run(["date-spec", "foo", "hours=14"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date-spec", "hours=14", "foo", "hours=14"],
             self.preprocessor.run(["date-spec", "hours=14", "foo", "hours=14"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             [
@@ -1740,7 +1740,7 @@ class TokenPreprocessorTest(TestCase):
                 ]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["#uname", "eq", "node1", "or", "date-spec", "hours=14"],
@@ -1748,7 +1748,7 @@ class TokenPreprocessorTest(TestCase):
                 ["#uname", "eq", "node1", "or", "date-spec", "hours=14"]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date-spec", "hours=14", "or", "#uname", "eq", "node1"],
@@ -1763,17 +1763,17 @@ class TokenPreprocessorTest(TestCase):
                 ]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
     def testDuration(self):
         self.assertEqual(["duration"], self.preprocessor.run(["duration"]))
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["duration", "hours=14"],
             self.preprocessor.run(["duration", "hours=14"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["duration", "hours weeks=6 months= moon=1"],
@@ -1781,19 +1781,19 @@ class TokenPreprocessorTest(TestCase):
                 ["duration", "hours", "weeks=6", "months=", "moon=1"]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["duration", "foo", "hours=14"],
             self.preprocessor.run(["duration", "foo", "hours=14"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["duration", "hours=14", "foo", "hours=14"],
             self.preprocessor.run(["duration", "hours=14", "foo", "hours=14"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             [
@@ -1816,7 +1816,7 @@ class TokenPreprocessorTest(TestCase):
                 ]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["#uname", "eq", "node1", "or", "duration", "hours=14"],
@@ -1824,7 +1824,7 @@ class TokenPreprocessorTest(TestCase):
                 ["#uname", "eq", "node1", "or", "duration", "hours=14"]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["duration", "hours=14", "or", "#uname", "eq", "node1"],
@@ -1839,7 +1839,7 @@ class TokenPreprocessorTest(TestCase):
                 ]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
     def testOperationDatespec(self):
         self.assertEqual(
@@ -1853,7 +1853,7 @@ class TokenPreprocessorTest(TestCase):
                 "Syntax 'operation=date_spec' is deprecated and will be "
                 "removed. Please use 'date-spec <date-spec options>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         self.assertEqual(
@@ -1867,7 +1867,7 @@ class TokenPreprocessorTest(TestCase):
                 "Syntax 'operation=date_spec' is deprecated and will be "
                 "removed. Please use 'date-spec <date-spec options>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         self.assertEqual(
@@ -1881,7 +1881,7 @@ class TokenPreprocessorTest(TestCase):
                 "Syntax 'operation=date_spec' is deprecated and will be "
                 "removed. Please use 'date-spec <date-spec options>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         self.assertEqual(
@@ -1890,7 +1890,7 @@ class TokenPreprocessorTest(TestCase):
                 ["date-spec", "weeks=6", "foo", "operation=date_spec", "moon=1"]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date-spec", "weeks=6 moon=1"],
@@ -1903,7 +1903,7 @@ class TokenPreprocessorTest(TestCase):
                 "Syntax 'operation=date_spec' is deprecated and will be "
                 "removed. Please use 'date-spec <date-spec options>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         self.assertEqual(
@@ -1917,7 +1917,7 @@ class TokenPreprocessorTest(TestCase):
                 "Syntax 'operation=date_spec' is deprecated and will be "
                 "removed. Please use 'date-spec <date-spec options>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         self.assertEqual(
@@ -1929,7 +1929,7 @@ class TokenPreprocessorTest(TestCase):
                 "Syntax 'operation=date_spec' is deprecated and will be "
                 "removed. Please use 'date-spec <date-spec options>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         self.assertEqual(
@@ -1938,7 +1938,7 @@ class TokenPreprocessorTest(TestCase):
                 ["date-spec", "weeks=6", "operation=foo", "moon=1"]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
     def testDateLegacySyntax(self):
         # valid syntax
@@ -1951,7 +1951,7 @@ class TokenPreprocessorTest(TestCase):
                 "Syntax 'date start=<date> gt' is deprecated and will be "
                 "removed. Please use 'date gt <date>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         self.assertEqual(
@@ -1963,7 +1963,7 @@ class TokenPreprocessorTest(TestCase):
                 "Syntax 'date end=<date> lt' is deprecated and will be "
                 "removed. Please use 'date lt <date>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         self.assertEqual(
@@ -1978,7 +1978,7 @@ class TokenPreprocessorTest(TestCase):
                 "and will be removed. Please use 'date in_range <date> to "
                 "<date>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         self.assertEqual(
@@ -1993,7 +1993,7 @@ class TokenPreprocessorTest(TestCase):
                 "and will be removed. Please use 'date in_range <date> to "
                 "<date>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         self.assertEqual(
@@ -2005,7 +2005,7 @@ class TokenPreprocessorTest(TestCase):
                 "Syntax 'date start=<date> gt' is deprecated and will be "
                 "removed. Please use 'date gt <date>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         self.assertEqual(
@@ -2017,7 +2017,7 @@ class TokenPreprocessorTest(TestCase):
                 "Syntax 'date end=<date> lt' is deprecated and will be "
                 "removed. Please use 'date lt <date>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         self.assertEqual(
@@ -2038,7 +2038,7 @@ class TokenPreprocessorTest(TestCase):
                 "and will be removed. Please use 'date in_range <date> to "
                 "<date>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         self.assertEqual(
@@ -2059,24 +2059,24 @@ class TokenPreprocessorTest(TestCase):
                 "and will be removed. Please use 'date in_range <date> to "
                 "<date>'.",
             ],
-            self.preprocessor.warning_list,
+            self.preprocessor.deprecation_warning_list,
         )
 
         # invalid syntax - no change
         self.assertEqual(["date"], self.preprocessor.run(["date"]))
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date", "start=2014-06-26"],
             self.preprocessor.run(["date", "start=2014-06-26"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date", "end=2014-06-26"],
             self.preprocessor.run(["date", "end=2014-06-26"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date", "start=2014-06-26", "end=2014-07-26"],
@@ -2084,7 +2084,7 @@ class TokenPreprocessorTest(TestCase):
                 ["date", "start=2014-06-26", "end=2014-07-26"]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date", "start=2014-06-26", "end=2014-07-26", "lt"],
@@ -2092,13 +2092,13 @@ class TokenPreprocessorTest(TestCase):
                 ["date", "start=2014-06-26", "end=2014-07-26", "lt"]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date", "start=2014-06-26", "lt", "foo"],
             self.preprocessor.run(["date", "start=2014-06-26", "lt", "foo"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date", "start=2014-06-26", "end=2014-07-26", "gt", "foo"],
@@ -2106,13 +2106,13 @@ class TokenPreprocessorTest(TestCase):
                 ["date", "start=2014-06-26", "end=2014-07-26", "gt", "foo"]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date", "end=2014-06-26", "gt"],
             self.preprocessor.run(["date", "end=2014-06-26", "gt"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date", "start=2014-06-26", "in_range", "foo"],
@@ -2120,96 +2120,96 @@ class TokenPreprocessorTest(TestCase):
                 ["date", "start=2014-06-26", "in_range", "foo"]
             ),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["date", "end=2014-07-26", "in_range"],
             self.preprocessor.run(["date", "end=2014-07-26", "in_range"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["foo", "start=2014-06-26", "gt"],
             self.preprocessor.run(["foo", "start=2014-06-26", "gt"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["foo", "end=2014-06-26", "lt"],
             self.preprocessor.run(["foo", "end=2014-06-26", "lt"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
     def testParenthesis(self):
         self.assertEqual(["("], self.preprocessor.run(["("]))
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual([")"], self.preprocessor.run([")"]))
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["(", "(", ")", ")"], self.preprocessor.run(["(", "(", ")", ")"])
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(["(", "(", ")", ")"], self.preprocessor.run(["(())"]))
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["a", "(", "b", ")", "c"],
             self.preprocessor.run(["a", "(", "b", ")", "c"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["a", "(", "b", "c", ")", "d"],
             self.preprocessor.run(["a", "(", "b", "c", ")", "d"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["a", ")", "b", "(", "c"],
             self.preprocessor.run(["a", ")", "b", "(", "c"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["a", "(", "b", ")", "c"], self.preprocessor.run(["a", "(b)", "c"])
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["a", "(", "b", ")", "c"], self.preprocessor.run(["a(", "b", ")c"])
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["a", "(", "b", ")", "c"], self.preprocessor.run(["a(b)c"])
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["aA", "(", "bB", ")", "cC"], self.preprocessor.run(["aA(bB)cC"])
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["(", "aA", "(", "bB", ")", "cC", ")"],
             self.preprocessor.run(["(aA(bB)cC)"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["(", "aA", "(", "(", "bB", ")", "cC", ")"],
             self.preprocessor.run(["(aA(", "(bB)cC)"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
         self.assertEqual(
             ["(", "aA", "(", "(", "(", "bB", ")", "cC", ")"],
             self.preprocessor.run(["(aA(", "(", "(bB)cC)"]),
         )
-        self.assertEqual([], self.preprocessor.warning_list)
+        self.assertEqual([], self.preprocessor.deprecation_warning_list)
 
 
 class ExportAsExpressionTest(TestCase):
@@ -2595,8 +2595,8 @@ Location Constraints:
             output,
             "Warning: invalid score 'pingd', setting score-attribute=pingd "
             "instead\n"
-            "Warning: Converting invalid score to score-attribute=pingd is "
-            "deprecated and will be removed.\n",
+            "Deprecation Warning: Converting invalid score to "
+            "score-attribute=pingd is deprecated and will be removed.\n",
         )
         self.assertEqual(0, returnVal)
 

--- a/pcs_test/tier1/legacy/test_stonith.py
+++ b/pcs_test/tier1/legacy/test_stonith.py
@@ -396,8 +396,8 @@ class StonithTest(TestCase, AssertPcsMixin):
 
         self.assert_pcs_success(
             "stonith create test fence_apc ip=i username=u action=a --force".split(),
-            "Warning: stonith option 'action' is deprecated and should not be"
-            " used, use 'pcmk_off_action', 'pcmk_reboot_action' instead\n",
+            "Warning: stonith option 'action' is deprecated and should not be "
+            "used, use 'pcmk_off_action', 'pcmk_reboot_action' instead\n",
         )
 
         self.assert_pcs_success(
@@ -453,8 +453,8 @@ class StonithTest(TestCase, AssertPcsMixin):
 
         self.assert_pcs_success(
             "stonith update test action=a --force".split(),
-            "Warning: stonith option 'action' is deprecated and should not be"
-            " used, use 'pcmk_off_action', 'pcmk_reboot_action' instead\n",
+            "Warning: stonith option 'action' is deprecated and should not be "
+            "used, use 'pcmk_off_action', 'pcmk_reboot_action' instead\n",
         )
 
         self.assert_pcs_success(
@@ -1176,8 +1176,9 @@ class LevelAdd(LevelTestsBase):
 
         self.assert_pcs_success(
             "stonith level add 1 rh7-1 F1,F2".split(),
-            "Warning: Delimiting stonith devices with ',' is deprecated and "
-            "will be removed. Please use a space to delimit stonith devices.\n",
+            "Deprecation Warning: Delimiting stonith devices with ',' is "
+            "deprecated and will be removed. Please use a space to delimit "
+            "stonith devices.\n",
         )
         self.assert_pcs_success(
             "stonith level".split(),
@@ -1191,8 +1192,9 @@ class LevelAdd(LevelTestsBase):
 
         self.assert_pcs_success(
             "stonith level add 2 rh7-1 F1,F2 F3".split(),
-            "Warning: Delimiting stonith devices with ',' is deprecated and "
-            "will be removed. Please use a space to delimit stonith devices.\n",
+            "Deprecation Warning: Delimiting stonith devices with ',' is "
+            "deprecated and will be removed. Please use a space to delimit "
+            "stonith devices.\n",
         )
         self.assert_pcs_success(
             "stonith level".split(),
@@ -1207,8 +1209,9 @@ class LevelAdd(LevelTestsBase):
 
         self.assert_pcs_success(
             "stonith level add 3 rh7-1 F1 F2,F3".split(),
-            "Warning: Delimiting stonith devices with ',' is deprecated and "
-            "will be removed. Please use a space to delimit stonith devices.\n",
+            "Deprecation Warning: Delimiting stonith devices with ',' is "
+            "deprecated and will be removed. Please use a space to delimit "
+            "stonith devices.\n",
         )
         self.assert_pcs_success(
             "stonith level".split(),
@@ -1389,9 +1392,9 @@ class LevelConfig(LevelTestsBase):
 
 class LevelClearDeprecatedSyntax(LevelTestsBase):
     deprecated_syntax = (
-        "Warning: Syntax 'pcs stonith level clear [<target> | <stonith id(s)>] "
-        "is deprecated and will be removed. Please use 'pcs stonith level "
-        "clear [target <target>] | [stonith <stonith id>...]'.\n"
+        "Deprecation Warning: Syntax 'pcs stonith level clear [<target> | "
+        "<stonith id(s)>] is deprecated and will be removed. Please use 'pcs "
+        "stonith level clear [target <target>] | [stonith <stonith id>...]'.\n"
     )
 
     def setUp(self):
@@ -1572,10 +1575,10 @@ class LevelClear(LevelTestsBase):
 class LevelDeleteRemoveDeprecatedSyntax(LevelTestsBase):
     command = None
     deprecation_warning = (
-        "Warning: Syntax 'pcs stonith level delete | remove <level> [<target>] "
-        "[<stonith id>...]' is deprecated and will be removed. Please use 'pcs "
-        "stonith level delete | remove <level> [target <target>] [stonith "
-        "<stonith id>...]'.\n"
+        "Deprecation Warning: Syntax 'pcs stonith level delete | remove "
+        "<level> [<target>] [<stonith id>...]' is deprecated and will be "
+        "removed. Please use 'pcs stonith level delete | remove <level> "
+        "[target <target>] [stonith <stonith id>...]'.\n"
     )
 
     def setUp(self):
@@ -1621,9 +1624,9 @@ class LevelDeleteRemoveDeprecatedSyntax(LevelTestsBase):
             ["stonith", "level", self.command, "3", r"regexp%rh7-\d", "F1,F2"],
             (
                 self.deprecation_warning
-                + "Warning: Delimiting stonith devices with ',' is deprecated "
-                "and will be removed. Please use a space to delimit stonith "
-                "devices.\n"
+                + "Deprecation Warning: Delimiting stonith devices with ',' is "
+                "deprecated and will be removed. Please use a space to delimit "
+                "stonith devices.\n"
                 "Error: Fencing level for 'rh7-\\d' at level '3' with "
                 "device(s) 'F1', 'F2' does not exist\n" + ERRORS_HAVE_OCURRED
             ),
@@ -1706,9 +1709,9 @@ class LevelDeleteRemoveDeprecatedSyntax(LevelTestsBase):
         self.assert_pcs_success(
             ["stonith", "level", self.command, "3", "F2,F1"],
             self.deprecation_warning
-            + "Warning: Delimiting stonith devices with ',' is deprecated "
-            "and will be removed. Please use a space to delimit stonith "
-            "devices.\n",
+            + "Deprecation Warning: Delimiting stonith devices with ',' is "
+            "deprecated and will be removed. Please use a space to delimit "
+            "stonith devices.\n",
         )
         self.assert_pcs_success(
             "stonith level config".split(),

--- a/pcs_test/tier1/test_cib_options.py
+++ b/pcs_test/tier1/test_cib_options.py
@@ -779,8 +779,9 @@ class DefaultsUpdateMixin(TestDefaultsMixin, AssertPcsMixin):
         warning_lines = []
         if not update_keyword:
             warning_lines.append(
-                "Warning: This command is deprecated and will be removed. "
-                f"Please use 'pcs {' '.join(self.cli_command)} update' instead.\n"
+                f"Deprecation Warning: This command is deprecated and will be "
+                f"removed. Please use 'pcs {' '.join(self.cli_command)} "
+                f"update' instead.\n"
             )
         warning_lines.append(
             "Warning: Defaults do not apply to resources which override "

--- a/pcs_test/tier1/test_misc.py
+++ b/pcs_test/tier1/test_misc.py
@@ -32,7 +32,7 @@ class ParseArgvDashDash(TestCase, AssertPcsMixin):
             self.cmd + ["-123"],
             outdent(
                 """\
-                Warning: Using '-123' without '--' is deprecated, those parameters will be considered position independent options in future pcs versions
+                Deprecation Warning: Using '-123' without '--' is deprecated, those parameters will be considered position independent options in future pcs versions
                 Error: Resource 'R1' does not exist
                 """
             ),
@@ -43,7 +43,7 @@ class ParseArgvDashDash(TestCase, AssertPcsMixin):
             self.cmd + ["-12.3"],
             outdent(
                 f"""\
-                Warning: Using '-12.3' without '--' is deprecated, those parameters will be considered position independent options in future pcs versions
+                Deprecation Warning: Using '-12.3' without '--' is deprecated, those parameters will be considered position independent options in future pcs versions
                 Error: invalid role value 'R2', allowed values are: {self.allowed_roles}
                 """
             ),
@@ -54,7 +54,7 @@ class ParseArgvDashDash(TestCase, AssertPcsMixin):
             self.cmd + ["-inFIniTY"],
             outdent(
                 f"""\
-                Warning: Using '-inFIniTY' without '--' is deprecated, those parameters will be considered position independent options in future pcs versions
+                Deprecation Warning: Using '-inFIniTY' without '--' is deprecated, those parameters will be considered position independent options in future pcs versions
                 Error: invalid role value 'R2', allowed values are: {self.allowed_roles}
                 """
             ),

--- a/pcs_test/tier1/test_status.py
+++ b/pcs_test/tier1/test_status.py
@@ -38,8 +38,8 @@ class StonithWarningTest(TestCase, AssertPcsMixin):
                 "stonith create Sa fence_apc ip=i username=u action=reboot "
                 "--force"
             ).split(),
-            "Warning: stonith option 'action' is deprecated and should not be"
-            " used, use 'pcmk_off_action', 'pcmk_reboot_action' instead\n",
+            "Warning: stonith option 'action' is deprecated and should not be "
+            "used, use 'pcmk_off_action', 'pcmk_reboot_action' instead\n",
         )
 
     def fixture_stonith_cycle(self):

--- a/pcs_test/tier1/test_tag.py
+++ b/pcs_test/tier1/test_tag.py
@@ -250,8 +250,8 @@ class TagList(
 ):
     command = "list"
     deprecation_msg = (
-        "Warning: This command is deprecated and will be removed. Please use "
-        "'pcs tag config' instead.\n"
+        "Deprecation Warning: This command is deprecated and will be removed. "
+        "Please use 'pcs tag config' instead.\n"
     )
 
 

--- a/pcs_test/tools/assertions.py
+++ b/pcs_test/tools/assertions.py
@@ -260,6 +260,7 @@ def assert_xml_equal(expected_xml, got_xml, context_explanation=""):
 SEVERITY_SHORTCUTS = {
     reports.ReportItemSeverity.INFO: "I",
     reports.ReportItemSeverity.WARNING: "W",
+    reports.ReportItemSeverity.DEPRECATION: "DW",
     reports.ReportItemSeverity.ERROR: "E",
     reports.ReportItemSeverity.DEBUG: "D",
 }

--- a/pcs_test/tools/fixture.py
+++ b/pcs_test/tools/fixture.py
@@ -21,6 +21,10 @@ def warn(code, context=None, **kwargs):
     return severities.WARNING, code, kwargs, None, context
 
 
+def deprecation(code, context=None, **kwargs):
+    return severities.DEPRECATION, code, kwargs, None, context
+
+
 def error(code, force_code=None, context=None, **kwargs):
     return severities.ERROR, code, kwargs, force_code, context
 
@@ -81,6 +85,9 @@ class ReportStore:
 
     def warn(self, name, code, **kwargs):
         return self.__append(name, warn(code, **kwargs))
+
+    def deprecation(self, name, code, **kwargs):
+        return self.__append(name, deprecation(code, **kwargs))
 
     def error(self, name, code, force_code=None, **kwargs):
         return self.__append(name, error(code, force_code=force_code, **kwargs))

--- a/pcsd/capabilities.xml
+++ b/pcsd/capabilities.xml
@@ -2228,6 +2228,16 @@
 
 
 
+    <capability id="pcs.reports.severity.deprecation" in-pcs="1" in-pcsd="0">
+      <description>
+        New report severity Deprecation is used for deprecation warnings.
+
+        pcs commands: all
+      </description>
+    </capability>
+
+
+
     <capability id="resource-agents.describe" in-pcs="1" in-pcsd="1">
       <description>
         Describe a resource agent - present its metadata.


### PR DESCRIPTION
Adds a new severity for deprecation warning. All deprecation warnings
now use the "Deprecation Warning:" prefix instead of "Warning:".