### PR TITLE
pcsd ruby: adjust to json 2.6.3 error message change

### DIFF
--- a/pcsd/test/test_config.rb
+++ b/pcsd/test/test_config.rb
@@ -126,7 +126,7 @@ class TestConfig < Test::Unit::TestCase
     assert_equal('error', $logger.log[0][0])
     assert_match(
       # the number is based on JSON gem version
-      /Unable to parse pcs_settings file: \d+: unexpected token/,
+      /Unable to parse pcs_settings file: (\d+: )?unexpected token/,
       $logger.log[0][1]
     )
     assert_equal(fixture_empty_config, cfg.text)
@@ -723,7 +723,7 @@ class TestCfgKnownHosts < Test::Unit::TestCase
     assert_equal('error', $logger.log[0][0])
     assert_match(
       # the number is based on JSON gem version
-      /Unable to parse known-hosts file: \d+: unexpected token/,
+      /Unable to parse known-hosts file: (\d+: )?unexpected token/,
       $logger.log[0][1]
     )
     assert_empty_data(cfg)


### PR DESCRIPTION
json 2.6.3 now removes line number information from parser error message.
Adjust regex pattern on pcs test code for ruby to support this error format.

Fixes #606 .