### PR TITLE
add support for OpenCloudOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -247,6 +247,15 @@ for i in $DISTRO $DISTROS; do
 			DISTROEXT=fedora
 			break
 		;;
+		opencloudos)
+			FOUND_DISTRO=1
+			CONFIGDIR="$sysconfdir/sysconfig"
+			PCSLIBDIR="$LIBDIR"
+			PCMKDAEMONDIR="$prefix/libexec/pacemaker"
+			COROSYNCLOGDIR="$localstatedir/log/cluster"
+			DISTROEXT=opencloudos
+			break
+		;;
 	esac
 done
 

--- a/pcsd/Makefile.am
+++ b/pcsd/Makefile.am
@@ -1,6 +1,7 @@
 EXTRA_DIST		= \
 			  pam/pcsd.debian \
 			  pam/pcsd.fedora \
+			  pam/pcsd.opencloudos \
 			  test/cib1.xml \
 			  test/corosync.conf \
 			  test/crm1.xml \

--- a/pcsd/pam/pcsd.opencloudos
+++ b/pcsd/pam/pcsd.opencloudos
@@ -1,0 +1,5 @@
+#%PAM-1.0
+auth       include      system-auth
+account    include      system-auth
+password   include      system-auth
+session    include      system-auth


### PR DESCRIPTION
This patch will help we to build pcs in OpenCloudOS

for more information about OpenCloudOS you can visit: https://www.opencloudos.org/