### PR TITLE
Fix snmp client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
   device to a cluster (broken since pcs-0.10.9) ([rhbz#2028902])
 - `resource update` command exiting with a traceback when updating a resource
   with a non-existing resource agent ([rhbz#2019836])
+- pcs\_snmp\_agent is working again (broken since pcs-0.10.1) ([ghpull#431])
 
+[ghpull#431]: https://github.com/ClusterLabs/pcs/pull/431
 [rhbz#2028902]: https://bugzilla.redhat.com/show_bug.cgi?id=2028902
 [rhbz#2019836]: https://bugzilla.redhat.com/show_bug.cgi?id=2019836
 

--- a/pcsd/pcsd-cli-main.rb
+++ b/pcsd/pcsd-cli-main.rb
@@ -10,6 +10,7 @@ require 'remote.rb'
 
 
 PCS = get_pcs_path()
+PCS_INTERNAL = get_pcs_internal_path()
 $logger_device = StringIO.new
 $logger = Logger.new($logger_device)
 early_log($logger)


### PR DESCRIPTION
Required constant is missing causing the command to fail on startup and breaking the pcs_snmp_agent service.