### PR TITLE
add check for closed stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [Unreleased]
+
+### Fixed
+- Crash in commands that ask for user input (like `pcs cluster destroy`) when
+  stdin is closed ([ghissue#612])
+
+[ghissue#612]: https://github.com/ClusterLabs/pcs/issues/612
+
+
 ## [0.11.5] - 2023-03-01
 
 ### Added

--- a/pcs/cli/common/output.py
+++ b/pcs/cli/common/output.py
@@ -43,7 +43,9 @@ def format_wrap_for_terminal(
     trim -- number which will be substracted from terminal size. Can be used in
         cases lines will be indented later by this number of spaces.
     """
-    if any((sys.stdout.isatty(), sys.stderr.isatty())):
+    if (sys.stdout is not None and sys.stdout.isatty()) or (
+        sys.stderr is not None and sys.stderr.isatty()
+    ):
         return format_wrap(
             text,
             # minimal line length is 40

--- a/pcs/utils.py
+++ b/pcs/utils.py
@@ -2061,7 +2061,12 @@ def is_run_interactive() -> bool:
     """
     Return True if pcs is running in an interactive environment, False otherwise
     """
-    return sys.stdin.isatty() and sys.stdout.isatty()
+    return (
+        sys.stdin is not None
+        and sys.stdout is not None
+        and sys.stdin.isatty()
+        and sys.stdout.isatty()
+    )
 
 
 def get_continue_confirmation_or_force(warning_text: str, force: bool) -> bool:
@@ -2087,7 +2092,7 @@ def get_terminal_password(message="Password: "):
     """
     Commandline options: no options
     """
-    if sys.stdin.isatty():
+    if sys.stdin is not None and sys.stdin.isatty():
         try:
             return getpass.getpass(message)
         except KeyboardInterrupt:

--- a/pcs_test/suite.py
+++ b/pcs_test/suite.py
@@ -261,7 +261,12 @@ def main():
             ),
             traceback_highlight=("--traceback-highlight" in sys.argv),
             fast_info=("--fast-info" in sys.argv),
-            rich_format=(sys.stdout.isatty() and sys.stderr.isatty()),
+            rich_format=(
+                sys.stdout is not None
+                and sys.stderr is not None
+                and sys.stdout.isatty()
+                and sys.stderr.isatty()
+            ),
             measure_time=("--time" in sys.argv),
         )
 


### PR DESCRIPTION
Resolves #612.

Authors of scripts sometimes close stdin. In some commands, we ask the user for input but first we check that pcs is not invoked from a script. This check was returning a traceback when stdin was closed. This commit adds a check that stdin is not None - that indicates that stdin is closed.