### PR TITLE
fix running pcs_internal from git repository [pcs-0.10]

### DIFF
--- a/pcs/pcs_internal.in
+++ b/pcs/pcs_internal.in
@@ -22,4 +22,5 @@ from pcs import (
 
 settings.pcsd_exec_location = os.path.join(PACKAGE_DIR, "pcsd")
 settings.pcsd_gem_path = os.path.join(PACKAGE_DIR, "@PCSD_BUNDLED_DIR_ROOT_LOCAL@")
+settings.pcs_data_dir = os.path.join(PACKAGE_DIR, "data")
 pcs_internal.main()


### PR DESCRIPTION
When running pcs_internal endpoint from git (not installed), path to
pcs data directory was not set properly.