### PR TITLE
rpm: use new package name for pacemaker devel on opensuse

### DIFF
--- a/rpm/pcs.spec.in
+++ b/rpm/pcs.spec.in
@@ -89,7 +89,11 @@ BuildRequires: corosync-qdevice-devel
 BuildRequires: corosynclib-devel >= 3.0
 BuildRequires: fence-agents-common
 %if 0%{?suse_version}
+%if 0%{?suse_version} > 1500
+BuildRequires: libpacemaker3-devel >= %{required_pacemaker_version}
+%else
 BuildRequires: libpacemaker-devel >= %{required_pacemaker_version}
+%endif
 %else
 BuildRequires: pacemaker-libs-devel >= %{required_pacemaker_version}
 %endif


### PR DESCRIPTION
Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>