### PR TITLE
[pcs-0.10] add check for closed stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Validate dates in location constraint rules ([ghpull#644], [rhbz#2178707])
 - Fix displaying differences between configuration checkpoints in
   `pcs config checkpoint diff` command ([rhbz#2176490])
+- Crash in commands that ask for user input (like `pcs cluster destroy`) when
+  stdin is closed ([ghissue#612])
 
 ### Changed
 - Resource/stonith agent self-validation of instance attributes is now
@@ -29,6 +31,7 @@
   ([rhbz#2159455])
 
 [ghissue#604]: https://github.com/ClusterLabs/pcs/issues/604
+[ghissue#612]: https://github.com/ClusterLabs/pcs/issues/612
 [ghpull#559]: https://github.com/ClusterLabs/pcs/pull/559
 [ghpull#644]: https://github.com/ClusterLabs/pcs/pull/644
 [rhbz#1957591]: https://bugzilla.redhat.com/show_bug.cgi?id=1957591

--- a/pcs/cli/common/output.py
+++ b/pcs/cli/common/output.py
@@ -43,7 +43,9 @@ def format_wrap_for_terminal(
     trim -- number which will be substracted from terminal size. Can be used in
         cases lines will be indented later by this number of spaces.
     """
-    if any((sys.stdout.isatty(), sys.stderr.isatty())):
+    if (sys.stdout is not None and sys.stdout.isatty()) or (
+        sys.stderr is not None and sys.stderr.isatty()
+    ):
         return format_wrap(
             text,
             # minimal line length is 40

--- a/pcs/utils.py
+++ b/pcs/utils.py
@@ -2008,7 +2008,7 @@ def get_terminal_password(message="Password: "):
     """
     Commandline options: no options
     """
-    if sys.stdin.isatty():
+    if sys.stdin is not None and sys.stdin.isatty():
         try:
             return getpass.getpass(message)
         except KeyboardInterrupt:

--- a/pcs_test/suite.py
+++ b/pcs_test/suite.py
@@ -241,7 +241,12 @@ def main():
             ),
             traceback_highlight=("--traceback-highlight" in sys.argv),
             fast_info=("--fast-info" in sys.argv),
-            rich_format=(sys.stdout.isatty() and sys.stderr.isatty()),
+            rich_format=(
+                sys.stdout is not None
+                and sys.stderr is not None
+                and sys.stdout.isatty()
+                and sys.stderr.isatty()
+            ),
             measure_time=("--time" in sys.argv),
         )
 


### PR DESCRIPTION
Authors of scripts sometimes close stdin. In some commands, we ask the user for input but first we check that pcs is not invoked from a script. This check was returning a traceback when stdin was closed. This commit adds a check that stdin is not None - that indicates that stdin is closed.