### PR TITLE
use ruby_CFLAGS variable for ruby extensions compilation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -139,6 +139,10 @@ if ENABLE_DOWNLOAD
 	rm -rf $$(realpath $(PCSD_BUNDLED_DIR_LOCAL)/../)
 	rm -rf .bundle Gemfile.lock
 else
+	with_cflags=""; \
+	if test "x$(ruby_CFLAGS)" != "x"; then \
+		with_cflags='--with-cflags=$(ruby_CFLAGS)'; \
+	fi; \
 	gem_files=`$(FIND) "$(PCSD_BUNDLED_CACHE_DIR)" -type f -name '*.gem'` && \
 	if test "x$${gem_files}" != "x"; then \
 		$(GEM) install \
@@ -146,6 +150,7 @@ else
 			-i "$(PCSD_BUNDLED_DIR_ROOT_LOCAL)" \
 			$${gem_files} \
 			-- \
+			"$${with_cflags}" \
 			'--with-ldflags=$(ruby_LIBS)'; \
 	fi
 endif


### PR DESCRIPTION
* ruby_CFLAGS is now used during ruby extensions compilation
* it can be specified as parameter for configure script