### PR TITLE
avoid usage of some types in lib command signatures available via api v2

### DIFF
--- a/pcs/lib/commands/cib_options.py
+++ b/pcs/lib/commands/cib_options.py
@@ -1,5 +1,6 @@
 from typing import (
     Any,
+    Collection,
     Container,
     Iterable,
     List,
@@ -42,7 +43,7 @@ def resource_defaults_create(
     nvpairs: Mapping[str, str],
     nvset_options: Mapping[str, str],
     nvset_rule: Optional[str] = None,
-    force_flags: Container[reports.types.ForceCode] = (),
+    force_flags: Collection[reports.types.ForceCode] = (),
 ) -> None:
     """
     Create new resource defaults nvset
@@ -73,7 +74,7 @@ def operation_defaults_create(
     nvpairs: Mapping[str, str],
     nvset_options: Mapping[str, str],
     nvset_rule: Optional[str] = None,
-    force_flags: Container[reports.types.ForceCode] = (),
+    force_flags: Collection[reports.types.ForceCode] = (),
 ) -> None:
     """
     Create new operation defaults nvset
@@ -239,7 +240,7 @@ def _defaults_config(
 
 
 def resource_defaults_remove(
-    env: LibraryEnvironment, nvset_id_list: Iterable[str]
+    env: LibraryEnvironment, nvset_id_list: Collection[str]
 ) -> None:
     """
     Remove specified resource defaults nvsets
@@ -251,7 +252,7 @@ def resource_defaults_remove(
 
 
 def operation_defaults_remove(
-    env: LibraryEnvironment, nvset_id_list: Iterable[str]
+    env: LibraryEnvironment, nvset_id_list: Collection[str]
 ) -> None:
     """
     Remove specified operation defaults nvsets

--- a/pcs/lib/commands/cluster.py
+++ b/pcs/lib/commands/cluster.py
@@ -4,7 +4,7 @@ import os.path
 import time
 from typing import (
     Any,
-    Container,
+    Collection,
     Mapping,
     Optional,
     Sequence,
@@ -204,7 +204,7 @@ def setup(
     enable: bool = False,
     no_keys_sync: bool = False,
     no_cluster_uuid: bool = False,
-    force_flags: Container[reports.types.ForceCode] = (),
+    force_flags: Collection[reports.types.ForceCode] = (),
 ):
     # pylint: disable=too-many-arguments
     # pylint: disable=too-many-locals
@@ -462,7 +462,7 @@ def setup_local(
     totem_options: Mapping[str, str],
     quorum_options: Mapping[str, str],
     no_cluster_uuid: bool = False,
-    force_flags: Container[reports.types.ForceCode] = (),
+    force_flags: Collection[reports.types.ForceCode] = (),
 ) -> bytes:
     """
     Return corosync.conf text based on specified parameters.
@@ -844,7 +844,7 @@ def add_nodes(
     start=False,
     enable=False,
     no_watchdog_validation=False,
-    force_flags: Container[reports.types.ForceCode] = (),
+    force_flags: Collection[reports.types.ForceCode] = (),
 ):
     # pylint: disable=too-many-locals, too-many-statements, too-many-branches
     """
@@ -1710,7 +1710,7 @@ def _verify_corosync_conf(corosync_conf_facade):
 def remove_nodes(
     env: LibraryEnvironment,
     node_list,
-    force_flags: Container[reports.types.ForceCode] = (),
+    force_flags: Collection[reports.types.ForceCode] = (),
 ):
     # pylint: disable=too-many-locals, too-many-branches, too-many-statements
     """
@@ -1956,7 +1956,7 @@ def add_link(
     env: LibraryEnvironment,
     node_addr_map,
     link_options=None,
-    force_flags: Container[reports.types.ForceCode] = (),
+    force_flags: Collection[reports.types.ForceCode] = (),
 ):
     """
     Add a corosync link to a cluster
@@ -2023,7 +2023,7 @@ def add_link(
 def remove_links(
     env: LibraryEnvironment,
     linknumber_list,
-    force_flags: Container[reports.types.ForceCode] = (),
+    force_flags: Collection[reports.types.ForceCode] = (),
 ):
     """
     Remove corosync links from a cluster
@@ -2066,7 +2066,7 @@ def update_link(
     linknumber,
     node_addr_map=None,
     link_options=None,
-    force_flags: Container[reports.types.ForceCode] = (),
+    force_flags: Collection[reports.types.ForceCode] = (),
 ):
     """
     Change an existing corosync link
@@ -2130,7 +2130,7 @@ def update_link(
 def corosync_authkey_change(
     env: LibraryEnvironment,
     corosync_authkey: Optional[bytes] = None,
-    force_flags: Container[reports.types.ForceCode] = (),
+    force_flags: Collection[reports.types.ForceCode] = (),
 ) -> None:
     """
     Distribute new corosync authkey to all cluster nodes.
@@ -2229,7 +2229,7 @@ def _generate_cluster_uuid(
 
 def generate_cluster_uuid(
     env: LibraryEnvironment,
-    force_flags: Container[reports.types.ForceCode] = (),
+    force_flags: Collection[reports.types.ForceCode] = (),
 ) -> None:
     """
     Add or update cluster UUID in live cluster
@@ -2249,7 +2249,7 @@ def generate_cluster_uuid(
 def generate_cluster_uuid_local(
     env: LibraryEnvironment,
     corosync_conf_content: bytes,
-    force_flags: Container[reports.types.ForceCode] = (),
+    force_flags: Collection[reports.types.ForceCode] = (),
 ) -> bytes:
     """
     Add or update cluster UUID in corosync.conf passed as an argument and return

--- a/pcs/lib/commands/fencing_topology.py
+++ b/pcs/lib/commands/fencing_topology.py
@@ -1,5 +1,5 @@
 from typing import (
-    Iterable,
+    Collection,
     Optional,
 )
 
@@ -83,7 +83,7 @@ def remove_levels_by_params(
     # TODO create a special type, so that it cannot accept any string
     target_type: Optional[str] = None,
     target_value=None,
-    devices: Optional[Iterable[str]] = None,
+    devices: Optional[Collection[str]] = None,
     # TODO remove, deprecated backward compatibility layer
     ignore_if_missing: bool = False,
     # TODO remove, deprecated backward compatibility layer

--- a/pcs/lib/commands/resource.py
+++ b/pcs/lib/commands/resource.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import (
     Any,
     Callable,
+    Collection,
     Dict,
     FrozenSet,
     Iterable,
@@ -1131,7 +1132,7 @@ def _disable_run_simulate(
 
 def disable(
     env: LibraryEnvironment,
-    resource_or_tag_ids: Iterable[str],
+    resource_or_tag_ids: Collection[str],
     wait: WaitType = False,
 ):
     """

--- a/pcs/lib/commands/scsi.py
+++ b/pcs/lib/commands/scsi.py
@@ -1,5 +1,8 @@
 import os.path
-from typing import Iterable
+from typing import (
+    Collection,
+    Iterable,
+)
 
 from pcs import settings
 from pcs.common import reports
@@ -86,8 +89,8 @@ def _unfence_node_devices(
 def unfence_node(
     env: LibraryEnvironment,
     node: str,
-    original_devices: Iterable[str],
-    updated_devices: Iterable[str],
+    original_devices: Collection[str],
+    updated_devices: Collection[str],
 ) -> None:
     """
     Unfence scsi devices on a node by calling fence_scsi agent script. Only
@@ -109,8 +112,8 @@ def unfence_node(
 def unfence_node_mpath(
     env: LibraryEnvironment,
     key: str,
-    original_devices: Iterable[str],
-    updated_devices: Iterable[str],
+    original_devices: Collection[str],
+    updated_devices: Collection[str],
 ) -> None:
     """
     Unfence mpath devices on a node by calling fence_mpath agent script. Only

--- a/pcs/lib/commands/stonith.py
+++ b/pcs/lib/commands/stonith.py
@@ -1,4 +1,5 @@
 from typing import (
+    Collection,
     Container,
     Iterable,
     List,
@@ -105,7 +106,7 @@ def create(
     env: LibraryEnvironment,
     stonith_id: str,
     stonith_agent_name: str,
-    operations: Iterable[Mapping[str, str]],
+    operations: Collection[Mapping[str, str]],
     meta_attributes: Mapping[str, str],
     instance_attributes: Mapping[str, str],
     allow_absent_agent: bool = False,
@@ -183,7 +184,7 @@ def create_in_group(
     stonith_id: str,
     stonith_agent_name: str,
     group_id: str,
-    operations: Iterable[Mapping[str, str]],
+    operations: Collection[Mapping[str, str]],
     meta_attributes: Mapping[str, str],
     instance_attributes: Mapping[str, str],
     allow_absent_agent: bool = False,

--- a/pcs_test/tier0/daemon/async_tasks/test_command_mapping.py
+++ b/pcs_test/tier0/daemon/async_tasks/test_command_mapping.py
@@ -1,0 +1,56 @@
+import inspect
+from dataclasses import (
+    fields,
+    is_dataclass,
+)
+from typing import (
+    Container,
+    Iterable,
+    get_args,
+    get_origin,
+)
+from unittest import TestCase
+
+from pcs.daemon.async_tasks.worker.command_mapping import COMMAND_MAP
+
+
+def prohibited_types_used(_type, prohibited_types):
+    if _type in prohibited_types:
+        return True
+    generic = get_origin(_type)
+    if generic:
+        if generic in prohibited_types:
+            return True
+        return any(
+            prohibited_types_used(arg, prohibited_types)
+            for arg in get_args(_type)
+        )
+    if is_dataclass(_type):
+        return any(
+            prohibited_types_used(field.type, prohibited_types)
+            for field in fields(_type)
+        )
+    return False
+
+
+def _get_generic(annotation):
+    return getattr(annotation, "__origin__", None)
+
+
+class DaciteTypingCompatibilityTest(TestCase):
+    def test_all(self):
+        prohibited_types = (Iterable, Container)
+        prohibited_types_normalized = [
+            get_origin(_type) for _type in prohibited_types
+        ]
+        for cmd_name, cmd in COMMAND_MAP.items():
+            for param in list(inspect.signature(cmd.cmd).parameters.values())[
+                1:
+            ]:
+                if param.annotation != inspect.Parameter.empty:
+                    self.assertFalse(
+                        prohibited_types_used(
+                            param.annotation, prohibited_types_normalized
+                        ),
+                        f"Prohibited type used in command: {cmd_name}; argument: {param}; prohibited_types: {prohibited_types}",
+                    )


### PR DESCRIPTION
dacite is unable to deserialize `list` to attributes annotated as `Iterable` or `Container`