### PR TITLE
More precise error messages for moving unmanaged resource

### DIFF
--- a/pcs/lib/commands/resource.py
+++ b/pcs/lib/commands/resource.py
@@ -1698,8 +1698,9 @@ def move_autoclean(
     if env.report_processor.report_list(report_list).has_errors:
         raise LibraryError()
 
+    cluster_state=env.get_cluster_state()
     resource_state_before = get_resource_state(
-        env.get_cluster_state(), resource_id
+        cluster_state, resource_id
     )
     if not _resource_running_on_nodes(resource_state_before):
         raise LibraryError(
@@ -1707,6 +1708,13 @@ def move_autoclean(
                 reports.messages.CannotMoveResourceNotRunning(resource_id)
             )
         )
+    if not is_resource_managed(cluster_state, resource_id):
+        raise LibraryError(
+            ReportItem.warning(
+                reports.messages.ResourceIsUnmanaged(resource_id)
+                )
+            )
+
     with get_tmp_cib(env.report_processor, cib_xml) as rsc_moved_cib_file:
         stdout, stderr, retval = resource_move(
             env.cmd_runner(dict(CIB_file=rsc_moved_cib_file.name)),

--- a/pcs/lib/commands/resource.py
+++ b/pcs/lib/commands/resource.py
@@ -1698,22 +1698,18 @@ def move_autoclean(
     if env.report_processor.report_list(report_list).has_errors:
         raise LibraryError()
 
-    cluster_state=env.get_cluster_state()
-    resource_state_before = get_resource_state(
-        cluster_state, resource_id
-    )
+    cluster_state = env.get_cluster_state()
+    resource_state_before = get_resource_state(cluster_state, resource_id)
+    if not is_resource_managed(cluster_state, resource_id):
+        raise LibraryError(
+            ReportItem.error(reports.messages.ResourceIsUnmanaged(resource_id))
+        )
     if not _resource_running_on_nodes(resource_state_before):
         raise LibraryError(
             ReportItem.error(
                 reports.messages.CannotMoveResourceNotRunning(resource_id)
             )
         )
-    if not is_resource_managed(cluster_state, resource_id):
-        raise LibraryError(
-            ReportItem.warning(
-                reports.messages.ResourceIsUnmanaged(resource_id)
-                )
-            )
 
     with get_tmp_cib(env.report_processor, cib_xml) as rsc_moved_cib_file:
         stdout, stderr, retval = resource_move(

--- a/pcs_test/tier0/lib/commands/resource/test_resource_move_autoclean.py
+++ b/pcs_test/tier0/lib/commands/resource/test_resource_move_autoclean.py
@@ -899,6 +899,29 @@ class MoveAutocleanValidations(MoveAutocleanCommonSetup):
             ]
         )
 
+    def test_unmanaged_resource(self):
+        resource_id = "A"
+        self.config.runner.cib.load(
+            resources=_resources_tag(_rsc_primitive_fixture(resource_id))
+        )
+        self.config.runner.pcmk.load_state(
+            resources=_resources_tag(
+                '<resource id="{resource_id}" managed="{managed}" />'.format(
+                    resource_id=resource_id, managed="false"
+                )
+            )
+        )
+        self.env_assist.assert_raise_library_error(
+            lambda: move_autoclean(self.env_assist.get_env(), resource_id),
+            [
+                fixture.error(
+                    reports.codes.RESOURCE_IS_UNMANAGED,
+                    resource_id=resource_id,
+                )
+            ],
+            expected_in_processor=False,
+        )
+
 
 @mock.patch.object(
     settings,


### PR DESCRIPTION
In my case, I don't have any constraint in the cluster , so the error message looks quite confusing.
```
Error: Unable to move resource 'xxxxx' using a location constraint. Current location of the resource may be affected by some other constraint.
```

Does this needs a test case?