### PR TITLE
fix upstream version parsing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -379,7 +379,7 @@ $(SPEC): $(SPEC).in .version config.status stamps/download_python_deps stamps/do
 		dirty="" && \
 		numcomm="0"; \
 	else \
-		gitver="`echo $$gvgver | sed 's/\(.*\)\./\1-/'`" && \
+		gitver="`echo $$gvgver | sed 's/\(.*\)+/\1-/'`" && \
 		rpmver=`echo $$gitver | sed 's/-.*//g'` && \
 		alphatag=`echo $$gvgver | sed 's/[^-]*-\([^-]*\).*/\1/'` && \
 		numcomm=`echo $$gitver | sed 's/[^-]*-\([^-]*\).*/\1/'` && \

--- a/rpm/pcs.spec.in
+++ b/rpm/pcs.spec.in
@@ -4,7 +4,7 @@
 
 Name: pcs
 Version: @version@
-Release: 1%{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}%{?dist}
+Release: 1%{?numcomm:+%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}%{?dist}
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/
 # https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing#Good_Licenses
 # GPL-2.0-only: pcs
@@ -53,7 +53,7 @@ Summary: Pacemaker/Corosync Configuration System
 #    /usr/bin/python will be removed or switched to Python 3 in the future.
 #global __python {__python3}
 
-Source0: %{name}-%{version}%{?numcomm:.%{numcomm}}%{?alphatag:-%{alphatag}}%{?dirty:-%{dirty}}.tar.gz
+Source0: %{name}-%{version}%{?numcomm:+%{numcomm}}%{?alphatag:-%{alphatag}}%{?dirty:-%{dirty}}.tar.gz
 
 Source41: pyagentx-%{pyagentx_version}.tar.gz
 @pysrc@
@@ -176,7 +176,7 @@ Provides: bundled(pyagentx) = %{pyagentx_version}
 SNMP agent that provides information about pacemaker cluster to the master agent (snmpd)
 
 %prep
-%autosetup -n %{name}-%{version}%{?numcomm:.%{numcomm}}%{?alphatag:-%{alphatag}}%{?dirty:-%{dirty}}
+%autosetup -n %{name}-%{version}%{?numcomm:+%{numcomm}}%{?alphatag:-%{alphatag}}%{?dirty:-%{dirty}}
 
 # prepare dirs/files necessary for building all bundles
 # -----------------------------------------------------
@@ -364,6 +364,6 @@ sed -i -e 's#^@#%#g' dynamic_files/pcs-snmp
 %license COPYING
 
 %changelog
-* @date@ Autotools generated version <nobody@nowhere.org> - @version@-1-@numcomm@.@alphatag@.@dirty@
+* @date@ Autotools generated version <nobody@nowhere.org> - @version@-1+@numcomm@.@alphatag@.@dirty@
 - Autotools generated version
 - These aren't the droids you're looking for.


### PR DESCRIPTION
related to: 0b6c1e7f6a8636126a8a7fcdef478ef396ceb68b

Update version parsing and rpm version building to support pcs versions containing + sign