### PR TITLE
Fix DatatransferObjectTest for Python 3.12

### DIFF
--- a/pcs_test/tier0/common/interface/test_dto.py
+++ b/pcs_test/tier0/common/interface/test_dto.py
@@ -22,13 +22,13 @@ from pcs.common.types import CorosyncNodeAddressType
 
 def _import_all(_path):
     # arbitrary prefix so it doesn't iteract with real import in real tests
-    for loader, module_name, is_pkg in pkgutil.walk_packages(
+    for module_finder, module_name, is_pkg in pkgutil.walk_packages(
         _path, prefix="_pcs."
     ):
         if module_name.startswith("_pcs.snmp."):
             continue
         del is_pkg
-        loader.find_module(module_name).load_module(module_name)
+        module_finder.find_spec(module_name).loader.load_module(module_name)
 
 
 def _all_subclasses(cls):


### PR DESCRIPTION
This fixes a test error when run with Python 3.12:
```
Traceback (most recent call last):
  File "pcs_test/tier0/common/interface/test_dto.py", line 41, in test_has_all_subclasses_are_dataclasses
    _import_all(pcs.__path__)
  File "pcs_test/tier0/common/interface/test_dto.py", line 31, in _import_all
    loader.find_module(module_name).load_module(module_name)
    ^^^^^^^^^^^^^^^^^^
AttributeError: 'FileFinder' object has no attribute 'find_module'
```
Instead, use the spec-based APIs introduced in 3.4:

https://docs.python.org/3.12/library/importlib.html#importlib.machinery.FileFinder
https://docs.python.org/3.12/library/importlib.html#importlib.machinery.ModuleSpec
