### PR TITLE
pcs resource manage --monitor enables monitor for all resources in a group

### DIFF
--- a/pcs/lib/cib/resource/common.py
+++ b/pcs/lib/cib/resource/common.py
@@ -273,6 +273,24 @@ def find_resources_to_manage(resource_el):
     )
 
 
+def find_resources_to_manage_with_monitor(resource_el):
+    """
+    Get the specific resource  that needed to be enable monitor op
+    """
+    if is_bundle(resource_el):
+        in_bundle = get_bundle_inner_resource(resource_el)
+        return (
+            [resource_el, in_bundle] if in_bundle is not None else [resource_el]
+        )
+    if is_any_clone(resource_el):
+        resource_el = get_clone_inner_resource(resource_el)
+    if is_group(resource_el):
+        return get_group_inner_resources(resource_el)
+    if is_primitive(resource_el):
+        return [resource_el]
+    return []
+
+
 def find_resources_to_unmanage(resource_el):
     """
     Get resources to unmanage to unmanage the specified resource successfully

--- a/pcs/lib/commands/resource.py
+++ b/pcs/lib/commands/resource.py
@@ -1397,6 +1397,14 @@ def manage(
             resource_el, ["monitor"]
         )
         if with_monitor:
+            disabled_resource_list, _ = _find_resources_expand_tags(
+                cib, resource_or_tag_ids, resource.common.find_resources_to_manage_with_monitor
+            )
+            for disabled_resource in disabled_resource_list:
+                if disabled_resource.attrib["id"] == resource_el.attrib["id"]:
+                    # find out the specific resource that needs to be enable monitor
+                    for op in op_list:
+                        resource.operations.enable(op)
             for op in op_list:
                 resource.operations.enable(op)
         else:


### PR DESCRIPTION
Fix rhbz#1918527:https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=1918527

I use the same code in `find_resources_to_unmanage` to find the specified resource, I'm not sure if this is the right way to do it.

