### PR TITLE
readd deprecated cmd `cluster pcsd-status`

### DIFF
--- a/pcs/app.py
+++ b/pcs/app.py
@@ -63,6 +63,7 @@ def _non_root_run(argv_cmd):
         ["cluster", "disable", "..."],
         ["cluster", "enable", "..."],
         ["cluster", "node", "..."],
+        ["cluster", "pcsd-status", "..."],  # TODO deprecated, remove command
         ["cluster", "start", "..."],
         ["cluster", "stop", "..."],
         ["cluster", "sync", "..."],

--- a/pcsd/pcsd.rb
+++ b/pcsd/pcsd.rb
@@ -198,6 +198,11 @@ post '/run_pcs' do
       'only_superuser' => false,
       'permissions' => Permissions::FULL,
     },
+    # TODO deprecated, remove command
+    ['cluster', 'pcsd-status', '...'] => {
+      'only_superuser' => false,
+      'permissions' => nil,
+    },
     # runs on the local node, check permissions
     ['cluster', 'start'] => {
       'only_superuser' => false,


### PR DESCRIPTION
This command was still available to the root user, but option to run it as
a non-root user was removed by a mistake.