### PR TITLE
revert of disallowing to clone a group with a stonith inside

### DIFF
--- a/pcs/resource.py
+++ b/pcs/resource.py
@@ -1697,7 +1697,7 @@ def resource_clone_create(
     ):
         element.parentNode.parentNode.removeChild(element.parentNode)
 
-    def _reject_stonith_clone_report(force_flags, stonith_ids, group_id=None):
+    if element.getAttribute("class") == "stonith":
         process_library_reports(
             [
                 reports.ReportItem(
@@ -1706,23 +1706,11 @@ def resource_clone_create(
                         is_forced=reports.codes.FORCE in force_flags,
                     ),
                     message=reports.messages.CloningStonithResourcesHasNoEffect(
-                        stonith_ids, group_id=group_id
+                        [name]
                     ),
                 )
             ]
         )
-
-    if element.getAttribute("class") == "stonith":
-        _reject_stonith_clone_report(force_flags, [name])
-
-    if element.tagName == "group":
-        stonith_ids = [
-            resource.getAttribute("id")
-            for resource in element.getElementsByTagName("primitive")
-            if resource.getAttribute("class") == "stonith"
-        ]
-        if stonith_ids:
-            _reject_stonith_clone_report(force_flags, stonith_ids, name)
 
     parts = parse_clone_args(argv, promotable=promotable)
     if not update_existing:

--- a/pcs_test/tier1/cib_resource/test_clone_unclone.py
+++ b/pcs_test/tier1/cib_resource/test_clone_unclone.py
@@ -354,12 +354,9 @@ class Clone(
 
     def test_clone_group_with_stonith(self):
         self.set_cib_file(FIXTURE_GROUP_WITH_STONITH)
-        self.assert_pcs_fail(
+        self.assert_effect(
             "resource clone Group".split(),
-            fixture_clone_stonith_msg(group=True),
-        )
-        self.assert_resources_xml_in_cib(
-            fixture_resources_xml(FIXTURE_GROUP_WITH_STONITH)
+            fixture_resources_xml(FIXTURE_CLONED_GROUP_WITH_STONITH),
         )
 
     def test_clone_group_with_stonith_forced(self):
@@ -367,7 +364,6 @@ class Clone(
         self.assert_effect(
             "resource clone Group --force".split(),
             fixture_resources_xml(FIXTURE_CLONED_GROUP_WITH_STONITH),
-            output=fixture_clone_stonith_msg(forced=True, group=True),
         )
 
     def test_promotable_clone(self):


### PR DESCRIPTION
Originaly, this was not fixed properly (it was possible to add a stonith
into a cloned group), therefore to stay consistent, this change is being
reverted. It will be fixed in the future by not allowing stonith to be
placed into a group.