### PR TITLE
build: deal better with network bottle necks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -133,6 +133,9 @@ if ENABLE_DOWNLOAD
 	echo 'BUNDLE_PATH: "$(PCSD_BUNDLED_DIR_ROOT_LOCAL)"' >> .bundle/config
 	echo 'BUNDLE_CACHE_PATH: "$(PCSD_BUNDLED_CACHE_DIR)"' >> .bundle/config
 	echo 'BUNDLE_BUILD: \"$(ruby_LIBS)\"' >> .bundle/config
+	echo 'BUNDLE_TIMEOUT: 30' >> .bundle/config
+	echo 'BUNDLE_RETRY: 30' >> .bundle/config
+	echo 'BUNDLE_JOBS: 1' >> .bundle/config
 	$(BUNDLE)
 	cp -rp $(PCSD_BUNDLED_DIR_LOCAL)/* $(PCSD_BUNDLED_DIR_ROOT_LOCAL)/
 	rm -rf $$(realpath $(PCSD_BUNDLED_DIR_LOCAL)/../)


### PR DESCRIPTION
simply increase the amount of retries and timeouts when
operating in less ideal network environment, that could
cause gems to fail to download.

issue was spotted in CI where many machines would access
rubygem at the same time from one single IP address
and hit some load-balancer limit.

this should not affect the single user as is, but only
build farms

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>