### PR TITLE
fix rsc update cmd when unable to get agent metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 ### Fixed
 - Pcs was not automatically enabling corosync-qdevice when adding a quorum
   device to a cluster (broken since pcs-0.10.9) ([rhbz#2028902])
+- `resource update` command exiting with a traceback when updating a resource
+  with a non-existing resource agent ([rhbz#2019836])
 
 [rhbz#2028902]: https://bugzilla.redhat.com/show_bug.cgi?id=2028902
+[rhbz#2019836]: https://bugzilla.redhat.com/show_bug.cgi?id=2019836
 
 
 ## [0.11.1] - 2021-11-30

--- a/pcs/resource.py
+++ b/pcs/resource.py
@@ -1075,13 +1075,15 @@ def resource_update(lib, args, modifiers, deal_with_guest_change=True):
         if report_list:
             process_library_reports(report_list)
     except lib_ra.ResourceAgentError as e:
-        severity = (
-            reports.ReportItemSeverity.WARNING
-            if modifiers.get("--force")
-            else reports.ReportItemSeverity.ERROR
-        )
         process_library_reports(
-            [lib_ra.resource_agent_error_to_report_item(e, severity)]
+            [
+                lib_ra.resource_agent_error_to_report_item(
+                    e,
+                    reports.get_severity(
+                        reports.codes.FORCE, modifiers.get("--force")
+                    ),
+                )
+            ]
         )
     except LibraryError as e:
         process_library_reports(e.args)

--- a/pcs_test/tier1/legacy/test_resource.py
+++ b/pcs_test/tier1/legacy/test_resource.py
@@ -4882,6 +4882,27 @@ class UpdateInstanceAttrs(
             ),
         )
 
+    def test_nonexisting_agent(self):
+        agent = "ocf:pacemaker:nonexistent"
+        message = (
+            f"Agent '{agent}' is not installed or does "
+            "not provide valid metadata: Metadata query for "
+            f"{agent} failed: Input/output error"
+        )
+        self.assert_pcs_success(
+            f"resource create --force D0 {agent}".split(),
+            f"Warning: {message}\n",
+        )
+
+        self.assert_pcs_fail(
+            "resource update D0 test=testA".split(),
+            f"Error: {message}, use --force to override\n",
+        )
+        self.assert_pcs_success(
+            "resource update --force D0 test=testA".split(),
+            f"Warning: {message}\n",
+        )
+
     def test_update_existing(self):
         xml = """
             <resources>


### PR DESCRIPTION
`resource update` command failed with a traceback when updating a
resource with a non-existing resource agent