### PR TITLE
update for PyParsing 3

### DIFF
--- a/pcs/lib/cib/rule/parser.py
+++ b/pcs/lib/cib/rule/parser.py
@@ -287,7 +287,7 @@ def __get_rule_parser() -> pyparsing.ParserElement:
             # operator
             pyparsing.Or(
                 [
-                    pyparsing.CaselessKeyword(op)
+                    pyparsing.CaselessKeyword(op).setName(f"'{op}'")
                     for op in _token_to_node_expr_unary_op
                 ]
             ).setResultsName("operator"),
@@ -312,7 +312,7 @@ def __get_rule_parser() -> pyparsing.ParserElement:
             # operator
             pyparsing.Or(
                 [
-                    pyparsing.CaselessKeyword(op)
+                    pyparsing.CaselessKeyword(op).setName(f"'{op}'")
                     for op in _token_to_node_expr_binary_op
                 ]
             ).setResultsName("operator"),
@@ -320,7 +320,7 @@ def __get_rule_parser() -> pyparsing.ParserElement:
             pyparsing.Optional(
                 pyparsing.Or(
                     [
-                        pyparsing.CaselessKeyword(type_)
+                        pyparsing.CaselessKeyword(type_).setName(f"'{type_}'")
                         for type_ in _token_to_node_expr_type
                     ]
                 )
@@ -339,11 +339,11 @@ def __get_rule_parser() -> pyparsing.ParserElement:
 
     date_unary_expr = pyparsing.And(
         [
-            pyparsing.CaselessKeyword("date"),
+            pyparsing.CaselessKeyword("date").setName("'date'"),
             # operator
             pyparsing.Or(
                 [
-                    pyparsing.CaselessKeyword(op)
+                    pyparsing.CaselessKeyword(op).setName(f"'{op}'")
                     for op in _token_to_date_expr_unary_op
                 ]
             ).setResultsName("operator"),
@@ -360,8 +360,8 @@ def __get_rule_parser() -> pyparsing.ParserElement:
 
     date_inrange_expr = pyparsing.And(
         [
-            pyparsing.CaselessKeyword("date"),
-            pyparsing.CaselessKeyword("in_range"),
+            pyparsing.CaselessKeyword("date").setName("'date'"),
+            pyparsing.CaselessKeyword("in_range").setName("'in_range'"),
             # date
             # It can by any string containing any characters except whitespace
             # (token separator) and "()" (brackets).
@@ -374,11 +374,13 @@ def __get_rule_parser() -> pyparsing.ParserElement:
                         pyparsing.Regex(r"[^\s()]+")
                         .setName("[<date>]")
                         .setResultsName("date1"),
-                        pyparsing.FollowedBy(pyparsing.CaselessKeyword("to")),
+                        pyparsing.FollowedBy(
+                            pyparsing.CaselessKeyword("to").setName("'to'")
+                        ),
                     ]
                 )
             ),
-            pyparsing.CaselessKeyword("to"),
+            pyparsing.CaselessKeyword("to").setName("'to'"),
             pyparsing.Or(
                 [
                     # date
@@ -391,7 +393,9 @@ def __get_rule_parser() -> pyparsing.ParserElement:
                     # duration
                     pyparsing.And(
                         [
-                            pyparsing.CaselessKeyword("duration"),
+                            pyparsing.CaselessKeyword("duration").setName(
+                                "'duration'"
+                            ),
                             __get_date_common_parser_part().setResultsName(
                                 "duration"
                             ),
@@ -405,7 +409,7 @@ def __get_rule_parser() -> pyparsing.ParserElement:
 
     datespec_expr = pyparsing.And(
         [
-            pyparsing.CaselessKeyword("date-spec"),
+            pyparsing.CaselessKeyword("date-spec").setName("'date-spec'"),
             __get_date_common_parser_part().setResultsName("datespec"),
         ]
     )
@@ -413,7 +417,7 @@ def __get_rule_parser() -> pyparsing.ParserElement:
 
     rsc_expr = pyparsing.And(
         [
-            pyparsing.CaselessKeyword("resource"),
+            pyparsing.CaselessKeyword("resource").setName("'resource'"),
             # resource name
             # Up to three parts seperated by ":". The parts can contain any
             # characters except whitespace (token separator), ":" (parts
@@ -427,7 +431,7 @@ def __get_rule_parser() -> pyparsing.ParserElement:
 
     op_interval = pyparsing.And(
         [
-            pyparsing.CaselessKeyword("interval"),
+            pyparsing.CaselessKeyword("interval").setName("'interval'"),
             # no spaces allowed around the "="
             pyparsing.Literal("=").leaveWhitespace(),
             # interval value: number followed by a time unit, no spaces allowed
@@ -446,7 +450,7 @@ def __get_rule_parser() -> pyparsing.ParserElement:
     )
     op_expr = pyparsing.And(
         [
-            pyparsing.CaselessKeyword("op"),
+            pyparsing.CaselessKeyword("op").setName("'op'"),
             # operation name
             # It can by any string containing any characters except whitespace
             # (token separator) and "()" (brackets). Operations are defined in
@@ -486,7 +490,10 @@ def __get_rule_parser() -> pyparsing.ParserElement:
     # https://github.com/pyparsing/pyparsing/blob/master/examples/simpleBool.py
     # https://github.com/pyparsing/pyparsing/blob/master/examples/eval_arith.py
     bool_operator = pyparsing.Or(
-        [pyparsing.CaselessKeyword("and"), pyparsing.CaselessKeyword("or")]
+        [
+            pyparsing.CaselessKeyword("and").setName("'and'"),
+            pyparsing.CaselessKeyword("or").setName("'or'"),
+        ]
     )
     bool_expr = pyparsing.infixNotation(
         simple_expr,

--- a/pcs_test/tier0/lib/cib/rule/test_parser.py
+++ b/pcs_test/tier0/lib/cib/rule/test_parser.py
@@ -782,8 +782,8 @@ class Parser(TestCase):
     def test_not_valid_rule(self):
         test_data = [
             # node attr misc
-            ("#uname", (1, 7, 6, 'Expected "eq"')),
-            ("string node1", (1, 8, 7, 'Expected "eq"')),
+            ("#uname", (1, 7, 6, "Expected 'eq'")),
+            ("string node1", (1, 8, 7, "Expected 'eq'")),
             # node attr unary
             ("defined", (1, 8, 7, "Expected <attribute name>")),
             ("not_defined", (1, 12, 11, "Expected <attribute name>")),
@@ -791,58 +791,58 @@ class Parser(TestCase):
             ("defined date-spec hours=1", (1, 19, 18, "Expected end of text")),
             ("defined duration hours=1", (1, 18, 17, "Expected end of text")),
             # node attr binary
-            ("eq", (1, 3, 2, 'Expected "eq"')),
+            ("eq", (1, 3, 2, "Expected 'eq'")),
             ("#uname eq", (1, 10, 9, "Expected <attribute value>")),
-            ("#uname node1", (1, 8, 7, 'Expected "eq"')),
-            ("eq #uname", (1, 4, 3, 'Expected "eq"')),
+            ("#uname node1", (1, 8, 7, "Expected 'eq'")),
+            ("eq #uname", (1, 4, 3, "Expected 'eq'")),
             ("eq lt", (1, 6, 5, "Expected <attribute value>")),
-            ("string #uname eq node1", (1, 8, 7, 'Expected "eq"')),
+            ("string #uname eq node1", (1, 8, 7, "Expected 'eq'")),
             ("date-spec hours=1 eq node1", (1, 19, 18, "Expected end of text")),
             (
                 "#uname eq date-spec hours=1",
                 (1, 21, 20, "Expected end of text"),
             ),
-            ("duration hours=1 eq node1", (1, 10, 9, 'Expected "eq"')),
+            ("duration hours=1 eq node1", (1, 10, 9, "Expected 'eq'")),
             ("#uname eq duration hours=1", (1, 20, 19, "Expected end of text")),
             # node attr binary with optional parts
-            ("string", (1, 7, 6, 'Expected "eq"')),
+            ("string", (1, 7, 6, "Expected 'eq'")),
             ("#uname eq string", (1, 17, 16, "Expected <attribute value>")),
-            ("string #uname eq node1", (1, 8, 7, 'Expected "eq"')),
+            ("string #uname eq node1", (1, 8, 7, "Expected 'eq'")),
             # resource, op
-            ("resource", (1, 9, 8, 'Expected "eq"')),
-            ("op", (1, 3, 2, 'Expected "eq"')),
+            ("resource", (1, 9, 8, "Expected 'eq'")),
+            ("op", (1, 3, 2, "Expected 'eq'")),
             ("resource ::rA and", (1, 15, 14, "Expected end of text")),
             ("resource ::rA and op ", (1, 15, 14, "Expected end of text")),
             ("resource ::rA and (", (1, 15, 14, "Expected end of text")),
             # and, or
-            ("and", (1, 4, 3, 'Expected "eq"')),
-            ("or", (1, 3, 2, 'Expected "eq"')),
-            ("#uname and node1", (1, 8, 7, 'Expected "eq"')),
-            ("#uname or node1", (1, 8, 7, 'Expected "eq"')),
-            ("#uname or eq", (1, 8, 7, 'Expected "eq"')),
+            ("and", (1, 4, 3, "Expected 'eq'")),
+            ("or", (1, 3, 2, "Expected 'eq'")),
+            ("#uname and node1", (1, 8, 7, "Expected 'eq'")),
+            ("#uname or node1", (1, 8, 7, "Expected 'eq'")),
+            ("#uname or eq", (1, 8, 7, "Expected 'eq'")),
             ("#uname eq node1 and node2", (1, 17, 16, "Expected end of text")),
             ("#uname eq node1 and", (1, 17, 16, "Expected end of text")),
             (
                 "#uname eq node1 and #uname eq",
                 (1, 17, 16, "Expected end of text"),
             ),
-            ("and #uname eq node1", (1, 5, 4, 'Expected "eq"')),
+            ("and #uname eq node1", (1, 5, 4, "Expected 'eq'")),
             (
                 "#uname ne node1 and duration hours=1",
                 (1, 17, 16, "Expected end of text"),
             ),
             (
                 "duration monthdays=1 or #uname ne node1",
-                (1, 10, 9, 'Expected "eq"'),
+                (1, 10, 9, "Expected 'eq'"),
             ),
             # date
-            ("date in_range", (1, 14, 13, 'Expected "to"')),
-            ("date in_range 2014-06-26", (1, 15, 14, 'Expected "to"')),
+            ("date in_range", (1, 14, 13, "Expected 'to'")),
+            ("date in_range 2014-06-26", (1, 15, 14, "Expected 'to'")),
             ("date in_range 2014-06-26 to", (1, 28, 27, "Expected <date>")),
-            ("in_range 2014-06-26 to 2014-07-26", (1, 10, 9, 'Expected "eq"')),
+            ("in_range 2014-06-26 to 2014-07-26", (1, 10, 9, "Expected 'eq'")),
             (
                 "date in_range #uname eq node1 to 2014-07-26",
-                (1, 15, 14, 'Expected "to"'),
+                (1, 15, 14, "Expected 'to'"),
             ),
             (
                 "date in_range 2014-06-26 to #uname eq node1",
@@ -850,7 +850,7 @@ class Parser(TestCase):
             ),
             (
                 "date in_range defined pingd to 2014-07-26",
-                (1, 15, 14, 'Expected "to"'),
+                (1, 15, 14, "Expected 'to'"),
             ),
             (
                 "date in_range 2014-06-26 to defined pingd",
@@ -858,11 +858,11 @@ class Parser(TestCase):
             ),
             (
                 "string date in_range 2014-06-26 to 2014-07-26",
-                (1, 8, 7, 'Expected "eq"'),
+                (1, 8, 7, "Expected 'eq'"),
             ),
             (
                 "date in_range string 2014-06-26 to 2014-07-26",
-                (1, 15, 14, 'Expected "to"'),
+                (1, 15, 14, "Expected 'to'"),
             ),
             (
                 "date in_range 2014-06-26 to string 2014-07-26",
@@ -870,26 +870,33 @@ class Parser(TestCase):
             ),
             (
                 "date in_range 2014-06-26 string to 2014-07-26",
-                (1, 15, 14, 'Expected "to"'),
+                (1, 15, 14, "Expected 'to'"),
             ),
             (
                 "#uname in_range 2014-06-26 to 2014-07-26",
-                (1, 8, 7, 'Expected "eq"'),
+                (1, 8, 7, "Expected 'eq'"),
             ),
             # braces
-            ("(#uname)", (1, 8, 7, 'Expected "eq"')),
-            ("(", (1, 2, 1, 'Expected "date"')),
-            ("()", (1, 2, 1, 'Expected "date"')),
-            ("(#uname", (1, 8, 7, 'Expected "eq"')),
+            ("(#uname)", (1, 8, 7, "Expected 'eq'")),
+            ("(", (1, 2, 1, "Expected 'date'")),
+            ("()", (1, 2, 1, "Expected 'date'")),
+            ("(#uname", (1, 8, 7, "Expected 'eq'")),
             ("(#uname eq", (1, 11, 10, "Expected <attribute value>")),
-            ("(#uname eq node1", (1, 17, 16, 'Expected ")"')),
+            # pyparsing 2 uses double quotes, pyparsing 3 uses single quotes
+            ("(#uname eq node1", (1, 17, 16, {"Expected ')'", 'Expected ")"'})),
         ]
         for rule_string, exception_data in test_data:
             with self.subTest(rule_string=rule_string):
                 with self.assertRaises(rule.RuleParseError) as cm:
                     rule.parse_rule(rule_string)
                 e = cm.exception
-                self.assertEqual(
-                    exception_data, (e.lineno, e.colno, e.pos, e.msg)
-                )
+                if isinstance(exception_data[3], set):
+                    self.assertIn(e.msg, exception_data[3])
+                    self.assertEqual(
+                        exception_data[0:3], (e.lineno, e.colno, e.pos)
+                    )
+                else:
+                    self.assertEqual(
+                        exception_data, (e.lineno, e.colno, e.pos, e.msg)
+                    )
                 self.assertEqual(rule_string, e.rule_string)

--- a/pcs_test/tier0/lib/cib/test_nvpair_multi.py
+++ b/pcs_test/tier0/lib/cib/test_nvpair_multi.py
@@ -533,7 +533,7 @@ class ValidateNvsetAppendNew(TestCase):
                 fixture.error(
                     reports.codes.RULE_EXPRESSION_PARSE_ERROR,
                     rule_string="bad rule",
-                    reason='Expected "eq"',
+                    reason="Expected 'eq'",
                     rule_line="bad rule",
                     line_number=1,
                     column_number=5,

--- a/pcs_test/tier0/lib/commands/test_cib_options.py
+++ b/pcs_test/tier0/lib/commands/test_cib_options.py
@@ -138,7 +138,7 @@ class DefaultsCreateMixin:
                 fixture.error(
                     reports.codes.RULE_EXPRESSION_PARSE_ERROR,
                     rule_string="bad rule",
-                    reason='Expected "eq"',
+                    reason="Expected 'eq'",
                     rule_line="bad rule",
                     line_number=1,
                     column_number=5,


### PR DESCRIPTION
PyParsing 2.x error message: `Expected "eq"`
PyParsing 3.x error message: `Expected CaselessKeyword 'eq'`

`.setName` makes the error messages the same in both PyParsing 2.x and 3.x.
For `Expected ')'`, tests have been modified to accept both double and single quotes in the error message.