### PR TITLE
printing cluster configuration changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
 - Fix `pcs stonith update-scsi-devices` command which was broken since
   Pacemaker-2.1.5-rc1 ([rhbz#2177996])
 
+### Changed
+- Commands for displaying cluster configuration have been slightly updated:
+  - Headings of empty sections are no longer displayed
+  - Resource listing is more dense as operations options are shown in a single
+    line
+  - Specifying `--full` to show IDs of elemets now shows IDs of nvpairs as well
+
 [ghissue#612]: https://github.com/ClusterLabs/pcs/issues/612
 [rhbz#1423473]: https://bugzilla.redhat.com/show_bug.cgi?id=1423473
 [rhbz#2163953]: https://bugzilla.redhat.com/show_bug.cgi?id=2163953

--- a/pcs/alert.py
+++ b/pcs/alert.py
@@ -218,17 +218,18 @@ def print_alert_config(lib, argv, modifiers):
     modifiers.ensure_only_supported("-f")
     if argv:
         raise CmdLineInputError()
-    print("\n".join(alert_config_lines(lib)))
+    lines = alert_config_lines(lib)
+    if lines:
+        print("\n".join(lines))
 
 
 def alert_config_lines(lib):
-    lines = ["Alerts:"]
+    lines = []
     alert_list = lib.alert.get_all_alerts()
     if alert_list:
+        lines.append("Alerts:")
         for alert in alert_list:
             lines.extend(indent(_alert_to_str(alert), 1))
-    else:
-        lines.append(" No alerts defined")
     return lines
 
 

--- a/pcs/cli/nvset.py
+++ b/pcs/cli/nvset.py
@@ -9,6 +9,7 @@ from pcs.cli.rule import (
 )
 from pcs.common.pacemaker.nvset import CibNvsetDto
 from pcs.common.str_tools import (
+    format_name_value_id_list,
     format_name_value_list,
     format_optional,
     indent,
@@ -54,9 +55,20 @@ def nvset_dto_to_lines(
             " ".join(format_name_value_list(sorted(nvset.options.items())))
         )
 
-    lines = format_name_value_list(
-        sorted([(nvpair.name, nvpair.value) for nvpair in nvset.nvpairs])
-    )
+    if with_ids:
+        lines = format_name_value_id_list(
+            sorted(
+                [
+                    (nvpair.name, nvpair.value, nvpair.id)
+                    for nvpair in nvset.nvpairs
+                ]
+            )
+        )
+    else:
+        lines = format_name_value_list(
+            sorted([(nvpair.name, nvpair.value) for nvpair in nvset.nvpairs])
+        )
+
     if nvset.rule:
         lines.extend(
             rule_expression_dto_to_lines(nvset.rule, with_ids=with_ids)

--- a/pcs/cli/nvset.py
+++ b/pcs/cli/nvset.py
@@ -1,7 +1,6 @@
 from typing import (
     Iterable,
     List,
-    Optional,
 )
 
 from pcs.cli.rule import (
@@ -22,10 +21,7 @@ def nvset_dto_list_to_lines(
     nvset_label: str,
     with_ids: bool = False,
     include_expired: bool = False,
-    text_if_empty: Optional[str] = None,
 ) -> List[str]:
-    if not nvset_dto_list:
-        return [text_if_empty] if text_if_empty else []
     if not include_expired:
         nvset_dto_list = [
             nvset_dto

--- a/pcs/cli/resource/output.py
+++ b/pcs/cli/resource/output.py
@@ -90,13 +90,14 @@ def _resource_operation_to_pairs(
 def _resource_operation_to_str(
     operation_dto: CibResourceOperationDto,
 ) -> List[str]:
-    lines = format_name_value_list(
-        [
-            pair
-            for pair in _resource_operation_to_pairs(operation_dto)
-            if pair[0] != "id"
-        ]
-    )
+    lines = []
+    op_pairs = [
+        pair
+        for pair in _resource_operation_to_pairs(operation_dto)
+        if pair[0] != "id"
+    ]
+    if op_pairs:
+        lines.append(" ".join(format_name_value_list(op_pairs)))
     # TODO: add support for meta and instance attributes once it is supported
     # by pcs
     return [

--- a/pcs/cli/rule.py
+++ b/pcs/cli/rule.py
@@ -45,7 +45,7 @@ def _rule_dto_to_lines(
         format_name_value_list(sorted(rule_expr.options.items()))
     )
     if with_ids:
-        heading_parts.append(f"(id:{rule_expr.id})")
+        heading_parts.append(f"(id: {rule_expr.id})")
 
     lines = []
     for child in rule_expr.expressions:
@@ -63,7 +63,7 @@ def _date_dto_to_lines(
     if operation == "date_spec":
         heading_parts = ["Expression:"]
         if with_ids:
-            heading_parts.append(f"(id:{rule_expr.id})")
+            heading_parts.append(f"(id: {rule_expr.id})")
         line_parts = ["Date Spec:"]
         if rule_expr.date_spec:
             line_parts.extend(
@@ -72,7 +72,7 @@ def _date_dto_to_lines(
                 )
             )
             if with_ids:
-                line_parts.append(f"(id:{rule_expr.date_spec.id})")
+                line_parts.append(f"(id: {rule_expr.date_spec.id})")
         return [" ".join(heading_parts)] + indent([" ".join(line_parts)])
 
     if operation == "in_range" and rule_expr.duration:
@@ -81,7 +81,7 @@ def _date_dto_to_lines(
             heading_parts.append(rule_expr.options["start"])
         heading_parts.extend(["to", "duration"])
         if with_ids:
-            heading_parts.append(f"(id:{rule_expr.id})")
+            heading_parts.append(f"(id: {rule_expr.id})")
         lines = [" ".join(heading_parts)]
 
         line_parts = ["Duration:"]
@@ -89,7 +89,7 @@ def _date_dto_to_lines(
             format_name_value_list(sorted(rule_expr.duration.options.items()))
         )
         if with_ids:
-            line_parts.append(f"(id:{rule_expr.duration.id})")
+            line_parts.append(f"(id: {rule_expr.duration.id})")
         lines.extend(indent([" ".join(line_parts)]))
 
         return lines
@@ -102,5 +102,5 @@ def _simple_expr_to_lines(
 ) -> List[str]:
     parts = ["Expression:", rule_expr.as_string]
     if with_ids:
-        parts.append(f"(id:{rule_expr.id})")
+        parts.append(f"(id: {rule_expr.id})")
     return [" ".join(parts)]

--- a/pcs/common/str_tools.py
+++ b/pcs/common/str_tools.py
@@ -101,6 +101,22 @@ def format_name_value_list(item_list: Sequence[Tuple[str, str]]) -> List[str]:
     return output
 
 
+# For now, Tuple[str, str, str] is sufficient. Feel free to change it if
+# needed, e.g. when values can be integers.
+def format_name_value_id_list(
+    item_list: Sequence[Tuple[str, str, str]]
+) -> List[str]:
+    """
+    Turn 3-tuples to 'name=value (id: id))' strings with standard quoting
+    """
+    output = []
+    for name, value, an_id in item_list:
+        name = quote(name, "= ")
+        value = quote(value, "= ")
+        output.append(f"{name}={value} (id: {an_id})")
+    return output
+
+
 def pairs_to_text(pairs: Sequence[tuple[str, str]]) -> list[str]:
     if pairs:
         return [" ".join(format_name_value_list(pairs))]

--- a/pcs/quorum.py
+++ b/pcs/quorum.py
@@ -25,8 +25,9 @@ def quorum_config_cmd(lib, argv, modifiers):
     modifiers.ensure_only_supported("--corosync_conf")
     if argv:
         raise CmdLineInputError()
-    config = lib.quorum.get_config()
-    print("\n".join(quorum_config_to_str(config)))
+    lines = quorum_config_to_str(lib.quorum.get_config())
+    if lines:
+        print("\n".join(lines))
 
 
 def quorum_config_to_str(config):
@@ -35,8 +36,8 @@ def quorum_config_to_str(config):
     """
     lines = []
 
-    lines.append("Options:")
     if "options" in config and config["options"]:
+        lines.append("Options:")
         lines.extend(
             indent(
                 [

--- a/pcs/resource.py
+++ b/pcs/resource.py
@@ -245,19 +245,14 @@ def _defaults_config_cmd(
     modifiers.ensure_only_supported(
         "-f", "--all", "--full", "--no-expire-check"
     )
-    print(
-        "\n".join(
-            nvset_dto_list_to_lines(
-                lib_command(
-                    not modifiers.get("--no-expire-check")
-                ).meta_attributes,
-                nvset_label="Meta Attrs",
-                with_ids=cast(bool, modifiers.get("--full")),
-                include_expired=cast(bool, modifiers.get("--all")),
-                text_if_empty="No defaults set",
-            )
-        )
+    lines = nvset_dto_list_to_lines(
+        lib_command(not modifiers.get("--no-expire-check")).meta_attributes,
+        nvset_label="Meta Attrs",
+        with_ids=cast(bool, modifiers.get("--full")),
+        include_expired=cast(bool, modifiers.get("--all")),
     )
+    if lines:
+        print("\n".join(lines))
 
 
 def resource_defaults_config_cmd(

--- a/pcs_test/tier0/cli/resource/test_defaults.py
+++ b/pcs_test/tier0/cli/resource/test_defaults.py
@@ -157,8 +157,8 @@ class DefaultsConfigMixin(DefaultsBaseMixin):
                 Meta Attrs (expired): my-meta_attributes
                   name1=value1
                   name2=value2
-                  Rule (expired): boolean-op=and score=INFINITY (id:my-meta-rule)
-                    Expression: resource ocf:pacemaker:Dummy (id:my-meta-rule-rsc)
+                  Rule (expired): boolean-op=and score=INFINITY (id: my-meta-rule)
+                    Expression: resource ocf:pacemaker:Dummy (id: my-meta-rule-rsc)
                 Meta Attrs: meta-plain score=123
                   "name 1"="value 1"'''
             )

--- a/pcs_test/tier0/cli/resource/test_defaults.py
+++ b/pcs_test/tier0/cli/resource/test_defaults.py
@@ -153,14 +153,14 @@ class DefaultsConfigMixin(DefaultsBaseMixin):
         self.lib_command.assert_called_once_with(True)
         mock_print.assert_called_once_with(
             dedent(
-                '''\
+                """\
                 Meta Attrs (expired): my-meta_attributes
-                  name1=value1
-                  name2=value2
+                  name1=value1 (id: my-id-pair1)
+                  name2=value2 (id: my-id-pair2)
                   Rule (expired): boolean-op=and score=INFINITY (id: my-meta-rule)
                     Expression: resource ocf:pacemaker:Dummy (id: my-meta-rule-rsc)
                 Meta Attrs: meta-plain score=123
-                  "name 1"="value 1"'''
+                  "name 1"="value 1" (id: my-id-pair3)"""
             )
         )
 

--- a/pcs_test/tier0/cli/resource/test_defaults.py
+++ b/pcs_test/tier0/cli/resource/test_defaults.py
@@ -97,7 +97,7 @@ class DefaultsConfigMixin(DefaultsBaseMixin):
         self.lib_command.return_value = self.empty_dto
         self._call_cmd([])
         self.lib_command.assert_called_once_with(True)
-        mock_print.assert_called_once_with("No defaults set")
+        mock_print.assert_not_called()
 
     def test_usage(self, mock_print):
         with self.assertRaises(CmdLineInputError) as cm:
@@ -110,13 +110,13 @@ class DefaultsConfigMixin(DefaultsBaseMixin):
         self.lib_command.return_value = self.empty_dto
         self._call_cmd([], {"full": True})
         self.lib_command.assert_called_once_with(True)
-        mock_print.assert_called_once_with("No defaults set")
+        mock_print.assert_not_called()
 
     def test_no_expire_check(self, mock_print):
         self.lib_command.return_value = self.empty_dto
         self._call_cmd([], {"no-expire-check": True})
         self.lib_command.assert_called_once_with(False)
-        mock_print.assert_called_once_with("No defaults set")
+        mock_print.assert_not_called()
 
     def test_print(self, mock_print):
         self.lib_command.return_value = self.dto_list

--- a/pcs_test/tier0/cli/test_nvset.py
+++ b/pcs_test/tier0/cli/test_nvset.py
@@ -81,9 +81,9 @@ class NvsetDtoToLines(TestCase):
         output = dedent(
             f"""\
             {self.label}: my-id score=150
-              "name 2"="value 2"
-              name1=value1
-              "name=3"="value=3"
+              "name 2"="value 2" (id: my-id-pair2)
+              name1=value1 (id: my-id-pair1)
+              "name=3"="value=3" (id: my-id-pair3)
               Rule: boolean-op=or (id: my-id-rule)
                 Expression: op monitor (id: my-id-rule-op)
             """
@@ -158,19 +158,19 @@ class NvsetDtoListToLines(TestCase):
         output = dedent(
             f"""\
             {self.label} (not yet in effect): id-NOT_YET_IN_EFFECT score=150
-              name1=value1
+              name1=value1 (id: id-NOT_YET_IN_EFFECT-pair1)
               Rule (not yet in effect): boolean-op=or (id: id-NOT_YET_IN_EFFECT-rule)
                 Expression: op monitor (id: id-NOT_YET_IN_EFFECT-rule-op)
             {self.label}: id-IN_EFFECT score=150
-              name1=value1
+              name1=value1 (id: id-IN_EFFECT-pair1)
               Rule: boolean-op=or (id: id-IN_EFFECT-rule)
                 Expression: op monitor (id: id-IN_EFFECT-rule-op)
             {self.label} (expired): id-EXPIRED score=150
-              name1=value1
+              name1=value1 (id: id-EXPIRED-pair1)
               Rule (expired): boolean-op=or (id: id-EXPIRED-rule)
                 Expression: op monitor (id: id-EXPIRED-rule-op)
             {self.label}: id-UNKNOWN score=150
-              name1=value1
+              name1=value1 (id: id-UNKNOWN-pair1)
               Rule: boolean-op=or (id: id-UNKNOWN-rule)
                 Expression: op monitor (id: id-UNKNOWN-rule-op)
         """
@@ -182,15 +182,15 @@ class NvsetDtoListToLines(TestCase):
         output = dedent(
             f"""\
             {self.label} (not yet in effect): id-NOT_YET_IN_EFFECT score=150
-              name1=value1
+              name1=value1 (id: id-NOT_YET_IN_EFFECT-pair1)
               Rule (not yet in effect): boolean-op=or (id: id-NOT_YET_IN_EFFECT-rule)
                 Expression: op monitor (id: id-NOT_YET_IN_EFFECT-rule-op)
             {self.label}: id-IN_EFFECT score=150
-              name1=value1
+              name1=value1 (id: id-IN_EFFECT-pair1)
               Rule: boolean-op=or (id: id-IN_EFFECT-rule)
                 Expression: op monitor (id: id-IN_EFFECT-rule-op)
             {self.label}: id-UNKNOWN score=150
-              name1=value1
+              name1=value1 (id: id-UNKNOWN-pair1)
               Rule: boolean-op=or (id: id-UNKNOWN-rule)
                 Expression: op monitor (id: id-UNKNOWN-rule-op)
         """

--- a/pcs_test/tier0/cli/test_nvset.py
+++ b/pcs_test/tier0/cli/test_nvset.py
@@ -84,8 +84,8 @@ class NvsetDtoToLines(TestCase):
               "name 2"="value 2"
               name1=value1
               "name=3"="value=3"
-              Rule: boolean-op=or (id:my-id-rule)
-                Expression: op monitor (id:my-id-rule-op)
+              Rule: boolean-op=or (id: my-id-rule)
+                Expression: op monitor (id: my-id-rule-op)
             """
         )
         self.assert_lines(dto, output)
@@ -159,20 +159,20 @@ class NvsetDtoListToLines(TestCase):
             f"""\
             {self.label} (not yet in effect): id-NOT_YET_IN_EFFECT score=150
               name1=value1
-              Rule (not yet in effect): boolean-op=or (id:id-NOT_YET_IN_EFFECT-rule)
-                Expression: op monitor (id:id-NOT_YET_IN_EFFECT-rule-op)
+              Rule (not yet in effect): boolean-op=or (id: id-NOT_YET_IN_EFFECT-rule)
+                Expression: op monitor (id: id-NOT_YET_IN_EFFECT-rule-op)
             {self.label}: id-IN_EFFECT score=150
               name1=value1
-              Rule: boolean-op=or (id:id-IN_EFFECT-rule)
-                Expression: op monitor (id:id-IN_EFFECT-rule-op)
+              Rule: boolean-op=or (id: id-IN_EFFECT-rule)
+                Expression: op monitor (id: id-IN_EFFECT-rule-op)
             {self.label} (expired): id-EXPIRED score=150
               name1=value1
-              Rule (expired): boolean-op=or (id:id-EXPIRED-rule)
-                Expression: op monitor (id:id-EXPIRED-rule-op)
+              Rule (expired): boolean-op=or (id: id-EXPIRED-rule)
+                Expression: op monitor (id: id-EXPIRED-rule-op)
             {self.label}: id-UNKNOWN score=150
               name1=value1
-              Rule: boolean-op=or (id:id-UNKNOWN-rule)
-                Expression: op monitor (id:id-UNKNOWN-rule-op)
+              Rule: boolean-op=or (id: id-UNKNOWN-rule)
+                Expression: op monitor (id: id-UNKNOWN-rule-op)
         """
         )
         self.assert_lines(self.fixture_dto_list(), True, output)
@@ -183,16 +183,16 @@ class NvsetDtoListToLines(TestCase):
             f"""\
             {self.label} (not yet in effect): id-NOT_YET_IN_EFFECT score=150
               name1=value1
-              Rule (not yet in effect): boolean-op=or (id:id-NOT_YET_IN_EFFECT-rule)
-                Expression: op monitor (id:id-NOT_YET_IN_EFFECT-rule-op)
+              Rule (not yet in effect): boolean-op=or (id: id-NOT_YET_IN_EFFECT-rule)
+                Expression: op monitor (id: id-NOT_YET_IN_EFFECT-rule-op)
             {self.label}: id-IN_EFFECT score=150
               name1=value1
-              Rule: boolean-op=or (id:id-IN_EFFECT-rule)
-                Expression: op monitor (id:id-IN_EFFECT-rule-op)
+              Rule: boolean-op=or (id: id-IN_EFFECT-rule)
+                Expression: op monitor (id: id-IN_EFFECT-rule-op)
             {self.label}: id-UNKNOWN score=150
               name1=value1
-              Rule: boolean-op=or (id:id-UNKNOWN-rule)
-                Expression: op monitor (id:id-UNKNOWN-rule-op)
+              Rule: boolean-op=or (id: id-UNKNOWN-rule)
+                Expression: op monitor (id: id-UNKNOWN-rule-op)
         """
         )
         self.assert_lines(self.fixture_dto_list(), False, output)

--- a/pcs_test/tier0/cli/test_rule.py
+++ b/pcs_test/tier0/cli/test_rule.py
@@ -57,8 +57,8 @@ class ExpressionDtoToLines(RuleDtoToLinesMixin, TestCase):
         )
         output = dedent(
             """\
-              Rule: (id:my-id)
-                Expression: defined pingd (id:my-id-expr)
+              Rule: (id: my-id)
+                Expression: defined pingd (id: my-id-expr)
             """
         )
         self.assert_lines(dto, output)
@@ -91,8 +91,8 @@ class ExpressionDtoToLines(RuleDtoToLinesMixin, TestCase):
         )
         output = dedent(
             """\
-              Rule: (id:my-id)
-                Expression: my-attr eq 'my value' (id:my-id-expr)
+              Rule: (id: my-id)
+                Expression: my-attr eq 'my value' (id: my-id-expr)
             """
         )
         self.assert_lines(dto, output)
@@ -126,8 +126,8 @@ class ExpressionDtoToLines(RuleDtoToLinesMixin, TestCase):
         )
         output = dedent(
             """\
-              Rule: (id:my-id)
-                Expression: foo gt version 1.2.3 (id:my-id-expr)
+              Rule: (id: my-id)
+                Expression: foo gt version 1.2.3 (id: my-id-expr)
             """
         )
         self.assert_lines(dto, output)
@@ -158,8 +158,8 @@ class DateExpressionDtoToLines(RuleDtoToLinesMixin, TestCase):
         )
         output = dedent(
             """\
-              Rule: (id:rule)
-                Expression: date gt 2014-06-26 (id:rule-expr)
+              Rule: (id: rule)
+                Expression: date gt 2014-06-26 (id: rule-expr)
             """
         )
         self.assert_lines(dto, output)
@@ -191,9 +191,9 @@ class DateExpressionDtoToLines(RuleDtoToLinesMixin, TestCase):
         )
         output = dedent(
             """\
-              Rule: (id:rule)
-                Expression: (id:rule-expr)
-                  Date Spec: hours=1-14 monthdays=20-30 months=1 (id:rule-expr-datespec)
+              Rule: (id: rule)
+                Expression: (id: rule-expr)
+                  Date Spec: hours=1-14 monthdays=20-30 months=1 (id: rule-expr-datespec)
             """
         )
         self.assert_lines(dto, output)
@@ -226,8 +226,8 @@ class DateExpressionDtoToLines(RuleDtoToLinesMixin, TestCase):
         )
         output = dedent(
             """\
-              Rule: (id:rule)
-                Expression: date in_range 2014-06-26 to 2014-07-26 (id:rule-expr)
+              Rule: (id: rule)
+                Expression: date in_range 2014-06-26 to 2014-07-26 (id: rule-expr)
             """
         )
         self.assert_lines(dto, output)
@@ -256,8 +256,8 @@ class DateExpressionDtoToLines(RuleDtoToLinesMixin, TestCase):
         )
         output = dedent(
             """\
-              Rule: (id:rule)
-                Expression: date in_range to 2014-07-26 (id:rule-expr)
+              Rule: (id: rule)
+                Expression: date in_range to 2014-07-26 (id: rule-expr)
             """
         )
         self.assert_lines(dto, output)
@@ -289,9 +289,9 @@ class DateExpressionDtoToLines(RuleDtoToLinesMixin, TestCase):
         )
         output = dedent(
             """\
-              Rule: (id:rule)
-                Expression: date in_range 2014-06-26 to duration (id:rule-expr)
-                  Duration: years=1 (id:rule-expr-duration)
+              Rule: (id: rule)
+                Expression: date in_range 2014-06-26 to duration (id: rule-expr)
+                  Duration: years=1 (id: rule-expr-duration)
             """
         )
         self.assert_lines(dto, output)
@@ -322,8 +322,8 @@ class OpExpressionDtoToLines(RuleDtoToLinesMixin, TestCase):
         )
         output = dedent(
             """\
-              Rule: (id:my-id)
-                Expression: op start (id:my-id-op)
+              Rule: (id: my-id)
+                Expression: op start (id: my-id-op)
             """
         )
         self.assert_lines(dto, output)
@@ -352,8 +352,8 @@ class OpExpressionDtoToLines(RuleDtoToLinesMixin, TestCase):
         )
         output = dedent(
             """\
-              Rule: (id:my-id)
-                Expression: op start interval=2min (id:my-id-op)
+              Rule: (id: my-id)
+                Expression: op start interval=2min (id: my-id-op)
             """
         )
         self.assert_lines(dto, output)
@@ -384,8 +384,8 @@ class ResourceExpressionDtoToLines(RuleDtoToLinesMixin, TestCase):
         )
         output = dedent(
             """\
-              Rule: (id:my-id)
-                Expression: resource ocf:pacemaker:Dummy (id:my-id-expr)
+              Rule: (id: my-id)
+                Expression: resource ocf:pacemaker:Dummy (id: my-id-expr)
             """
         )
         self.assert_lines(dto, output)
@@ -421,8 +421,8 @@ class InEffect(RuleDtoToLinesMixin, TestCase):
             self.fixture_dto(CibRuleInEffectStatus.UNKNOWN),
             dedent(
                 """\
-                  Rule: (id:my-id)
-                    Expression: defined pingd (id:my-id-expr)
+                  Rule: (id: my-id)
+                    Expression: defined pingd (id: my-id-expr)
                 """
             ),
         )
@@ -432,8 +432,8 @@ class InEffect(RuleDtoToLinesMixin, TestCase):
             self.fixture_dto(CibRuleInEffectStatus.EXPIRED),
             dedent(
                 """\
-                  Rule (expired): (id:my-id)
-                    Expression: defined pingd (id:my-id-expr)
+                  Rule (expired): (id: my-id)
+                    Expression: defined pingd (id: my-id-expr)
                 """
             ),
         )
@@ -443,8 +443,8 @@ class InEffect(RuleDtoToLinesMixin, TestCase):
             self.fixture_dto(CibRuleInEffectStatus.NOT_YET_IN_EFFECT),
             dedent(
                 """\
-                  Rule (not yet in effect): (id:my-id)
-                    Expression: defined pingd (id:my-id-expr)
+                  Rule (not yet in effect): (id: my-id)
+                    Expression: defined pingd (id: my-id-expr)
                 """
             ),
         )
@@ -563,16 +563,16 @@ class RuleDtoToLines(RuleDtoToLinesMixin, TestCase):
         )
         output = dedent(
             """\
-            Rule: boolean-op=or score=INFINITY (id:complex)
-              Rule: boolean-op=and score=0 (id:complex-rule-1)
-                Expression: (id:complex-rule-1-expr)
-                  Date Spec: hours=12-23 weekdays=1-5 (id:complex-rule-1-expr-datespec)
-                Expression: date in_range 2014-07-26 to duration (id:complex-rule-1-expr-1)
-                  Duration: months=1 (id:complex-rule-1-expr-1-durat)
-              Rule: boolean-op=and score=0 (id:complex-rule)
-                Expression: foo gt version 1.2 (id:complex-rule-expr-1)
-                Expression: #uname eq 'node3 4' (id:complex-rule-expr)
-                Expression: #uname eq nodeA (id:complex-rule-expr-2)
+            Rule: boolean-op=or score=INFINITY (id: complex)
+              Rule: boolean-op=and score=0 (id: complex-rule-1)
+                Expression: (id: complex-rule-1-expr)
+                  Date Spec: hours=12-23 weekdays=1-5 (id: complex-rule-1-expr-datespec)
+                Expression: date in_range 2014-07-26 to duration (id: complex-rule-1-expr-1)
+                  Duration: months=1 (id: complex-rule-1-expr-1-durat)
+              Rule: boolean-op=and score=0 (id: complex-rule)
+                Expression: foo gt version 1.2 (id: complex-rule-expr-1)
+                Expression: #uname eq 'node3 4' (id: complex-rule-expr)
+                Expression: #uname eq nodeA (id: complex-rule-expr-2)
             """
         )
         self.assert_lines(dto, output)

--- a/pcs_test/tier0/common/test_str_tools.py
+++ b/pcs_test/tier0/common/test_str_tools.py
@@ -241,6 +241,27 @@ class FormatNameValueList(TestCase):
         )
 
 
+class FormatNameValueIdList(TestCase):
+    def test_empty(self):
+        self.assertEqual([], tools.format_name_value_id_list([]))
+
+    def test_many(self):
+        self.assertEqual(
+            [
+                "name1=value1 (id: id1)",
+                '"name=2"="value 2" (id: id: 2)',
+                '"name 3"="value=3" (id: id 3)',
+            ],
+            tools.format_name_value_id_list(
+                [
+                    ("name1", "value1", "id1"),
+                    ("name=2", "value 2", "id: 2"),
+                    ("name 3", "value=3", "id 3"),
+                ]
+            ),
+        )
+
+
 class Quote(TestCase):
     def test_no_quote(self):
         self.assertEqual("string", tools.quote("string", " "))

--- a/pcs_test/tier1/cib_resource/test_bundle.py
+++ b/pcs_test/tier1/cib_resource/test_bundle.py
@@ -816,8 +816,7 @@ class BundleShow(TestCase, AssertPcsMixin):
                   Resource: A (class=ocf provider=pacemaker type=Dummy)
                     Operations:
                       monitor: A-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -879,8 +878,7 @@ class BundleShow(TestCase, AssertPcsMixin):
                   Resource: A (class=ocf provider=pacemaker type=Dummy)
                     Operations:
                       monitor: A-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )

--- a/pcs_test/tier1/constraint/test_config.py
+++ b/pcs_test/tier1/constraint/test_config.py
@@ -285,10 +285,10 @@ class ConstraintConfigText(TestCase):
               resource pattern 'R*' prefers node 'localhost' with score INFINITY (id: location-R-localhost-INFINITY)
               resource 'R6-clone' (id: loc_constr_with_not_expired_rule)
                 Rules:
-                  Rule: role=Unpromoted score=500 (id:loc_constr_with_not_expired_rule-rule)
-                    Expression: date gt 2000-01-01 (id:loc_constr_with_not_expired_rule-rule-expr)
-                  Rule: role=Promoted score-attribute=test-attr (id:loc_constr_with_not_expired_rule-rule-1)
-                    Expression: date gt 2010-12-31 (id:loc_constr_with_not_expired_rule-rule-1-expr)
+                  Rule: role=Unpromoted score=500 (id: loc_constr_with_not_expired_rule-rule)
+                    Expression: date gt 2000-01-01 (id: loc_constr_with_not_expired_rule-rule-expr)
+                  Rule: role=Promoted score-attribute=test-attr (id: loc_constr_with_not_expired_rule-rule-1)
+                    Expression: date gt 2010-12-31 (id: loc_constr_with_not_expired_rule-rule-1-expr)
             Colocation Constraints:
               Promoted resource 'G1-clone' with Stopped resource 'R6-clone' (id: colocation-G1-clone-R6-clone--100)
                 score=-100
@@ -345,14 +345,14 @@ class ConstraintConfigText(TestCase):
               resource pattern 'R*' prefers node 'localhost' with score INFINITY (id: location-R-localhost-INFINITY)
               resource 'B2' (id: loc_constr_with_expired_rule)
                 Rules:
-                  Rule (expired): score=500 (id:loc_constr_with_expired_rule-rule)
-                    Expression: date lt 2000-01-01 (id:loc_constr_with_expired_rule-rule-expr)
+                  Rule (expired): score=500 (id: loc_constr_with_expired_rule-rule)
+                    Expression: date lt 2000-01-01 (id: loc_constr_with_expired_rule-rule-expr)
               resource 'R6-clone' (id: loc_constr_with_not_expired_rule)
                 Rules:
-                  Rule: role=Unpromoted score=500 (id:loc_constr_with_not_expired_rule-rule)
-                    Expression: date gt 2000-01-01 (id:loc_constr_with_not_expired_rule-rule-expr)
-                  Rule: role=Promoted score-attribute=test-attr (id:loc_constr_with_not_expired_rule-rule-1)
-                    Expression: date gt 2010-12-31 (id:loc_constr_with_not_expired_rule-rule-1-expr)
+                  Rule: role=Unpromoted score=500 (id: loc_constr_with_not_expired_rule-rule)
+                    Expression: date gt 2000-01-01 (id: loc_constr_with_not_expired_rule-rule-expr)
+                  Rule: role=Promoted score-attribute=test-attr (id: loc_constr_with_not_expired_rule-rule-1)
+                    Expression: date gt 2010-12-31 (id: loc_constr_with_not_expired_rule-rule-1-expr)
             Colocation Constraints:
               Promoted resource 'G1-clone' with Stopped resource 'R6-clone' (id: colocation-G1-clone-R6-clone--100)
                 score=-100

--- a/pcs_test/tier1/legacy/test_alert.py
+++ b/pcs_test/tier1/legacy/test_alert.py
@@ -29,13 +29,7 @@ class PcsAlertTest(unittest.TestCase, AssertPcsMixin):
 
 class CreateAlertTest(PcsAlertTest):
     def test_create_multiple_without_id(self):
-        self.assert_pcs_success(
-            "alert config".split(),
-            """\
-Alerts:
- No alerts defined
-""",
-        )
+        self.assert_pcs_success("alert config".split(), "")
 
         self.assert_pcs_success("alert create path=test".split())
         self.assert_pcs_success("alert create path=test".split())
@@ -51,13 +45,7 @@ Alerts:
         )
 
     def test_create_multiple_with_id(self):
-        self.assert_pcs_success(
-            "alert config".split(),
-            """\
-Alerts:
- No alerts defined
-""",
-        )
+        self.assert_pcs_success("alert config".split(), "")
         self.assert_pcs_success("alert create id=alert1 path=test".split())
         self.assert_pcs_success(
             "alert create id=alert2 description=desc path=test".split()
@@ -118,13 +106,7 @@ Alerts:
 
 class UpdateAlertTest(PcsAlertTest):
     def test_update_everything(self):
-        self.assert_pcs_success(
-            "alert config".split(),
-            """\
-Alerts:
- No alerts defined
-""",
-        )
+        self.assert_pcs_success("alert config".split(), "")
         self.assert_pcs_success(
             (
                 "alert create id=alert1 description=desc path=test "
@@ -185,15 +167,7 @@ class DeleteRemoveAlertTest(PcsAlertTest):
         )
 
     def _test_one(self):
-        self.assert_pcs_success(
-            "alert config".split(),
-            outdent(
-                """\
-                Alerts:
-                 No alerts defined
-                """
-            ),
-        )
+        self.assert_pcs_success("alert config".split(), "")
 
         self.assert_pcs_success("alert create path=test id=alert1".split())
         self.assert_pcs_success(
@@ -206,26 +180,10 @@ class DeleteRemoveAlertTest(PcsAlertTest):
             ),
         )
         self.assert_pcs_success(["alert", self.command, "alert1"])
-        self.assert_pcs_success(
-            "alert config".split(),
-            outdent(
-                """\
-                Alerts:
-                 No alerts defined
-                """
-            ),
-        )
+        self.assert_pcs_success("alert config".split(), "")
 
     def _test_multiple(self):
-        self.assert_pcs_success(
-            "alert config".split(),
-            outdent(
-                """\
-                Alerts:
-                 No alerts defined
-                """
-            ),
-        )
+        self.assert_pcs_success("alert config".split(), "")
 
         self.assert_pcs_success("alert create path=test id=alert1".split())
         self.assert_pcs_success("alert create path=test id=alert2".split())

--- a/pcs_test/tier1/legacy/test_constraints.py
+++ b/pcs_test/tier1/legacy/test_constraints.py
@@ -182,22 +182,22 @@ class ConstraintTest(unittest.TestCase, AssertPcsMixin):
                 Location Constraints:
                   resource 'D1' (id: location-D1)
                     Rules:
-                      Rule: score=222 (id:location-D1-rule)
-                        Expression: #uname eq c00n03 (id:location-D1-rule-expr)
+                      Rule: score=222 (id: location-D1-rule)
+                        Expression: #uname eq c00n03 (id: location-D1-rule-expr)
                   resource 'D2' (id: location-D2)
                     Rules:
-                      Rule: score=-INFINITY (id:location-D2-rule)
-                        Expression: #uname eq c00n04 (id:location-D2-rule-expr)
+                      Rule: score=-INFINITY (id: location-D2-rule)
+                        Expression: #uname eq c00n04 (id: location-D2-rule-expr)
                   resource 'D3' (id: location-D3)
                     Rules:
-                      Rule: boolean-op=or score=-INFINITY (id:location-D3-rule)
-                        Expression: not_defined pingd (id:location-D3-rule-expr)
-                        Expression: pingd lte 0 (id:location-D3-rule-expr-1)
+                      Rule: boolean-op=or score=-INFINITY (id: location-D3-rule)
+                        Expression: not_defined pingd (id: location-D3-rule-expr)
+                        Expression: pingd lte 0 (id: location-D3-rule-expr-1)
                   resource 'D3' (id: location-D3-1)
                     Rules:
-                      Rule: boolean-op=and score=-INFINITY (id:location-D3-1-rule)
-                        Expression: not_defined pingd (id:location-D3-1-rule-expr)
-                        Expression: pingd lte 0 (id:location-D3-1-rule-expr-1)
+                      Rule: boolean-op=and score=-INFINITY (id: location-D3-1-rule)
+                        Expression: not_defined pingd (id: location-D3-1-rule-expr)
+                        Expression: pingd lte 0 (id: location-D3-1-rule-expr-1)
                 """
             ),
         )
@@ -222,9 +222,9 @@ class ConstraintTest(unittest.TestCase, AssertPcsMixin):
                 Location Constraints:
                   resource 'D1' (id: location-D1)
                     Rules:
-                      Rule: boolean-op=or score=INFINITY (id:location-D1-rule)
-                        Expression: not_defined pingd (id:location-D1-rule-expr)
-                        Expression: pingd lte 0 (id:location-D1-rule-expr-1)
+                      Rule: boolean-op=or score=INFINITY (id: location-D1-rule)
+                        Expression: not_defined pingd (id: location-D1-rule-expr)
+                        Expression: pingd lte 0 (id: location-D1-rule-expr-1)
                 """
             ),
         )
@@ -1275,14 +1275,14 @@ class ConstraintTest(unittest.TestCase, AssertPcsMixin):
                   resource 'crd' (id: location-crd)
                     resource-discovery=exclusive
                     Rules:
-                      Rule: boolean-op=and score=-INFINITY (id:location-crd-rule)
-                        Expression: opsrole ne controller0 (id:location-crd-rule-expr)
-                        Expression: opsrole ne controller1 (id:location-crd-rule-expr-1)
+                      Rule: boolean-op=and score=-INFINITY (id: location-crd-rule)
+                        Expression: opsrole ne controller0 (id: location-crd-rule-expr)
+                        Expression: opsrole ne controller1 (id: location-crd-rule-expr-1)
                   resource 'crd1' (id: location-crd1)
                     resource-discovery=exclusive
                     Rules:
-                      Rule: score=-INFINITY (id:location-crd1-rule)
-                        Expression: opsrole2 ne controller2 (id:location-crd1-rule-expr)
+                      Rule: score=-INFINITY (id: location-crd1-rule)
+                        Expression: opsrole2 ne controller2 (id: location-crd1-rule-expr)
                 """
             ),
         )
@@ -1843,17 +1843,17 @@ Error: invalid option 'foo', allowed options are: 'id', 'kind', 'symmetrical'
                 Location Constraints:
                   resource 'D1' (id: location-D1-rh7-1-INFINITY)
                     Rules:
-                      Rule: score=INFINITY (id:location-D1-rh7-1-INFINITY-rule)
-                        Expression: #uname eq rh7-1 (id:location-D1-rh7-1-INFINITY-rule-expr)
-                      Rule: score=INFINITY (id:location-D1-rh7-1-INFINITY-rule-1)
-                        Expression: #uname eq rh7-1 (id:location-D1-rh7-1-INFINITY-rule-1-expr)
-                      Rule: score=INFINITY (id:location-D1-rh7-1-INFINITY-rule-2)
-                        Expression: #uname eq rh7-1 (id:location-D1-rh7-1-INFINITY-rule-2-expr)
+                      Rule: score=INFINITY (id: location-D1-rh7-1-INFINITY-rule)
+                        Expression: #uname eq rh7-1 (id: location-D1-rh7-1-INFINITY-rule-expr)
+                      Rule: score=INFINITY (id: location-D1-rh7-1-INFINITY-rule-1)
+                        Expression: #uname eq rh7-1 (id: location-D1-rh7-1-INFINITY-rule-1-expr)
+                      Rule: score=INFINITY (id: location-D1-rh7-1-INFINITY-rule-2)
+                        Expression: #uname eq rh7-1 (id: location-D1-rh7-1-INFINITY-rule-2-expr)
                   resource 'D2' (id: location-D2-rh7-2-INFINITY)
                     Rules:
-                      Rule: score=INFINITY (id:location-D2-rh7-2-INFINITY-rule)
-                        Expression: (id:location-D2-rh7-2-INFINITY-rule-expr)
-                          Date Spec: hours=9-16 weekdays=1-5 (id:location-D2-rh7-2-INFINITY-rule-expr-datespec)
+                      Rule: score=INFINITY (id: location-D2-rh7-2-INFINITY-rule)
+                        Expression: (id: location-D2-rh7-2-INFINITY-rule-expr)
+                          Date Spec: hours=9-16 weekdays=1-5 (id: location-D2-rh7-2-INFINITY-rule-expr-datespec)
                 """
             ),
         )
@@ -1885,13 +1885,13 @@ Error: invalid option 'foo', allowed options are: 'id', 'kind', 'symmetrical'
                 Location Constraints:
                   resource 'D1' (id: location-D1-rh7-1-INFINITY)
                     Rules:
-                      Rule: score=INFINITY (id:location-D1-rh7-1-INFINITY-rule)
-                        Expression: #uname eq rh7-1 (id:location-D1-rh7-1-INFINITY-rule-expr)
+                      Rule: score=INFINITY (id: location-D1-rh7-1-INFINITY-rule)
+                        Expression: #uname eq rh7-1 (id: location-D1-rh7-1-INFINITY-rule-expr)
                   resource 'D2' (id: location-D2-rh7-2-INFINITY)
                     Rules:
-                      Rule: score=INFINITY (id:location-D2-rh7-2-INFINITY-rule)
-                        Expression: (id:location-D2-rh7-2-INFINITY-rule-expr)
-                          Date Spec: hours=9-16 weekdays=1-5 (id:location-D2-rh7-2-INFINITY-rule-expr-datespec)
+                      Rule: score=INFINITY (id: location-D2-rh7-2-INFINITY-rule)
+                        Expression: (id: location-D2-rh7-2-INFINITY-rule-expr)
+                          Date Spec: hours=9-16 weekdays=1-5 (id: location-D2-rh7-2-INFINITY-rule-expr-datespec)
                 """
             ),
         )
@@ -1913,9 +1913,9 @@ Error: invalid option 'foo', allowed options are: 'id', 'kind', 'symmetrical'
                 Location Constraints:
                   resource 'D2' (id: location-D2-rh7-2-INFINITY)
                     Rules:
-                      Rule: score=INFINITY (id:location-D2-rh7-2-INFINITY-rule)
-                        Expression: (id:location-D2-rh7-2-INFINITY-rule-expr)
-                          Date Spec: hours=9-16 weekdays=1-5 (id:location-D2-rh7-2-INFINITY-rule-expr-datespec)
+                      Rule: score=INFINITY (id: location-D2-rh7-2-INFINITY-rule)
+                        Expression: (id: location-D2-rh7-2-INFINITY-rule-expr)
+                          Date Spec: hours=9-16 weekdays=1-5 (id: location-D2-rh7-2-INFINITY-rule-expr-datespec)
                 """
             ),
         )
@@ -1985,8 +1985,8 @@ Error: invalid option 'foo', allowed options are: 'id', 'kind', 'symmetrical'
                 Location Constraints:
                   resource 'stateful0' (id: location-stateful0)
                     Rules:
-                      Rule: role={const.PCMK_ROLE_PROMOTED_PRIMARY} score=INFINITY (id:location-stateful0-rule)
-                        Expression: #uname eq rh7-1 (id:location-stateful0-rule-expr)
+                      Rule: role={const.PCMK_ROLE_PROMOTED_PRIMARY} score=INFINITY (id: location-stateful0-rule)
+                        Expression: #uname eq rh7-1 (id: location-stateful0-rule-expr)
                 """
             ),
         )
@@ -2266,8 +2266,8 @@ Error: invalid option 'foo', allowed options are: 'id', 'kind', 'symmetrical'
                   resource 'stateful1' prefers node 'rh7-1' with score INFINITY (id: location-stateful1-rh7-1-INFINITY)
                   resource 'statefulG' (id: location-statefulG)
                     Rules:
-                      Rule: score=INFINITY (id:location-statefulG-rule)
-                        Expression: #uname eq rh7-1 (id:location-statefulG-rule-expr)
+                      Rule: score=INFINITY (id: location-statefulG-rule)
+                        Expression: #uname eq rh7-1 (id: location-statefulG-rule-expr)
                 Colocation Constraints:
                   resource 'stateful1' with resource 'dummy1' (id: colocation-stateful1-dummy1-INFINITY)
                     score=INFINITY
@@ -2526,8 +2526,8 @@ Error: invalid option 'foo', allowed options are: 'id', 'kind', 'symmetrical'
                   resource 'dummy' prefers node 'rh7-1' with score INFINITY (id: location-dummy-rh7-1-INFINITY)
                   resource 'dummyG' (id: location-dummyG)
                     Rules:
-                      Rule: score=INFINITY (id:location-dummyG-rule)
-                        Expression: #uname eq rh7-1 (id:location-dummyG-rule-expr)
+                      Rule: score=INFINITY (id: location-dummyG-rule)
+                        Expression: #uname eq rh7-1 (id: location-dummyG-rule-expr)
                 Colocation Constraints:
                   resource 'dummy' with resource 'dummy1' (id: colocation-dummy-dummy1-INFINITY)
                     score=INFINITY
@@ -3609,26 +3609,26 @@ Error: duplicate constraint already exists, use --force to override
                 Location Constraints:
                   resource 'D1' (id: location-D1)
                     Rules:
-                      Rule: score=INFINITY (id:location-D1-rule)
-                        Expression: #uname eq node1 (id:location-D1-rule-expr)
+                      Rule: score=INFINITY (id: location-D1-rule)
+                        Expression: #uname eq node1 (id: location-D1-rule-expr)
                   resource 'D1' (id: location-D1-1)
                     Rules:
-                      Rule: score=INFINITY (id:location-D1-1-rule)
-                        Expression: #uname eq node1 (id:location-D1-1-rule-expr)
+                      Rule: score=INFINITY (id: location-D1-1-rule)
+                        Expression: #uname eq node1 (id: location-D1-1-rule-expr)
                   resource 'D2' (id: location-D2)
                     Rules:
-                      Rule: score=INFINITY (id:location-D2-rule)
-                        Expression: #uname eq node1 (id:location-D2-rule-expr)
+                      Rule: score=INFINITY (id: location-D2-rule)
+                        Expression: #uname eq node1 (id: location-D2-rule-expr)
                   resource 'D2' (id: location-D2-1)
                     Rules:
-                      Rule: boolean-op=or score=INFINITY (id:location-D2-1-rule)
-                        Expression: #uname eq node1 (id:location-D2-1-rule-expr)
-                        Expression: #uname eq node2 (id:location-D2-1-rule-expr-1)
+                      Rule: boolean-op=or score=INFINITY (id: location-D2-1-rule)
+                        Expression: #uname eq node1 (id: location-D2-1-rule-expr)
+                        Expression: #uname eq node2 (id: location-D2-1-rule-expr-1)
                   resource 'D2' (id: location-D2-2)
                     Rules:
-                      Rule: boolean-op=or score=INFINITY (id:location-D2-2-rule)
-                        Expression: #uname eq node2 (id:location-D2-2-rule-expr)
-                        Expression: #uname eq node1 (id:location-D2-2-rule-expr-1)
+                      Rule: boolean-op=or score=INFINITY (id: location-D2-2-rule)
+                        Expression: #uname eq node2 (id: location-D2-2-rule-expr)
+                        Expression: #uname eq node1 (id: location-D2-2-rule-expr-1)
                 """
             ),
         )
@@ -3832,12 +3832,12 @@ Error: duplicate constraint already exists, use --force to override
                 Location Constraints:
                   resource 'D1' (id: id9)
                     Rules:
-                      Rule: score=INFINITY (id:id9-rule)
-                        Expression: defined pingd (id:id9-rule-expr)
+                      Rule: score=INFINITY (id: id9-rule)
+                        Expression: defined pingd (id: id9-rule-expr)
                   resource 'D2' (id: id10)
                     Rules:
-                      Rule: score=100 (id:rule1)
-                        Expression: defined pingd (id:rule1-expr)
+                      Rule: score=100 (id: rule1)
+                        Expression: defined pingd (id: rule1-expr)
                 Colocation Constraints:
                   resource 'D1' with resource 'D2' (id: id1)
                     score=INFINITY
@@ -4373,8 +4373,8 @@ class LocationShowWithPattern(ConstraintBaseTest):
                     resource-discovery=never
                   resource pattern 'R_[0-9]+' (id: location-R_0-9)
                     Rules:
-                      Rule: score=20 (id:location-R_0-9-rule)
-                        Expression: defined pingd (id:location-R_0-9-rule-expr)
+                      Rule: score=20 (id: location-R_0-9-rule)
+                        Expression: defined pingd (id: location-R_0-9-rule-expr)
                 """
             ),
         )
@@ -5146,8 +5146,8 @@ class ExpiredConstraints(ConstraintBaseTest):
                 Location Constraints:
                   resource 'dummy' (id: location-dummy)
                     Rules:
-                      Rule: score=INFINITY (id:test-rule)
-                        Expression: date gt 2019-01-01 (id:test-rule-expr)
+                      Rule: score=INFINITY (id: test-rule)
+                        Expression: date gt 2019-01-01 (id: test-rule-expr)
                 """
             ),
         )
@@ -5188,8 +5188,8 @@ class ExpiredConstraints(ConstraintBaseTest):
                 Location Constraints:
                   resource 'dummy' (id: location-dummy)
                     Rules:
-                      Rule: score=INFINITY (id:test-rule)
-                        Expression: date gt 2019-01-01 (id:test-rule-expr)
+                      Rule: score=INFINITY (id: test-rule)
+                        Expression: date gt 2019-01-01 (id: test-rule-expr)
                 """
             ),
         )
@@ -5271,8 +5271,8 @@ class ExpiredConstraints(ConstraintBaseTest):
                 Location Constraints:
                   resource 'dummy' (id: location-dummy)
                     Rules:
-                      Rule (expired): score=INFINITY (id:test-rule)
-                        Expression: date lt 2019-01-01 (id:test-rule-expr)
+                      Rule (expired): score=INFINITY (id: test-rule)
+                        Expression: date lt 2019-01-01 (id: test-rule-expr)
                 """
             ),
         )
@@ -5324,9 +5324,9 @@ class ExpiredConstraints(ConstraintBaseTest):
                 Location Constraints:
                   resource 'dummy' (id: location-dummy)
                     Rules:
-                      Rule: boolean-op=or score=INFINITY (id:test-rule)
-                        Expression: date eq 2019-01-01 (id:test-rule-expr)
-                        Expression: date eq 2019-03-01 (id:test-rule-expr-1)
+                      Rule: boolean-op=or score=INFINITY (id: test-rule)
+                        Expression: date eq 2019-01-01 (id: test-rule-expr)
+                        Expression: date eq 2019-03-01 (id: test-rule-expr-1)
                 """
             ),
         )
@@ -5368,9 +5368,9 @@ class ExpiredConstraints(ConstraintBaseTest):
                 Location Constraints:
                   resource 'dummy' (id: location-dummy)
                     Rules:
-                      Rule: boolean-op=or score=INFINITY (id:test-rule)
-                        Expression: date eq 2019-01-01 (id:test-rule-expr)
-                        Expression: date eq 2019-03-01 (id:test-rule-expr-1)
+                      Rule: boolean-op=or score=INFINITY (id: test-rule)
+                        Expression: date eq 2019-01-01 (id: test-rule-expr)
+                        Expression: date eq 2019-03-01 (id: test-rule-expr-1)
                 """
             ),
         )
@@ -5429,8 +5429,8 @@ class ExpiredConstraints(ConstraintBaseTest):
                 Location Constraints:
                   resource 'dummy' (id: location-dummy)
                     Rules:
-                      Rule (not yet in effect): score=INFINITY (id:test-rule)
-                        Expression: date gt {self._tomorrow} (id:test-rule-expr)
+                      Rule (not yet in effect): score=INFINITY (id: test-rule)
+                        Expression: date gt {self._tomorrow} (id: test-rule-expr)
                 """
             ),
         )
@@ -5467,8 +5467,8 @@ class ExpiredConstraints(ConstraintBaseTest):
                 Location Constraints:
                   resource 'dummy' (id: location-dummy)
                     Rules:
-                      Rule (not yet in effect): score=INFINITY (id:test-rule)
-                        Expression: date gt {self._tomorrow} (id:test-rule-expr)
+                      Rule (not yet in effect): score=INFINITY (id: test-rule)
+                        Expression: date gt {self._tomorrow} (id: test-rule-expr)
                 """
             ),
         )

--- a/pcs_test/tier1/legacy/test_resource.py
+++ b/pcs_test/tier1/legacy/test_resource.py
@@ -83,15 +83,11 @@ class ResourceDescribe(TestCase, AssertPcsMixin):
 {0}
             Default operations:
               start:
-                interval=0s
-                timeout=10s
+                interval=0s timeout=10s
               stop:
-                interval=0s
-                timeout=10s
+                interval=0s timeout=10s
               monitor:
-                interval=10s
-                start-delay=0s
-                timeout=10s
+                interval=10s start-delay=0s timeout=10s
             """.format(
                 advanced_params if advanced else ""
             )
@@ -596,8 +592,7 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: dummy0 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: dummy0-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 """
             ),
         )
@@ -756,12 +751,9 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: OPTest (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: OPTest-monitor-interval-30s
-                      interval=30s
-                      OCF_CHECK_LEVEL=1
+                      interval=30s OCF_CHECK_LEVEL=1
                     monitor: OPTest-monitor-interval-25s
-                      interval=25s
-                      enabled=0
-                      OCF_CHECK_LEVEL=1
+                      interval=25s enabled=0 OCF_CHECK_LEVEL=1
                 """
             ),
         )
@@ -797,17 +789,13 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: OPTest2 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: OPTest2-monitor-interval-30s
-                      interval=30s
-                      OCF_CHECK_LEVEL=1
+                      interval=30s OCF_CHECK_LEVEL=1
                     monitor: OPTest2-monitor-interval-25s
-                      interval=25s
-                      OCF_CHECK_LEVEL=2
+                      interval=25s OCF_CHECK_LEVEL=2
                     start: OPTest2-start-interval-0s
-                      interval=0s
-                      timeout=30s
+                      interval=0s timeout=30s
                     monitor: OPTest2-monitor-interval-60s
-                      interval=60s
-                      timeout=1800s
+                      interval=60s timeout=1800s
                 """
             ),
         )
@@ -823,8 +811,7 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: OPTest3 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: OPTest3-monitor-interval-60s
-                      interval=60s
-                      OCF_CHECK_LEVEL=1
+                      interval=60s OCF_CHECK_LEVEL=1
                 """
             ),
         )
@@ -844,8 +831,7 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: OPTest4 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: OPTest4-monitor-interval-60s
-                      interval=60s
-                      OCF_CHECK_LEVEL=1
+                      interval=60s OCF_CHECK_LEVEL=1
                 """
             ),
         )
@@ -865,8 +851,7 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: OPTest5 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: OPTest5-monitor-interval-60s
-                      interval=60s
-                      OCF_CHECK_LEVEL=1
+                      interval=60s OCF_CHECK_LEVEL=1
                 """
             ),
         )
@@ -886,11 +871,9 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: OPTest6 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: OPTest6-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                     monitor: OPTest6-monitor-interval-30s
-                      interval=30s
-                      OCF_CHECK_LEVEL=1
+                      interval=30s OCF_CHECK_LEVEL=1
                 """
             ),
         )
@@ -922,11 +905,9 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: OPTest7 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: OPTest7-monitor-interval-60s
-                      interval=60s
-                      OCF_CHECK_LEVEL=1
+                      interval=60s OCF_CHECK_LEVEL=1
                     monitor: OPTest7-monitor-interval-61s
-                      interval=61s
-                      OCF_CHECK_LEVEL=1
+                      interval=61s OCF_CHECK_LEVEL=1
                 """
             ),
         )
@@ -966,13 +947,11 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: OCFTest1 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: OCFTest1-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                     monitor: OCFTest1-monitor-interval-31s
                       interval=31s
                     monitor: OCFTest1-monitor-interval-30s
-                      interval=30s
-                      OCF_CHECK_LEVEL=15
+                      interval=30s OCF_CHECK_LEVEL=15
                 """
             ),
         )
@@ -988,13 +967,11 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: OCFTest1 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: OCFTest1-monitor-interval-61s
-                      interval=61s
-                      OCF_CHECK_LEVEL=5
+                      interval=61s OCF_CHECK_LEVEL=5
                     monitor: OCFTest1-monitor-interval-31s
                       interval=31s
                     monitor: OCFTest1-monitor-interval-30s
-                      interval=30s
-                      OCF_CHECK_LEVEL=15
+                      interval=30s OCF_CHECK_LEVEL=15
                 """
             ),
         )
@@ -1010,13 +987,11 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: OCFTest1 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: OCFTest1-monitor-interval-60s
-                      interval=60s
-                      OCF_CHECK_LEVEL=4
+                      interval=60s OCF_CHECK_LEVEL=4
                     monitor: OCFTest1-monitor-interval-31s
                       interval=31s
                     monitor: OCFTest1-monitor-interval-30s
-                      interval=30s
-                      OCF_CHECK_LEVEL=15
+                      interval=30s OCF_CHECK_LEVEL=15
                 """
             ),
         )
@@ -1032,13 +1007,11 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: OCFTest1 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: OCFTest1-monitor-interval-35s
-                      interval=35s
-                      OCF_CHECK_LEVEL=4
+                      interval=35s OCF_CHECK_LEVEL=4
                     monitor: OCFTest1-monitor-interval-31s
                       interval=31s
                     monitor: OCFTest1-monitor-interval-30s
-                      interval=30s
-                      OCF_CHECK_LEVEL=15
+                      interval=30s OCF_CHECK_LEVEL=15
                 """
             ),
         )
@@ -1078,16 +1051,11 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: state (class=ocf provider=pacemaker type=Stateful)
                   Operations:
                     monitor: state-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
-                      role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                      interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                     monitor: state-monitor-interval-11
-                      interval=11
-                      timeout=20s
-                      role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                      interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                     monitor: state-monitor-interval-15
-                      interval=15
-                      role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                      interval=15 role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                 """
             ),
         )
@@ -1214,11 +1182,9 @@ class Resource(TestCase, AssertPcsMixin):
                     ip=192.168.0.99
                   Operations:
                     stop: ClusterIP-stop-interval-0s
-                      interval=0s
-                      timeout=34s
+                      interval=0s timeout=34s
                     start: ClusterIP-start-interval-0s
-                      interval=0s
-                      timeout=33s
+                      interval=0s timeout=33s
                 """
             ),
         )
@@ -1291,8 +1257,7 @@ class Resource(TestCase, AssertPcsMixin):
                 monitor: ClusterIP-monitor-interval-33s
                   interval=33s
                 start: ClusterIP-start-interval-30s
-                  interval=30s
-                  timeout=180s
+                  interval=30s timeout=180s
             """
         )
         self.assert_pcs_success(
@@ -1366,8 +1331,7 @@ class Resource(TestCase, AssertPcsMixin):
                     monitor: abcd
                       interval=60s
                     start: ClusterIP-start-interval-30s
-                      interval=30s
-                      timeout=180s
+                      interval=30s timeout=180s
                 """
             ),
         )
@@ -1385,24 +1349,19 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: A (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     migrate_from: A-migrate_from-interval-0s
-                      interval=0s
-                      timeout=20s
+                      interval=0s timeout=20s
                     migrate_to: A-migrate_to-interval-0s
-                      interval=0s
-                      timeout=20s
+                      interval=0s timeout=20s
                     monitor: A-monitor-interval-10
                       interval=10
                     monitor: A-monitor-interval-20
                       interval=20
                     reload: A-reload-interval-0s
-                      interval=0s
-                      timeout=20s
+                      interval=0s timeout=20s
                     start: A-start-interval-0s
-                      interval=0s
-                      timeout=20s
+                      interval=0s timeout=20s
                     stop: A-stop-interval-0s
-                      interval=0s
-                      timeout=20s
+                      interval=0s timeout=20s
                 """
             ),
         )
@@ -1426,24 +1385,19 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: A (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     migrate_from: A-migrate_from-interval-0s
-                      interval=0s
-                      timeout=20s
+                      interval=0s timeout=20s
                     migrate_to: A-migrate_to-interval-0s
-                      interval=0s
-                      timeout=20s
+                      interval=0s timeout=20s
                     monitor: A-monitor-interval-11
                       interval=11
                     monitor: A-monitor-interval-20
                       interval=20
                     reload: A-reload-interval-0s
-                      interval=0s
-                      timeout=20s
+                      interval=0s timeout=20s
                     start: A-start-interval-0s
-                      interval=0s
-                      timeout=20s
+                      interval=0s timeout=20s
                     stop: A-stop-interval-0s
-                      interval=0s
-                      timeout=20s
+                      interval=0s timeout=20s
                 """
             ),
         )
@@ -1506,8 +1460,7 @@ class Resource(TestCase, AssertPcsMixin):
                     monitor: B-monitor-interval-30
                       interval=30
                     start: B-start-interval-0
-                      interval=0
-                      timeout=10
+                      interval=0 timeout=10
                 """
             ),
         )
@@ -1525,8 +1478,7 @@ class Resource(TestCase, AssertPcsMixin):
                     monitor: B-monitor-interval-30
                       interval=30
                     start: B-start-interval-0
-                      interval=0
-                      timeout=20
+                      interval=0 timeout=20
                 """
             ),
         )
@@ -1544,8 +1496,7 @@ class Resource(TestCase, AssertPcsMixin):
                     monitor: B-monitor-interval-33
                       interval=33
                     start: B-start-interval-0
-                      interval=0
-                      timeout=20
+                      interval=0 timeout=20
                 """
             ),
         )
@@ -1563,11 +1514,9 @@ class Resource(TestCase, AssertPcsMixin):
                     monitor: B-monitor-interval-33
                       interval=33
                     start: B-start-interval-0
-                      interval=0
-                      timeout=20
+                      interval=0 timeout=20
                     monitor: B-monitor-interval-100
-                      interval=100
-                      role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                      interval=100 role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                 """
             ),
         )
@@ -1585,11 +1534,9 @@ class Resource(TestCase, AssertPcsMixin):
                     monitor: B-monitor-interval-33
                       interval=33
                     start: B-start-interval-0
-                      interval=0
-                      timeout=22
+                      interval=0 timeout=22
                     monitor: B-monitor-interval-100
-                      interval=100
-                      role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                      interval=100 role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                 """
             ),
         )
@@ -1712,28 +1659,23 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: A1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: A1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                   Resource: A2 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: A2-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                   Resource: A3 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: A3-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                   Resource: A4 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: A4-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                   Resource: A5 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: A5-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -1952,8 +1894,7 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -2196,13 +2137,11 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: D0 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: D0-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: D1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -2242,13 +2181,11 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: dummy1 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: dummy2 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -2262,13 +2199,11 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: dummy1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: dummy1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                   Resource: dummy2 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: dummy2-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -2284,13 +2219,11 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: dummy1 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: dummy2 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -2304,13 +2237,11 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: dummy1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: dummy1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                   Resource: dummy2 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: dummy2-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -2326,13 +2257,11 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: dummy1 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: dummy2 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -2345,15 +2274,13 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: dummy1 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: dummy1-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Clone: gr-clone
                   Group: gr
                     Resource: dummy2 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -2366,13 +2293,11 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: dummy1 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: dummy1-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Resource: dummy2 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: dummy2-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 """
             ),
         )
@@ -2420,26 +2345,18 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: dummy1 (class=ocf provider=pacemaker type=Stateful)
                     Operations:
                       monitor: dummy1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
-                        role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                        interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                       monitor: dummy1-monitor-interval-11
-                        interval=11
-                        timeout=20s
-                        role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                        interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 Clone: dummy2-master
                   Meta Attributes:
                     promotable=true
                   Resource: dummy2 (class=ocf provider=pacemaker type=Stateful)
                     Operations:
                       monitor: dummy2-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
-                        role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                        interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                       monitor: dummy2-monitor-interval-11
-                        interval=11
-                        timeout=20s
-                        role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                        interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 """
             ),
         )
@@ -2452,24 +2369,16 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: dummy2 (class=ocf provider=pacemaker type=Stateful)
                   Operations:
                     monitor: dummy2-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
-                      role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                      interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                     monitor: dummy2-monitor-interval-11
-                      interval=11
-                      timeout=20s
-                      role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                      interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 Group: gr
                   Resource: dummy1 (class=ocf provider=pacemaker type=Stateful)
                     Operations:
                       monitor: dummy1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
-                        role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                        interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                       monitor: dummy1-monitor-interval-11
-                        interval=11
-                        timeout=20s
-                        role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                        interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 """
             ),
         )
@@ -2491,23 +2400,15 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: dummy1 (class=ocf provider=pacemaker type=Stateful)
                       Operations:
                         monitor: dummy1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
-                          role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                          interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                         monitor: dummy1-monitor-interval-11
-                          interval=11
-                          timeout=20s
-                          role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                          interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                     Resource: dummy2 (class=ocf provider=pacemaker type=Stateful)
                       Operations:
                         monitor: dummy2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
-                          role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                          interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                         monitor: dummy2-monitor-interval-11
-                          interval=11
-                          timeout=20s
-                          role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                          interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 """
             ),
         )
@@ -2521,23 +2422,15 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: dummy1 (class=ocf provider=pacemaker type=Stateful)
                     Operations:
                       monitor: dummy1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
-                        role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                        interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                       monitor: dummy1-monitor-interval-11
-                        interval=11
-                        timeout=20s
-                        role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                        interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                   Resource: dummy2 (class=ocf provider=pacemaker type=Stateful)
                     Operations:
                       monitor: dummy2-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
-                        role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                        interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                       monitor: dummy2-monitor-interval-11
-                        interval=11
-                        timeout=20s
-                        role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                        interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 """
             ),
         )
@@ -2558,23 +2451,15 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: dummy1 (class=ocf provider=pacemaker type=Stateful)
                       Operations:
                         monitor: dummy1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
-                          role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                          interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                         monitor: dummy1-monitor-interval-11
-                          interval=11
-                          timeout=20s
-                          role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                          interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                     Resource: dummy2 (class=ocf provider=pacemaker type=Stateful)
                       Operations:
                         monitor: dummy2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
-                          role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                          interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                         monitor: dummy2-monitor-interval-11
-                          interval=11
-                          timeout=20s
-                          role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                          interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 """
             ),
         )
@@ -2588,23 +2473,15 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: dummy1 (class=ocf provider=pacemaker type=Stateful)
                     Operations:
                       monitor: dummy1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
-                        role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                        interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                       monitor: dummy1-monitor-interval-11
-                        interval=11
-                        timeout=20s
-                        role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                        interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                   Resource: dummy2 (class=ocf provider=pacemaker type=Stateful)
                     Operations:
                       monitor: dummy2-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
-                        role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                        interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                       monitor: dummy2-monitor-interval-11
-                        interval=11
-                        timeout=20s
-                        role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                        interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 """
             ),
         )
@@ -2622,13 +2499,9 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: dummy2 (class=ocf provider=pacemaker type=Stateful)
                   Operations:
                     monitor: dummy2-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
-                      role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                      interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                     monitor: dummy2-monitor-interval-11
-                      interval=11
-                      timeout=20s
-                      role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                      interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 Clone: gr-master
                   Meta Attributes:
                     promotable=true
@@ -2636,13 +2509,9 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: dummy1 (class=ocf provider=pacemaker type=Stateful)
                       Operations:
                         monitor: dummy1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
-                          role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                          interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                         monitor: dummy1-monitor-interval-11
-                          interval=11
-                          timeout=20s
-                          role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                          interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 """
             ),
         )
@@ -2655,23 +2524,15 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: dummy2 (class=ocf provider=pacemaker type=Stateful)
                   Operations:
                     monitor: dummy2-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
-                      role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                      interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                     monitor: dummy2-monitor-interval-11
-                      interval=11
-                      timeout=20s
-                      role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                      interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 Resource: dummy1 (class=ocf provider=pacemaker type=Stateful)
                   Operations:
                     monitor: dummy1-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
-                      role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                      interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                     monitor: dummy1-monitor-interval-11
-                      interval=11
-                      timeout=20s
-                      role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                      interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 """
             ),
         )
@@ -2693,23 +2554,15 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: dummy1 (class=ocf provider=pacemaker type=Stateful)
                       Operations:
                         monitor: dummy1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
-                          role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                          interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                         monitor: dummy1-monitor-interval-11
-                          interval=11
-                          timeout=20s
-                          role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                          interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                     Resource: dummy2 (class=ocf provider=pacemaker type=Stateful)
                       Operations:
                         monitor: dummy2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
-                          role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                          interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                         monitor: dummy2-monitor-interval-11
-                          interval=11
-                          timeout=20s
-                          role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                          interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 """
             ),
         )
@@ -2723,13 +2576,9 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: dummy2 (class=ocf provider=pacemaker type=Stateful)
                   Operations:
                     monitor: dummy2-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
-                      role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                      interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                     monitor: dummy2-monitor-interval-11
-                      interval=11
-                      timeout=20s
-                      role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                      interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 Clone: gr-master
                   Meta Attributes:
                     promotable=true
@@ -2737,13 +2586,9 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: dummy1 (class=ocf provider=pacemaker type=Stateful)
                       Operations:
                         monitor: dummy1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
-                          role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                          interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                         monitor: dummy1-monitor-interval-11
-                          interval=11
-                          timeout=20s
-                          role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                          interval=11 timeout=20s role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                 """
             ),
         )
@@ -2765,14 +2610,12 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: D0-clone
                   Resource: D0 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D0-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -2786,14 +2629,12 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: D0 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D0-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: D1-clone
                   Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -2815,16 +2656,14 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: D0-clone
                   Meta Attributes: D0-clone-meta_attributes
                     promotable=true
                   Resource: D0 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D0-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -2840,16 +2679,14 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: D0 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D0-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: D1-clone
                   Meta Attributes: D1-clone-meta_attributes
                     promotable=true
                   Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -2897,32 +2734,28 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: D0 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D0-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: D3-clone
                   Meta Attributes: D3-clone-meta_attributes
                     promotable=true
                   Resource: D3 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D3-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: D1-master-custom
                   Meta Attributes:
                     promotable=true
                   Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: D2-master
                   Meta Attributes:
                     promotable=true
                   Resource: D2 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D2-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -2949,29 +2782,25 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: D0 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: D0-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Resource: D2 (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: D2-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Clone: D3-clone
                   Meta Attributes: D3-clone-meta_attributes
                     promotable=true
                   Resource: D3 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D3-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: D1-master-custom
                   Meta Attributes:
                     promotable=true
                   Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -3000,8 +2829,7 @@ class Resource(TestCase, AssertPcsMixin):
                     foo=bar
                   Operations:
                     monitor: D2-monitor-interval-15
-                      interval=15
-                      timeout=15
+                      interval=15 timeout=15
                 """
             ),
         )
@@ -3030,8 +2858,7 @@ class Resource(TestCase, AssertPcsMixin):
                     foo=bar
                   Operations:
                     monitor: D2-monitor-interval-15
-                      interval=15
-                      timeout=15
+                      interval=15 timeout=15
                 """
             ),
         )
@@ -3088,8 +2915,7 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: D1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -3121,8 +2947,7 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: D1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -3241,14 +3066,12 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: dummy-clone (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: dummy-clone-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Clone: dummy-clone-1
                   Resource: dummy (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: dummy-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -3267,14 +3090,12 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: dummy-clone (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: dummy-clone-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Clone: dummy-clone-1
                   Resource: dummy (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: dummy-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -3294,16 +3115,14 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: dummy-clone (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: dummy-clone-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Clone: dummy-clone-1
                   Meta Attributes: dummy-clone-1-meta_attributes
                     promotable=true
                   Resource: dummy (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: dummy-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -3322,16 +3141,14 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: dummy-clone (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: dummy-clone-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Clone: dummy-clone-1
                   Meta Attributes: dummy-clone-1-meta_attributes
                     promotable=true
                   Resource: dummy (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: dummy-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -3348,8 +3165,7 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -3365,8 +3181,7 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -3383,8 +3198,7 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -3400,8 +3214,7 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: D1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -3430,13 +3243,11 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: A (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: A-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Resource: B (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: B-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 """
             ),
         )
@@ -3524,8 +3335,7 @@ class Resource(TestCase, AssertPcsMixin):
                   Resource: A (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       monitor: A-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 """
             ),
         )
@@ -3547,13 +3357,11 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: D1 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: D1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: D2 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: D2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -3604,13 +3412,11 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: B (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: B-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Resource: C (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: C-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 """
             ),
         )
@@ -3635,13 +3441,11 @@ class Resource(TestCase, AssertPcsMixin):
                     monitor: B-monitor-interval-30s
                       interval=30s
                     monitor: B-monitor-interval-31s
-                      interval=31s
-                      role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                      interval=31s role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                 Resource: C (class=ocf provider=heartbeat type=Dummy)
                   Operations:
                     monitor: C-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 """
             ),
         )
@@ -3737,28 +3541,24 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: myip (class=ocf provider=heartbeat type=IPaddr2)
                   Operations:
                     monitor: myip-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Resource: myip2 (class=ocf provider=heartbeat type=IPaddr2)
                   Attributes: myip2-instance_attributes
                     ip=3.3.3.3
                   Operations:
                     monitor: myip2-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Resource: myfs (class=ocf provider=heartbeat type=Filesystem)
                   Operations:
                     monitor: myfs-monitor-interval-20s
-                      interval=20s
-                      timeout=40s
+                      interval=20s timeout=40s
                 Resource: myfs2 (class=ocf provider=heartbeat type=Filesystem)
                   Attributes: myfs2-instance_attributes
                     device=x
                     directory=y
                   Operations:
                     monitor: myfs2-monitor-interval-20s
-                      interval=20s
-                      timeout=40s
+                      interval=20s timeout=40s
                 Resource: myfs3 (class=ocf provider=heartbeat type=Filesystem)
                   Attributes: myfs3-instance_attributes
                     device=x
@@ -3766,8 +3566,7 @@ class Resource(TestCase, AssertPcsMixin):
                     fstype=z
                   Operations:
                     monitor: myfs3-monitor-interval-20s
-                      interval=20s
-                      timeout=40s
+                      interval=20s timeout=40s
                 """
             ),
         )
@@ -3792,18 +3591,15 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: dummy1 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: dummy2 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: dummy3 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy3-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -3861,18 +3657,15 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: dummy1 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: dummy2 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: dummy3 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy3-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -3918,18 +3711,15 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: dummy1 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: dummy2 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: dummy3 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy3-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -3992,18 +3782,15 @@ class Resource(TestCase, AssertPcsMixin):
                     Resource: dummy1 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: dummy2 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: dummy3 (class=ocf provider=heartbeat type=Dummy)
                       Operations:
                         monitor: dummy3-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -4051,37 +3838,31 @@ class Resource(TestCase, AssertPcsMixin):
             Resource: D1 (class=ocf provider=pacemaker type=Dummy)
               Operations:
                 monitor: D1-monitor-interval-10s
-                  interval=10s
-                  timeout=20s
+                  interval=10s timeout=20s
             Group: GR
               Resource: DG1 (class=ocf provider=pacemaker type=Dummy)
                 Operations:
                   monitor: DG1-monitor-interval-10s
-                    interval=10s
-                    timeout=20s
+                    interval=10s timeout=20s
               Resource: DG2 (class=ocf provider=pacemaker type=Dummy)
                 Operations:
                   monitor: DG2-monitor-interval-10s
-                    interval=10s
-                    timeout=20s
+                    interval=10s timeout=20s
             Clone: DC-clone
               Resource: DC (class=ocf provider=pacemaker type=Dummy)
                 Operations:
                   monitor: DC-monitor-interval-10s
-                    interval=10s
-                    timeout=20s
+                    interval=10s timeout=20s
             Clone: GRC-clone
               Group: GRC
                 Resource: DGC1 (class=ocf provider=pacemaker type=Dummy)
                   Operations:
                     monitor: DGC1-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Resource: DGC2 (class=ocf provider=pacemaker type=Dummy)
                   Operations:
                     monitor: DGC2-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
             """
         )
 
@@ -4124,8 +3905,7 @@ class Resource(TestCase, AssertPcsMixin):
                     resource-stickiness=0
                   Operations:
                     monitor: D1-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Group: GR
                   Meta Attributes: GR-meta_attributes
                     resource-stickiness=0
@@ -4134,15 +3914,13 @@ class Resource(TestCase, AssertPcsMixin):
                       resource-stickiness=0
                     Operations:
                       monitor: DG1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                   Resource: DG2 (class=ocf provider=pacemaker type=Dummy)
                     Meta Attributes: DG2-meta_attributes
                       resource-stickiness=0
                     Operations:
                       monitor: DG2-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: DC-clone
                   Meta Attributes: DC-clone-meta_attributes
                     resource-stickiness=0
@@ -4151,8 +3929,7 @@ class Resource(TestCase, AssertPcsMixin):
                       resource-stickiness=0
                     Operations:
                       monitor: DC-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: GRC-clone
                   Meta Attributes: GRC-clone-meta_attributes
                     resource-stickiness=0
@@ -4164,15 +3941,13 @@ class Resource(TestCase, AssertPcsMixin):
                         resource-stickiness=0
                       Operations:
                         monitor: DGC1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: DGC2 (class=ocf provider=pacemaker type=Dummy)
                       Meta Attributes: DGC2-meta_attributes
                         resource-stickiness=0
                       Operations:
                         monitor: DGC2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -4197,29 +3972,25 @@ class Resource(TestCase, AssertPcsMixin):
                     resource-stickiness=0
                   Operations:
                     monitor: D1-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Group: GR
                   Resource: DG1 (class=ocf provider=pacemaker type=Dummy)
                     Meta Attributes: DG1-meta_attributes
                       resource-stickiness=0
                     Operations:
                       monitor: DG1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                   Resource: DG2 (class=ocf provider=pacemaker type=Dummy)
                     Operations:
                       monitor: DG2-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: DC-clone
                   Resource: DC (class=ocf provider=pacemaker type=Dummy)
                     Meta Attributes: DC-meta_attributes
                       resource-stickiness=0
                     Operations:
                       monitor: DC-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: GRC-clone
                   Group: GRC
                     Resource: DGC1 (class=ocf provider=pacemaker type=Dummy)
@@ -4227,13 +3998,11 @@ class Resource(TestCase, AssertPcsMixin):
                         resource-stickiness=0
                       Operations:
                         monitor: DGC1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: DGC2 (class=ocf provider=pacemaker type=Dummy)
                       Operations:
                         monitor: DGC2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -4256,25 +4025,21 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: D1 (class=ocf provider=pacemaker type=Dummy)
                   Operations:
                     monitor: D1-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Group: GR
                   Resource: DG1 (class=ocf provider=pacemaker type=Dummy)
                     Operations:
                       monitor: DG1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                   Resource: DG2 (class=ocf provider=pacemaker type=Dummy)
                     Operations:
                       monitor: DG2-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: DC-clone
                   Resource: DC (class=ocf provider=pacemaker type=Dummy)
                     Operations:
                       monitor: DC-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: GRC-clone
                   Meta Attributes: GRC-clone-meta_attributes
                     resource-stickiness=0
@@ -4286,15 +4051,13 @@ class Resource(TestCase, AssertPcsMixin):
                         resource-stickiness=0
                       Operations:
                         monitor: DGC1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: DGC2 (class=ocf provider=pacemaker type=Dummy)
                       Meta Attributes: DGC2-meta_attributes
                         resource-stickiness=0
                       Operations:
                         monitor: DGC2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -4317,8 +4080,7 @@ class Resource(TestCase, AssertPcsMixin):
                 Resource: D1 (class=ocf provider=pacemaker type=Dummy)
                   Operations:
                     monitor: D1-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Group: GR
                   Meta Attributes: GR-meta_attributes
                     resource-stickiness=0
@@ -4327,15 +4089,13 @@ class Resource(TestCase, AssertPcsMixin):
                       resource-stickiness=0
                     Operations:
                       monitor: DG1-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                   Resource: DG2 (class=ocf provider=pacemaker type=Dummy)
                     Meta Attributes: DG2-meta_attributes
                       resource-stickiness=0
                     Operations:
                       monitor: DG2-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: DC-clone
                   Meta Attributes: DC-clone-meta_attributes
                     resource-stickiness=0
@@ -4344,20 +4104,17 @@ class Resource(TestCase, AssertPcsMixin):
                       resource-stickiness=0
                     Operations:
                       monitor: DC-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                 Clone: GRC-clone
                   Group: GRC
                     Resource: DGC1 (class=ocf provider=pacemaker type=Dummy)
                       Operations:
                         monitor: DGC1-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                     Resource: DGC2 (class=ocf provider=pacemaker type=Dummy)
                       Operations:
                         monitor: DGC2-monitor-interval-10s
-                          interval=10s
-                          timeout=20s
+                          interval=10s timeout=20s
                 """
             ),
         )
@@ -5341,23 +5098,17 @@ class CloneMasterUpdate(TestCase, AssertPcsMixin):
                   Resource: dummy (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       migrate_from: dummy-migrate_from-interval-0s
-                        interval=0s
-                        timeout=20s
+                        interval=0s timeout=20s
                       migrate_to: dummy-migrate_to-interval-0s
-                        interval=0s
-                        timeout=20s
+                        interval=0s timeout=20s
                       monitor: dummy-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                       reload: dummy-reload-interval-0s
-                        interval=0s
-                        timeout=20s
+                        interval=0s timeout=20s
                       start: dummy-start-interval-0s
-                        interval=0s
-                        timeout=20s
+                        interval=0s timeout=20s
                       stop: dummy-stop-interval-0s
-                        interval=0s
-                        timeout=20s
+                        interval=0s timeout=20s
                 """
             ),
         )
@@ -5377,23 +5128,17 @@ class CloneMasterUpdate(TestCase, AssertPcsMixin):
                   Resource: dummy (class=ocf provider=heartbeat type=Dummy)
                     Operations:
                       migrate_from: dummy-migrate_from-interval-0s
-                        interval=0s
-                        timeout=20s
+                        interval=0s timeout=20s
                       migrate_to: dummy-migrate_to-interval-0s
-                        interval=0s
-                        timeout=20s
+                        interval=0s timeout=20s
                       monitor: dummy-monitor-interval-10s
-                        interval=10s
-                        timeout=20s
+                        interval=10s timeout=20s
                       reload: dummy-reload-interval-0s
-                        interval=0s
-                        timeout=20s
+                        interval=0s timeout=20s
                       start: dummy-start-interval-0s
-                        interval=0s
-                        timeout=20s
+                        interval=0s timeout=20s
                       stop: dummy-stop-interval-0s
-                        interval=0s
-                        timeout=20s
+                        interval=0s timeout=20s
                 """
             ),
         )
@@ -5410,22 +5155,15 @@ class CloneMasterUpdate(TestCase, AssertPcsMixin):
               Resource: dummy (class=ocf provider=pacemaker type=Stateful)
                 Operations:
                   monitor: dummy-monitor-interval-10
-                    interval=10
-                    timeout=20
-                    role={const.PCMK_ROLE_PROMOTED_PRIMARY}
+                    interval=10 timeout=20 role={const.PCMK_ROLE_PROMOTED_PRIMARY}
                   monitor: dummy-monitor-interval-11
-                    interval=11
-                    timeout=20
-                    role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
+                    interval=11 timeout=20 role={const.PCMK_ROLE_UNPROMOTED_PRIMARY}
                   notify: dummy-notify-interval-0s
-                    interval=0s
-                    timeout=5
+                    interval=0s timeout=5
                   start: dummy-start-interval-0s
-                    interval=0s
-                    timeout=20
+                    interval=0s timeout=20
                   stop: dummy-stop-interval-0s
-                    interval=0s
-                    timeout=20
+                    interval=0s timeout=20
             """
         )
         self.assert_pcs_success("resource config dummy-master".split(), show)
@@ -6162,15 +5900,13 @@ class ResourceUpdateUniqueAttrChecks(TestCase, AssertPcsMixin):
                 state=1
               Operations:
                 monitor: R1-monitor-interval-10s
-                  interval=10s
-                  timeout=20s
+                  interval=10s timeout=20s
             Resource: R2 (class=ocf provider=pacemaker type=Dummy)
               Attributes: R2-instance_attributes
                 state=1
               Operations:
                 monitor: R2-monitor-interval-10s
-                  interval=10s
-                  timeout=20s
+                  interval=10s timeout=20s
             """
         )
         self.assert_pcs_success("resource config".split(), res_config)
@@ -6191,15 +5927,13 @@ class ResourceUpdateUniqueAttrChecks(TestCase, AssertPcsMixin):
                 state=1
               Operations:
                 monitor: R1-monitor-interval-10s
-                  interval=10s
-                  timeout=20s
+                  interval=10s timeout=20s
             Resource: R2 (class=ocf provider=pacemaker type=Dummy)
               Attributes: R2-instance_attributes
                 state=2
               Operations:
                 monitor: R2-monitor-interval-10s
-                  interval=10s
-                  timeout=20s
+                  interval=10s timeout=20s
             """
         )
         self.assert_pcs_success("resource update R2 state=2".split())
@@ -6234,20 +5968,17 @@ class ResourceUpdateUniqueAttrChecks(TestCase, AssertPcsMixin):
                     state=1
                   Operations:
                     monitor: R1-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Resource: R2 (class=ocf provider=pacemaker type=Dummy)
                   Attributes: R2-instance_attributes
                     state=1
                   Operations:
                     monitor: R2-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Resource: R3 (class=ocf provider=pacemaker type=Dummy)
                   Operations:
                     monitor: R3-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 """
             ),
         )
@@ -6269,22 +6000,19 @@ class ResourceUpdateUniqueAttrChecks(TestCase, AssertPcsMixin):
                     state=1
                   Operations:
                     monitor: R1-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Resource: R2 (class=ocf provider=pacemaker type=Dummy)
                   Attributes: R2-instance_attributes
                     state=1
                   Operations:
                     monitor: R2-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 Resource: R3 (class=ocf provider=pacemaker type=Dummy)
                   Attributes: R3-instance_attributes
                     state=1
                   Operations:
                     monitor: R3-monitor-interval-10s
-                      interval=10s
-                      timeout=20s
+                      interval=10s timeout=20s
                 """
             ),
         )

--- a/pcs_test/tier1/legacy/test_resource.py
+++ b/pcs_test/tier1/legacy/test_resource.py
@@ -1925,25 +1925,6 @@ class Resource(TestCase, AssertPcsMixin):
                       Operations:
                         monitor: ClusterIP5-monitor-interval-30s
                           interval=30s
-
-                Stonith Devices:
-                Fencing Levels:
-
-                Alerts:
-                 No alerts defined
-
-                Resources Defaults:
-                  No defaults set
-                Operations Defaults:
-                  No defaults set
-
-                Cluster Properties:
-
-                Tags:
-                 No tags defined
-
-                Quorum:
-                  Options:
                 """
             ),
         )
@@ -2151,28 +2132,9 @@ class Resource(TestCase, AssertPcsMixin):
                         monitor: ClusterIP4-monitor-interval-30s
                           interval=30s
 
-                Stonith Devices:
-                Fencing Levels:
-
                 Location Constraints:
                   resource 'ClusterIP5' prefers node 'rh7-1' with score INFINITY (id: location-ClusterIP5-rh7-1-INFINITY)
                   resource 'ClusterIP5' prefers node 'rh7-2' with score INFINITY (id: location-ClusterIP5-rh7-2-INFINITY)
-
-                Alerts:
-                 No alerts defined
-
-                Resources Defaults:
-                  No defaults set
-                Operations Defaults:
-                  No defaults set
-
-                Cluster Properties:
-
-                Tags:
-                 No tags defined
-
-                Quorum:
-                  Options:
             """
             ),
         )

--- a/pcs_test/tier1/legacy/test_rule.py
+++ b/pcs_test/tier1/legacy/test_rule.py
@@ -2214,31 +2214,31 @@ class DomRuleAddTest(TestCase, AssertPcsMixin):
                 Location Constraints:
                   resource 'dummy1' (id: location-dummy1)
                     Rules:
-                      Rule: score=INFINITY (id:location-dummy1-rule)
-                        Expression: #uname eq node1 (id:location-dummy1-rule-expr)
+                      Rule: score=INFINITY (id: location-dummy1-rule)
+                        Expression: #uname eq node1 (id: location-dummy1-rule-expr)
                   resource 'dummy1' (id: location-dummy1-1)
                     Rules:
-                      Rule: role={const.PCMK_ROLE_PROMOTED_PRIMARY} score=100 (id:MyRule)
-                        Expression: #uname eq node2 (id:MyRule-expr)
+                      Rule: role={const.PCMK_ROLE_PROMOTED_PRIMARY} score=100 (id: MyRule)
+                        Expression: #uname eq node2 (id: MyRule-expr)
                   resource 'dummy1' (id: location-dummy1-2)
                     Rules:
-                      Rule: boolean-op=or score=INFINITY (id:complexRule)
-                        Rule: boolean-op=and score=0 (id:complexRule-rule)
-                          Expression: #uname eq node3 (id:complexRule-rule-expr)
-                          Expression: foo gt version 1.2 (id:complexRule-rule-expr-1)
-                        Rule: boolean-op=and score=0 (id:complexRule-rule-1)
-                          Expression: (id:complexRule-rule-1-expr)
-                            Date Spec: hours=12-23 weekdays=1-5 (id:complexRule-rule-1-expr-datespec)
-                          Expression: date in_range 2014-07-26 to duration (id:complexRule-rule-1-expr-1)
-                            Duration: months=1 (id:complexRule-rule-1-expr-1-duration)
+                      Rule: boolean-op=or score=INFINITY (id: complexRule)
+                        Rule: boolean-op=and score=0 (id: complexRule-rule)
+                          Expression: #uname eq node3 (id: complexRule-rule-expr)
+                          Expression: foo gt version 1.2 (id: complexRule-rule-expr-1)
+                        Rule: boolean-op=and score=0 (id: complexRule-rule-1)
+                          Expression: (id: complexRule-rule-1-expr)
+                            Date Spec: hours=12-23 weekdays=1-5 (id: complexRule-rule-1-expr-datespec)
+                          Expression: date in_range 2014-07-26 to duration (id: complexRule-rule-1-expr-1)
+                            Duration: months=1 (id: complexRule-rule-1-expr-1-duration)
                   resource 'dummy1' (id: location-dummy1-3)
                     Rules:
-                      Rule: boolean-op=and score=INFINITY (id:location-dummy1-3-rule)
-                        Expression: #uname eq node3 (id:location-dummy1-3-rule-expr)
-                        Rule: boolean-op=or score=0 (id:location-dummy1-3-rule-rule)
-                          Expression: date gt 2022-01-01 (id:location-dummy1-3-rule-rule-expr)
-                          Expression: date lt 2023-01-01 (id:location-dummy1-3-rule-rule-expr-1)
-                          Expression: date in_range 2023-02-01 to 2023-02-28 (id:location-dummy1-3-rule-rule-expr-2)
+                      Rule: boolean-op=and score=INFINITY (id: location-dummy1-3-rule)
+                        Expression: #uname eq node3 (id: location-dummy1-3-rule-expr)
+                        Rule: boolean-op=or score=0 (id: location-dummy1-3-rule-rule)
+                          Expression: date gt 2022-01-01 (id: location-dummy1-3-rule-rule-expr)
+                          Expression: date lt 2023-01-01 (id: location-dummy1-3-rule-rule-expr-1)
+                          Expression: date in_range 2023-02-01 to 2023-02-28 (id: location-dummy1-3-rule-rule-expr-2)
                 """,
             ),
         )
@@ -2292,8 +2292,8 @@ class DomRuleAddTest(TestCase, AssertPcsMixin):
                 Location Constraints:
                   resource 'dummy1' (id: location-dummy1)
                     Rules:
-                      Rule: score-attribute=pingd (id:location-dummy1-rule)
-                        Expression: defined pingd (id:location-dummy1-rule-expr)
+                      Rule: score-attribute=pingd (id: location-dummy1-rule)
+                        Expression: defined pingd (id: location-dummy1-rule-expr)
                 """,
             ),
         )
@@ -2355,8 +2355,8 @@ class DomRuleAddTest(TestCase, AssertPcsMixin):
                 Location Constraints:
                   resource 'dummy1' (id: location-dummy1)
                     Rules:
-                      Rule: score=INFINITY (id:MyRule)
-                        Expression: #uname eq node1 (id:MyRule-expr)
+                      Rule: score=INFINITY (id: MyRule)
+                        Expression: #uname eq node1 (id: MyRule-expr)
                 """,
             ),
         )

--- a/pcs_test/tier1/legacy/test_stonith.py
+++ b/pcs_test/tier1/legacy/test_stonith.py
@@ -1397,8 +1397,6 @@ class StonithTest(TestCase, AssertPcsMixin):
                  rh7-1 rh7-2
                 Pacemaker Nodes:
 
-                Resources:
-
                 Stonith Devices:
                   Resource: test1 (class=stonith type=fence_noexist)
                     Operations:
@@ -1421,23 +1419,6 @@ class StonithTest(TestCase, AssertPcsMixin):
                     Operations:
                       monitor: test-fencing-monitor-interval-61s
                         interval=61s
-                Fencing Levels:
-
-                Alerts:
-                 No alerts defined
-
-                Resources Defaults:
-                  No defaults set
-                Operations Defaults:
-                  No defaults set
-
-                Cluster Properties:
-
-                Tags:
-                 No tags defined
-
-                Quorum:
-                  Options:
                 """
             ),
         )
@@ -2579,26 +2560,9 @@ class LevelConfig(LevelTestsBase):
         Pacemaker Nodes:
          rh7-1 rh7-2
 
-        Resources:
-
         Stonith Devices:{devices}
+
         Fencing Levels:{levels}
-
-        Alerts:
-         No alerts defined
-
-        Resources Defaults:
-          No defaults set
-        Operations Defaults:
-          No defaults set
-
-        Cluster Properties:
-
-        Tags:
-         No tags defined
-
-        Quorum:
-          Options:
         """
     )
 
@@ -2610,7 +2574,16 @@ class LevelConfig(LevelTestsBase):
             "corosync.conf"
         )
         self.assert_pcs_success(
-            ["config"], self.full_config.format(devices="", levels="")
+            ["config"],
+            dedent(
+                """\
+                Cluster Name: test99
+                Corosync Nodes:
+                 rh7-1 rh7-2
+                Pacemaker Nodes:
+                 rh7-1 rh7-2
+                """
+            ),
         )
 
     def test_all_possibilities(self):
@@ -2647,32 +2620,38 @@ class LevelConfig(LevelTestsBase):
         self.assert_pcs_success(
             ["config"],
             self.full_config.format(
-                devices="""
-  Resource: F1 (class=stonith type=fence_apc)
-    Attributes: F1-instance_attributes
-      ip=i
-      pcmk_host_list="rh7-1 rh7-2"
-      username=u
-    Operations:
-      monitor: F1-monitor-interval-60s
-        interval=60s
-  Resource: F2 (class=stonith type=fence_apc)
-    Attributes: F2-instance_attributes
-      ip=i
-      pcmk_host_list="rh7-1 rh7-2"
-      username=u
-    Operations:
-      monitor: F2-monitor-interval-60s
-        interval=60s
-  Resource: F3 (class=stonith type=fence_apc)
-    Attributes: F3-instance_attributes
-      ip=i
-      pcmk_host_list="rh7-1 rh7-2"
-      username=u
-    Operations:
-      monitor: F3-monitor-interval-60s
-        interval=60s\
-""",
+                devices="\n".join(
+                    indent(
+                        dedent(
+                            """
+                            Resource: F1 (class=stonith type=fence_apc)
+                              Attributes: F1-instance_attributes
+                                ip=i
+                                pcmk_host_list="rh7-1 rh7-2"
+                                username=u
+                              Operations:
+                                monitor: F1-monitor-interval-60s
+                                  interval=60s
+                            Resource: F2 (class=stonith type=fence_apc)
+                              Attributes: F2-instance_attributes
+                                ip=i
+                                pcmk_host_list="rh7-1 rh7-2"
+                                username=u
+                              Operations:
+                                monitor: F2-monitor-interval-60s
+                                  interval=60s
+                            Resource: F3 (class=stonith type=fence_apc)
+                              Attributes: F3-instance_attributes
+                                ip=i
+                                pcmk_host_list="rh7-1 rh7-2"
+                                username=u
+                              Operations:
+                                monitor: F3-monitor-interval-60s
+                                  interval=60s
+                            """
+                        ).splitlines()
+                    )
+                ),
                 levels=("\n" + "\n".join(indent(self.config_lines, 2))),
             ),
         )

--- a/pcs_test/tier1/test_quorum.py
+++ b/pcs_test/tier1/test_quorum.py
@@ -41,7 +41,7 @@ class TestBase(TestCase, AssertPcsMixin):
 
 class QuorumConfigTest(TestBase):
     def test_no_device(self):
-        self.assert_pcs_success("quorum config".split(), "Options:\n")
+        self.assert_pcs_success("quorum config".split(), "")
 
     def test_with_device(self):
         self.fixture_conf_qdevice()
@@ -49,7 +49,6 @@ class QuorumConfigTest(TestBase):
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   Model: net
                     host: 127.0.0.1
@@ -89,14 +88,7 @@ class QuorumUpdateTest(TestBase):
         )
 
     def test_success(self):
-        self.assert_pcs_success(
-            "quorum config".split(),
-            dedent(
-                """\
-                Options:
-                """
-            ),
-        )
+        self.assert_pcs_success("quorum config".split(), "")
         self.assert_pcs_success("quorum update wait_for_all=1".split())
         self.assert_pcs_success(
             "quorum config".split(),
@@ -172,7 +164,6 @@ class DeviceAddTest(TestBase):
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   Model: net
                     algorithm: lms
@@ -192,7 +183,6 @@ class DeviceAddTest(TestBase):
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   timeout: 12345
                   votes: 1
@@ -222,7 +212,6 @@ class DeviceAddTest(TestBase):
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   votes: 1
                   Model: net
@@ -248,7 +237,6 @@ class DeviceAddTest(TestBase):
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   votes: 1
                   Model: net
@@ -280,7 +268,6 @@ class DeviceAddTest(TestBase):
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   timeout: 12345
                   votes: 1
@@ -338,7 +325,6 @@ Warning: 'bad' is not a valid mode value, use 'off', 'on', 'sync'
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   a: b
                   timeout: -1
@@ -369,7 +355,6 @@ Warning: 'bad' is not a valid mode value, use 'off', 'on', 'sync'
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   Model: invalid
                     x: y
@@ -390,7 +375,7 @@ class DeviceDeleteRemoveTest(TestBase):
     def _test_success(self):
         self.fixture_conf_qdevice()
         self.assert_pcs_success(["quorum", "device", self.command])
-        self.assert_pcs_success("quorum config".split(), "Options:\n")
+        self.assert_pcs_success("quorum config".split(), "")
 
     def _test_bad_options(self):
         self.assert_pcs_fail(
@@ -445,7 +430,6 @@ class DeviceHeuristicsDeleteRemove(TestBase):
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   Model: net
                     host: 127.0.0.1
@@ -480,7 +464,6 @@ class DeviceUpdateTest(TestBase):
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   timeout: 12345
                   Model: net
@@ -498,7 +481,6 @@ class DeviceUpdateTest(TestBase):
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   Model: net
                     host: 127.0.0.2
@@ -522,7 +504,6 @@ class DeviceUpdateTest(TestBase):
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   Model: net
                     host: 127.0.0.1
@@ -544,7 +525,6 @@ class DeviceUpdateTest(TestBase):
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   Model: net
                     host: 127.0.0.1
@@ -574,7 +554,6 @@ class DeviceUpdateTest(TestBase):
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   timeout: 12345
                   Model: net
@@ -664,7 +643,6 @@ Warning: '-1' is not a valid timeout value, use a positive integer
             "quorum config".split(),
             dedent(
                 """\
-                Options:
                 Device:
                   a: b
                   timeout: -1

--- a/pcs_test/tier1/test_tag.py
+++ b/pcs_test/tier1/test_tag.py
@@ -262,34 +262,14 @@ class PcsConfigTagsTest(TestTagMixin, TestCase):
         Cluster Name: test99
         Corosync Nodes:
          rh7-1 rh7-2
-        {pacemaker_nodes}
-        {resources}
-        {stonith_devices}{fencing_levels}{constraints}
-        Alerts:
-         No alerts defined
-
-        Resources Defaults:
-          No defaults set
-        Operations Defaults:
-          No defaults set
-
-        Cluster Properties:
-        {tags}
-        Quorum:
-          Options:
-        """
+        {pacemaker_nodes}{resources}{stonith_devices}{fencing_levels}{constraints}{tags}"""
     )
-    empty_pacemaker_nodes = "Pacemaker Nodes:"
-    empty_resources = "\nResources:\n"
-    empty_stonith_devices = "Stonith Devices:\n"
-    empty_fencing_levels = "Fencing Levels:\n"
+    empty_pacemaker_nodes = "Pacemaker Nodes:\n"
+    empty_resources = ""
+    empty_stonith_devices = ""
+    empty_fencing_levels = ""
     empty_constraints = ""
-    empty_tags = outdent(
-        """
-        Tags:
-         No tags defined
-        """
-    )
+    empty_tags = ""
     expected_pacemaker_nodes = outdent(
         """\
         Pacemaker Nodes:
@@ -297,8 +277,7 @@ class PcsConfigTagsTest(TestTagMixin, TestCase):
         """
     )
     expected_resources = outdent(
-        # pylint: disable=line-too-long
-        """\
+        """
         Resources:
           Resource: not-in-tags (class=ocf provider=pacemaker type=Dummy)
             Operations:
@@ -334,7 +313,7 @@ class PcsConfigTagsTest(TestTagMixin, TestCase):
         """
     )
     expected_stonith_devices = outdent(
-        """\
+        """
         Stonith Devices:
           Resource: fence-rh-1 (class=stonith type=fence_xvm)
             Operations:
@@ -353,7 +332,7 @@ class PcsConfigTagsTest(TestTagMixin, TestCase):
         """
     )
     expected_fencing_levels = outdent(
-        """\
+        """
         Fencing Levels:
           Target: rh-1
             Level 1 - fence-kdump

--- a/pcs_test/tier1/test_tag.py
+++ b/pcs_test/tier1/test_tag.py
@@ -282,34 +282,28 @@ class PcsConfigTagsTest(TestTagMixin, TestCase):
           Resource: not-in-tags (class=ocf provider=pacemaker type=Dummy)
             Operations:
               monitor: not-in-tags-monitor-interval-10s
-                interval=10s
-                timeout=20s
+                interval=10s timeout=20s
           Resource: x1 (class=ocf provider=pacemaker type=Dummy)
             Operations:
               monitor: x1-monitor-interval-10s
-                interval=10s
-                timeout=20s
+                interval=10s timeout=20s
           Resource: x2 (class=ocf provider=pacemaker type=Dummy)
             Operations:
               monitor: x2-monitor-interval-10s
-                interval=10s
-                timeout=20s
+                interval=10s timeout=20s
           Resource: x3 (class=ocf provider=pacemaker type=Dummy)
             Operations:
               monitor: x3-monitor-interval-10s
-                interval=10s
-                timeout=20s
+                interval=10s timeout=20s
           Resource: y1 (class=ocf provider=pacemaker type=Dummy)
             Operations:
               monitor: y1-monitor-interval-10s
-                interval=10s
-                timeout=20s
+                interval=10s timeout=20s
           Clone: y2-clone
             Resource: y2 (class=ocf provider=pacemaker type=Dummy)
               Operations:
                 monitor: y2-monitor-interval-10s
-                  interval=10s
-                  timeout=20s
+                  interval=10s timeout=20s
         """
     )
     expected_stonith_devices = outdent(


### PR DESCRIPTION
- fix formatting of rule ids in pcs config
- do not print headers of empty sections in pcs config
- make resource config output more dense
- print ids of nvpairs if printing ids is requested