### PR TITLE
configure.ac: do not depend on daemons gem

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -385,7 +385,6 @@ PCS_CHECK_GEM([test-unit])
 if test "x$tests_only" != "xyes"; then
 	PCS_CHECK_GEM([backports])
 	PCS_CHECK_GEM([childprocess])
-	PCS_CHECK_GEM([daemons])
 	PCS_CHECK_GEM([ethon])
 	PCS_CHECK_GEM([ffi])
 	PCS_CHECK_GEM([json])

--- a/rpm/pcs.spec.in
+++ b/rpm/pcs.spec.in
@@ -10,11 +10,10 @@ Release: 1%{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}%{?
 # GPLv2: pcs
 # ASL 2.0: dataclasses, tornado
 # ASL 2.0 or BSD: dateutil
-# MIT: backports, childprocess, dacite, daemons, ember, ethon, handlebars, jquery,
-#      jquery-ui, mustermann, rack, rack-protection, rack-test, sinatra, tilt, nio4r
-# GPLv2 or Ruby: eventmachne, json
+# MIT: backports, childprocess, dacite, ethon, mustermann, nio4r, rack,
+#      rack-protection, rack-test, sinatra, tilt
+# GPLv2 or Ruby: json
 # BSD: puma
-# (GPLv2 or Ruby) and BSD: thin
 # BSD or Ruby: ruby2_keywords
 # BSD and MIT: ffi
 License: GPLv2 and ASL 2.0 and MIT and BSD and (GPLv2 or Ruby) and (BSD or Ruby) and (ASL 2.0 or BSD)


### PR DESCRIPTION
daemons gem was apparently added only because it is a thin dependency. Now that thin was replaced with puma, there is no need to depend on daemons anymore.

Commit with the replace of thin with puma:

https://github.com/ClusterLabs/pcs/commit/aba40f267c0d7926c7e1cf62d3de817c359e4c3d