### PR TITLE
Do not bundle platfrom specific ruby gems.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -129,6 +129,7 @@ if ENABLE_DOWNLOAD
 	echo 'BUNDLE_TIMEOUT: 30' >> .bundle/config
 	echo 'BUNDLE_RETRY: 30' >> .bundle/config
 	echo 'BUNDLE_JOBS: 1' >> .bundle/config
+	echo 'BUNDLE_FORCE_RUBY_PLATFORM: "true"' >> .bundle/config
 	$(BUNDLE)
 	cp -rp $(PCSD_BUNDLED_DIR_LOCAL)/* $(PCSD_BUNDLED_DIR_ROOT_LOCAL)/
 	rm -rf $$(realpath $(PCSD_BUNDLED_DIR_LOCAL)/../)


### PR DESCRIPTION
* BUNDLE_FORCE_RUBY_PLATFORM: Ignore the current machine's platform and install only ruby platform gems. As a result, gems with native extensions will be compiled from source.