### PR TITLE
--brief option usage does not match description

### DIFF
--- a/pcs/resource.py
+++ b/pcs/resource.py
@@ -2483,6 +2483,11 @@ def resource_disable_common(
             modifiers.get("--wait"),
         )
         return
+    if modifiers.get("--brief"):
+        raise CmdLineInputError(
+            "The --brief option should be used after --simulate "
+            "or --safe option"
+        )
     lib.resource.disable(argv, modifiers.get("--wait"))
 
 

--- a/pcs/resource.py
+++ b/pcs/resource.py
@@ -2485,8 +2485,7 @@ def resource_disable_common(
         return
     if modifiers.get("--brief"):
         raise CmdLineInputError(
-            "The --brief option should be used after --simulate "
-            "or --safe option"
+            "'--brief' cannot be used without '--simulate' or '--safe'"
         )
     lib.resource.disable(argv, modifiers.get("--wait"))
 

--- a/pcs_test/tier0/cli/test_resource.py
+++ b/pcs_test/tier0/cli/test_resource.py
@@ -690,6 +690,19 @@ class ResourceDisable(TestCase):
         self.resource.disable_safe.assert_not_called()
         self.resource.disable_simulate.assert_not_called()
 
+    def test_brief(self):
+        with self.assertRaises(CmdLineInputError) as cm:
+            resource.resource_disable_common(
+                self.lib, ["R1","R2"], dict_to_modifiers(dict(brief=True))
+            )
+        self.assertEqual(
+            cm.exception.message, "The --brief option should be used after --simulate or --safe option"
+        )
+        self.report_processor.suppress_reports_of_severity.assert_not_called()
+        self.resource.disable.assert_not_called()
+        self.resource.disable_safe.assert_not_called()
+        self.resource.disable_simulate.assert_not_called()
+
     def test_safe(self):
         resource.resource_disable_common(
             self.lib, ["R1", "R2"], dict_to_modifiers(dict(safe=True))

--- a/pcs_test/tier0/cli/test_resource.py
+++ b/pcs_test/tier0/cli/test_resource.py
@@ -693,10 +693,11 @@ class ResourceDisable(TestCase):
     def test_brief(self):
         with self.assertRaises(CmdLineInputError) as cm:
             resource.resource_disable_common(
-                self.lib, ["R1","R2"], dict_to_modifiers(dict(brief=True))
+                self.lib, ["R1", "R2"], dict_to_modifiers(dict(brief=True))
             )
         self.assertEqual(
-            cm.exception.message, "The --brief option should be used after --simulate or --safe option"
+            cm.exception.message,
+            "'--brief' cannot be used without '--simulate' or '--safe'",
         )
         self.report_processor.suppress_reports_of_severity.assert_not_called()
         self.resource.disable.assert_not_called()


### PR DESCRIPTION
Description of problem:
pcs resource disable usage shows --brief option should be use after --safe or --simulate option:
```    
disable <resource id | tag id>... [--safe [--brief] [--no-strict]]
            [--simulate [--brief]] [--wait[=n]]
```

If use --brief option alone, it will also take effect without any output, which is confusing.

Perhaps use warning is better? But in that way I'm not sure how to modify tests.