### PR TITLE
Disable build isolation for dependencies [DO NOT MERGE - CI test]

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,7 +78,7 @@ endif
 
 stamps/download_python_deps: rpm/requirements.txt stamps/download_pyagentx dev_requirements.txt
 if ENABLE_DOWNLOAD
-	PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring $(PIP) download --disable-pip-version-check --no-deps $(pipopts) --dest rpm/ --no-binary :all: -r rpm/requirements.txt
+	PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring $(PIP) download --disable-pip-version-check --no-deps --no-build-isolation $(pipopts) --dest rpm/ --no-binary :all: -r rpm/requirements.txt
 endif
 	touch $@
 


### PR DESCRIPTION
This should help resolve mismatch in versions during CI runs. With build isolation, when dependencies are built a new venv is created for every dependency. This by itself is not a problem, the problem is that it also installs build requirements that are significantly newer than the rest of the system. This often creates errors because newer setuptools refuse to use their vendored dependencies and the system ones are preferred.