### PR TITLE
Fixed PAM auth skipping authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@
 - Booth ticket name validation ([rhbz#2053177])
 - Adding booth ticket doesn't report 'mode' as an uknown option anymore
   ([rhbz#2058243])
+- Pcs daemon was allowing expired accounts, and accounts with expired
+  passwords to login when using PAM auth. ([huntr#220307])
 
 [rhbz#2024522]: https://bugzilla.redhat.com/show_bug.cgi?id=2024522
 [rhbz#2053177]: https://bugzilla.redhat.com/show_bug.cgi?id=2053177
 [rhbz#2054671]: https://bugzilla.redhat.com/show_bug.cgi?id=2054671
 [rhbz#2058243]: https://bugzilla.redhat.com/show_bug.cgi?id=2058243
+[huntr#220307]: https://huntr.dev/bounties/7aa921fc-a568-4fd8-96f4-7cd826246aa5/
 
 
 ## [0.11.2] - 2022-02-01

--- a/pcs/daemon/auth.py
+++ b/pcs/daemon/auth.py
@@ -64,6 +64,7 @@ libpam = CDLL(find_library("pam"))
 strdup = prep_fn(libc.strdup, POINTER(c_char), [c_char_p])
 calloc = prep_fn(libc.calloc, c_void_p, [c_uint, c_uint])
 pam_authenticate = prep_fn(libpam.pam_authenticate, c_int, [pam_handle, c_int])
+pam_acct_mgmt = prep_fn(libpam.pam_acct_mgmt, c_int, [pam_handle, c_int])
 pam_end = prep_fn(libpam.pam_end, c_int, [pam_handle, c_int])
 pam_start = prep_fn(
     libpam.pam_start,
@@ -102,6 +103,8 @@ def authenticate_by_pam(username, password):
     )
     if returncode == PAM_SUCCESS:
         returncode = pam_authenticate(pamh, 0)
+    if returncode == PAM_SUCCESS:
+        returncode = pam_acct_mgmt(pamh, 0)
     pam_end(pamh, returncode)
     return returncode == PAM_SUCCESS
 


### PR DESCRIPTION
The security fix PR as requested in the [huntr.dev report](https://huntr.dev/bounties/7aa921fc-a568-4fd8-96f4-7cd826246aa5/). The provided link will be viewable for everyone once it's public.

This bug has been found during a weekly [C3H2 CTF](https://twitter.com/c3h2_ctf) open source review session. 