### PR TITLE
Confusing error message in 'pcs constraint ticket add' when an unknown option is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   ([rhbz#2151164], [ghissue#604])
 - Allow time values in stonith-watchdog-time property ([rhbz#2158790])
 - Enable/Disable sbd when cluster is not running ([rhbz#2166249])
+- Confusing error message in `pcs constraint ticket add` command
+  ([rhbz#2168617], [ghpull#559])
 
 ### Changed
 - Resource/stonith agent self-validation of instance attributes is now
@@ -22,11 +24,13 @@
   ([rhbz#2159454])
 
 [ghissue#604]: https://github.com/ClusterLabs/pcs/issues/604
+[ghpull#559]: https://github.com/ClusterLabs/pcs/pull/559
 [rhbz#2151164]: https://bugzilla.redhat.com/show_bug.cgi?id=2151164
 [rhbz#2151524]: https://bugzilla.redhat.com/show_bug.cgi?id=2151524
 [rhbz#2158790]: https://bugzilla.redhat.com/show_bug.cgi?id=2158790
 [rhbz#2159454]: https://bugzilla.redhat.com/show_bug.cgi?id=2159454
 [rhbz#2166249]: https://bugzilla.redhat.com/show_bug.cgi?id=2166249
+[rhbz#2168617]: https://bugzilla.redhat.com/show_bug.cgi?id=2168617
 
 
 ## [0.11.4] - 2022-11-21

--- a/pcs/cli/constraint_ticket/command.py
+++ b/pcs/cli/constraint_ticket/command.py
@@ -49,9 +49,21 @@ def add(lib, argv, modifiers):
             "Resource role must not be specified among options"
             + ", specify it before resource id"
         )
-
     if resource_role:
         options["rsc-role"] = resource_role
+
+    allowed_option = ['id', 'loss-policy']
+    invalid_names = [ 
+        name for name in options.keys() if name not in allowed_option
+    ]
+    if invalid_names:
+        raise LibraryError(
+            ReportItem.error(
+                reports.messages.InvalidOptions(
+                    sorted(invalid_names), sorted(allowed_option), None
+                )
+            )
+        )
 
     lib.constraint_ticket.create(
         ticket,

--- a/pcs/cli/constraint_ticket/command.py
+++ b/pcs/cli/constraint_ticket/command.py
@@ -57,11 +57,10 @@ def add(lib, argv, modifiers):
         name for name in options.keys() if name not in allowed_option
     ]
     if invalid_names:
-        raise LibraryError(
-            ReportItem.error(
-                reports.messages.InvalidOptions(
-                    sorted(invalid_names), sorted(allowed_option), None
-                )
+        invalid_option = " ".join(invalid_names)
+        raise CmdLineInputError(
+            "invalid option '{0}', allowed options are: 'id', 'loss-policy'".format(
+                invalid_option
             )
         )
 

--- a/pcs/cli/constraint_ticket/command.py
+++ b/pcs/cli/constraint_ticket/command.py
@@ -49,11 +49,9 @@ def add(lib, argv, modifiers):
             "Resource role must not be specified among options"
             + ", specify it before resource id"
         )
-    if resource_role:
-        options["rsc-role"] = resource_role
 
     allowed_option = ['id', 'loss-policy']
-    invalid_names = [ 
+    invalid_names = [
         name for name in options.keys() if name not in allowed_option
     ]
     if invalid_names:
@@ -63,6 +61,9 @@ def add(lib, argv, modifiers):
                 invalid_option
             )
         )
+
+    if resource_role:
+        options["rsc-role"] = resource_role
 
     lib.constraint_ticket.create(
         ticket,

--- a/pcs/cli/reports/processor.py
+++ b/pcs/cli/reports/processor.py
@@ -1,6 +1,8 @@
 from typing import (
+    Callable,
     Iterable,
     List,
+    Optional,
     Set,
 )
 
@@ -21,15 +23,21 @@ from .output import (
     warn,
 )
 
+ReportItemPreprocessor = Callable[[ReportItem], Optional[ReportItem]]
+
 
 class ReportProcessorToConsole(ReportProcessor):
     def __init__(self, debug: bool = False) -> None:
         super().__init__()
         self.debug = debug
         self._ignore_severities = self._get_ignored_severities([])
+        self._report_item_preprocessor: ReportItemPreprocessor = lambda x: x
 
     def _do_report(self, report_item: ReportItem) -> None:
-        report_item_dto = report_item.to_dto()
+        filtered_report_item = self._report_item_preprocessor(report_item)
+        if not filtered_report_item:
+            return
+        report_item_dto = filtered_report_item.to_dto()
         if report_item_dto.severity.level not in self._ignore_severities:
             print_report(report_item_dto)
 
@@ -47,6 +55,12 @@ class ReportProcessorToConsole(ReportProcessor):
         self, severity_list: Iterable[SeverityLevel]
     ) -> None:
         self._ignore_severities = self._get_ignored_severities(severity_list)
+
+    def set_report_item_preprocessor(
+        self,
+        report_item_preprocessor: ReportItemPreprocessor,
+    ) -> None:
+        self._report_item_preprocessor = report_item_preprocessor
 
 
 def print_report(report_item_dto: ReportItemDto) -> None:

--- a/pcs/lib/cib/constraint/constraint.py
+++ b/pcs/lib/cib/constraint/constraint.py
@@ -27,14 +27,8 @@ from pcs.lib.xml_tools import (
 
 
 def _validate_attrib_names(attrib_names, options):
-    positional_arguments = ['rsc','rsc-role','ticket']
-    options2 = options.copy()
-    for arg in positional_arguments:
-        if arg in options2:
-            options2.pop(arg)
-
     invalid_names = [
-        name for name in options2.keys() if name not in attrib_names
+        name for name in options.keys() if name not in attrib_names
     ]
     if invalid_names:
         raise LibraryError(

--- a/pcs/lib/cib/constraint/constraint.py
+++ b/pcs/lib/cib/constraint/constraint.py
@@ -27,8 +27,14 @@ from pcs.lib.xml_tools import (
 
 
 def _validate_attrib_names(attrib_names, options):
+    positional_arguments = ['rsc','rsc-role','ticket']
+    options2 = options.copy()
+    for arg in positional_arguments:
+        if arg in options2:
+            options2.pop(arg)
+
     invalid_names = [
-        name for name in options.keys() if name not in attrib_names
+        name for name in options2.keys() if name not in attrib_names
     ]
     if invalid_names:
         raise LibraryError(

--- a/pcs/lib/cib/constraint/ticket.py
+++ b/pcs/lib/cib/constraint/ticket.py
@@ -149,7 +149,6 @@ def prepare_options_plain(
         else:
             del options["rsc-role"]
 
-
     return constraint.prepare_options(
         tuple(list(ATTRIB) + list(ATTRIB_PLAIN)),
         options,

--- a/pcs/lib/cib/constraint/ticket.py
+++ b/pcs/lib/cib/constraint/ticket.py
@@ -149,10 +149,9 @@ def prepare_options_plain(
         else:
             del options["rsc-role"]
 
-    allowed_options = ('loss-policy',)
 
     return constraint.prepare_options(
-        allowed_options,
+        tuple(list(ATTRIB) + list(ATTRIB_PLAIN)),
         options,
         partial(
             _create_id,

--- a/pcs/lib/cib/constraint/ticket.py
+++ b/pcs/lib/cib/constraint/ticket.py
@@ -149,8 +149,10 @@ def prepare_options_plain(
         else:
             del options["rsc-role"]
 
+    allowed_options = ('loss-policy',)
+
     return constraint.prepare_options(
-        tuple(list(ATTRIB) + list(ATTRIB_PLAIN)),
+        allowed_options,
         options,
         partial(
             _create_id,

--- a/pcs_test/tier0/cli/constraint_ticket/test_command.py
+++ b/pcs_test/tier0/cli/constraint_ticket/test_command.py
@@ -54,6 +54,19 @@ class AddTest(TestCase):
         )
 
     @mock.patch("pcs.cli.constraint_ticket.command.parse_args.parse_add")
+    def test_refuse_unknown_option_in_options(self, mock_parse_add):
+        mock_parse_add.return_value = (
+            "ticket",
+            "resource_id",
+            "resource_role",
+            {"unknown": "option"},
+        )
+        lib = None
+        self.assertRaises(
+            CmdLineInputError, lambda: command.add(lib, ["argv"], _modifiers())
+        )
+
+    @mock.patch("pcs.cli.constraint_ticket.command.parse_args.parse_add")
     def test_put_resource_role_to_options_for_library(self, mock_parse_add):
         mock_parse_add.return_value = (
             "ticket",

--- a/pcs_test/tier0/cli/constraint_ticket/test_command.py
+++ b/pcs_test/tier0/cli/constraint_ticket/test_command.py
@@ -16,7 +16,11 @@ def _modifiers(force=True):
 
 
 class AddTest(TestCase):
-    # pylint: disable=no-self-use
+    def setUp(self):
+        self.lib = mock.MagicMock()
+        self.lib.constraint_ticket = mock.MagicMock()
+        self.lib.constraint_ticket.create = mock.MagicMock()
+
     @mock.patch("pcs.cli.constraint_ticket.command.parse_args.parse_add")
     def test_call_library_with_correct_attrs(self, mock_parse_add):
         mock_parse_add.return_value = (
@@ -25,14 +29,11 @@ class AddTest(TestCase):
             "",
             {"loss-policy": "fence"},
         )
-        lib = mock.MagicMock()
-        lib.constraint_ticket = mock.MagicMock()
-        lib.constraint_ticket.create = mock.MagicMock()
 
-        command.add(lib, ["argv"], _modifiers())
+        command.add(self.lib, ["argv"], _modifiers())
 
         mock_parse_add.assert_called_once_with(["argv"])
-        lib.constraint_ticket.create.assert_called_once_with(
+        self.lib.constraint_ticket.create.assert_called_once_with(
             "ticket",
             "resource_id",
             {"loss-policy": "fence"},
@@ -48,22 +49,9 @@ class AddTest(TestCase):
             "resource_role",
             {"rsc-role": "master"},
         )
-        lib = None
         self.assertRaises(
-            CmdLineInputError, lambda: command.add(lib, ["argv"], _modifiers())
-        )
-
-    @mock.patch("pcs.cli.constraint_ticket.command.parse_args.parse_add")
-    def test_refuse_unknown_option_in_options(self, mock_parse_add):
-        mock_parse_add.return_value = (
-            "ticket",
-            "resource_id",
-            "resource_role",
-            {"unknown": "option"},
-        )
-        lib = None
-        self.assertRaises(
-            CmdLineInputError, lambda: command.add(lib, ["argv"], _modifiers())
+            CmdLineInputError,
+            lambda: command.add(self.lib, ["argv"], _modifiers()),
         )
 
     @mock.patch("pcs.cli.constraint_ticket.command.parse_args.parse_add")
@@ -74,14 +62,11 @@ class AddTest(TestCase):
             "resource_role",
             {"loss-policy": "fence"},
         )
-        lib = mock.MagicMock()
-        lib.constraint_ticket = mock.MagicMock()
-        lib.constraint_ticket.create = mock.MagicMock()
 
-        command.add(lib, ["argv"], _modifiers())
+        command.add(self.lib, ["argv"], _modifiers())
 
         mock_parse_add.assert_called_once_with(["argv"])
-        lib.constraint_ticket.create.assert_called_once_with(
+        self.lib.constraint_ticket.create.assert_called_once_with(
             "ticket",
             "resource_id",
             {"loss-policy": "fence", "rsc-role": "resource_role"},

--- a/pcs_test/tier0/lib/cib/test_constraint_ticket.py
+++ b/pcs_test/tier0/lib/cib/test_constraint_ticket.py
@@ -95,9 +95,6 @@ class PrepareOptionsPlainTest(TestCase):
                     "allowed": [
                         "id",
                         "loss-policy",
-                        "rsc",
-                        "rsc-role",
-                        "ticket",
                     ],
                     "allowed_patterns": [],
                 },

--- a/pcs_test/tier0/lib/cib/test_constraint_ticket.py
+++ b/pcs_test/tier0/lib/cib/test_constraint_ticket.py
@@ -82,26 +82,25 @@ class PrepareOptionsPlainTest(TestCase):
     def test_refuse_unknown_attributes(self, _):
         assert_raise_library_error(
             lambda: self.prepare(
-                {"unknown": "nonsense", "rsc-role": "master"},
+                {"unknown": "nonsense", "rsc-role": "promoted"},
                 "ticket-key",
                 "resourceA",
-            ),
-            (
-                severities.ERROR,
-                report_codes.INVALID_OPTIONS,
-                {
-                    "option_names": ["unknown"],
-                    "option_type": None,
-                    "allowed": [
+            )
+        )
+        self.report_processor.assert_reports(
+            [
+                fixture.error(
+                    report_codes.INVALID_OPTIONS,
+                    option_names=["unknown"],
+                    option_type=None,
+                    allowed=[
                         "id",
                         "loss-policy",
-                        "rsc",
                         "rsc-role",
-                        "ticket",
                     ],
-                    "allowed_patterns": [],
-                },
-            ),
+                    allowed_patterns=[],
+                )
+            ]
         )
 
     def test_refuse_bad_role(self, _):
@@ -187,7 +186,7 @@ class PrepareOptionsPlainTest(TestCase):
         # pylint: disable=unused-argument
         assert_raise_library_error(
             lambda: self.prepare(
-                {"loss-policy": "unknown", "ticket": "T", "id": "id"},
+                {"loss-policy": "unknown", "id": "id"},
                 "ticket-key",
                 "resourceA",
             ),
@@ -210,7 +209,6 @@ class PrepareOptionsPlainTest(TestCase):
         mock_create_id.return_value = "generated_id"
         options = {
             "loss-policy": "freeze",
-            "ticket": "T",
             "rsc-role": const.PCMK_ROLE_PROMOTED,
         }
         ticket_key = "ticket-key"

--- a/pcs_test/tier0/lib/cib/test_constraint_ticket.py
+++ b/pcs_test/tier0/lib/cib/test_constraint_ticket.py
@@ -95,6 +95,9 @@ class PrepareOptionsPlainTest(TestCase):
                     "allowed": [
                         "id",
                         "loss-policy",
+                        "rsc",
+                        "rsc-role",
+                        "ticket",
                     ],
                     "allowed_patterns": [],
                 },


### PR DESCRIPTION
A simple way to fix rhbz2022748 : https://bugzilla.redhat.com/show_bug.cgi?id=2022748
perhaps it's better to split 'options' into arguments and options?