### PR TITLE
pcsd-ruby: do not use posix_spawn with childprocess library

### DIFF
--- a/pcsd/pcs.rb
+++ b/pcsd/pcs.rb
@@ -853,7 +853,6 @@ def run_cmd_options(auth_user, options, *args)
   read_stdout, write_stdout = IO.pipe
   read_stderr, write_stderr = IO.pipe
   begin
-    ChildProcess.posix_spawn = true
     cmd = ChildProcess.build(*args)
     cmd.io.stdout = write_stdout
     cmd.io.stderr = write_stderr

--- a/pcsd/remote.rb
+++ b/pcsd/remote.rb
@@ -329,7 +329,6 @@ def config_restore(params, request, auth_user)
     if params[:tarball] != nil and params[:tarball] != ""
       read_stderr, write_stderr = IO.pipe
       begin
-        ChildProcess.posix_spawn = true
         pcs_restore_config = ChildProcess.build(PCS, "config", "restore", "--local")
         pcs_restore_config.io.stderr = write_stderr
         pcs_restore_config.duplex = true


### PR DESCRIPTION
* combination of childprocess posix_spawn and OS.pipe causes exception BlockingIOError when running python scripts
* use fork+exec instead