### PR TITLE
 add meta option usage for pcs resource clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,16 @@
     line
   - Specifying `--full` to show IDs of elements now shows IDs of nvpairs as well
 
+### Deprecated
+- Keyword `meta` in `pcs resource clone` and `pcs resource promotable` commands
+  (it wasn't doing anything anyway) ([rhbz#2168155], [ghpull#648])
+
 [ghissue#612]: https://github.com/ClusterLabs/pcs/issues/612
+[ghpull#648]: https://github.com/ClusterLabs/pcs/pull/648
 [rhbz#1423473]: https://bugzilla.redhat.com/show_bug.cgi?id=1423473
 [rhbz#1860626]: https://bugzilla.redhat.com/show_bug.cgi?id=1860626
 [rhbz#2163953]: https://bugzilla.redhat.com/show_bug.cgi?id=2163953
+[rhbz#2168155]: https://bugzilla.redhat.com/show_bug.cgi?id=2168155
 [rhbz#2175881]: https://bugzilla.redhat.com/show_bug.cgi?id=2175881
 [rhbz#2177996]: https://bugzilla.redhat.com/show_bug.cgi?id=2177996
 [rhbz#2179388]: https://bugzilla.redhat.com/show_bug.cgi?id=2179388

--- a/pcs/cli/resource/parse_args.py
+++ b/pcs/cli/resource/parse_args.py
@@ -6,6 +6,7 @@ from pcs.cli.common.parse_args import (
     group_by_keywords,
     prepare_options,
 )
+from pcs.cli.reports.output import deprecation_warning
 
 
 def parse_create_simple(arg_list):

--- a/pcs/cli/resource/parse_args.py
+++ b/pcs/cli/resource/parse_args.py
@@ -50,6 +50,12 @@ def parse_clone(arg_list, promotable=False):
         raise CmdLineInputError(
             "op settings must be changed on base resource, not the clone",
         )
+
+    if "meta" in groups:
+        deprecation_warning(
+            "option 'meta' is deprecated and will be removed in a future release."
+        )
+
     parts["meta"] = prepare_options(
         groups.get("options", []) + groups.get("meta", []),
     )

--- a/pcs/resource.py
+++ b/pcs/resource.py
@@ -1036,8 +1036,14 @@ def resource_update(args: List[str], modifiers: InputModifiers) -> None:
             clone_child = utils.dom_elem_get_clone_ms_resource(clone)
             if clone_child:
                 child_id = clone_child.getAttribute("id")
+                # Drop 'meta' keyword as it is not allowed in 'pcs resource
+                # clone' command ultimately called from here
+                new_args = ra_values + meta_values
+                for op_args in op_values:
+                    if op_args:
+                        new_args += ["op"] + op_args
                 return resource_update_clone(
-                    dom, clone, child_id, args, wait, wait_timeout
+                    dom, clone, child_id, new_args, wait, wait_timeout
                 )
         utils.err("Unable to find resource: %s" % res_id)
 

--- a/pcs_test/tier1/cib_resource/test_clone_unclone.py
+++ b/pcs_test/tier1/cib_resource/test_clone_unclone.py
@@ -529,6 +529,10 @@ class Clone(
                 "c=d"
             ).split(),
             fixture_resources_xml(FIXTURE_CLONE_WITH_OPTIONS),
+            stderr_full=(
+                "Deprecation Warning: option 'meta' is deprecated and will be "
+                "removed in a future release.\n"
+            ),
         )
 
     def test_group_last_member(self):


### PR DESCRIPTION
fix https://bugzilla.redhat.com/show_bug.cgi?id=2168155
I'm not sure modify usage enough for this issue. The output looks like it adds meta properties for the clone, not the base resource. But to my understanding meta option is set for primitive resource 

