### PR TITLE
Allow rpmbuild in venv for CI [DO NOT MERGE]

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -431,6 +431,7 @@ $(SPEC): $(SPEC).in .version config.status stamps/download_python_deps stamps/do
 			-e "s#@dirty@#$$dirty#g" \
 			-e "s#@date@#$$date#g" \
 			-e "s#@pcs_bundled_dir@#${PCS_BUNDLED_DIR_LOCAL}#g" \
+			-e "s#@pyversion@#${PYVERSION}#g" \
 		$(abs_srcdir)/$@.in > $@-t; \
 	else \
 		sed \
@@ -440,6 +441,7 @@ $(SPEC): $(SPEC).in .version config.status stamps/download_python_deps stamps/do
 			-e "s#@dirty@#$$dirty#g" \
 			-e "s#@date@#$$date#g" \
 			-e "s#@pcs_bundled_dir@#${PCS_BUNDLED_DIR_LOCAL}#g" \
+			-e "s#@pyversion@#${PYVERSION}#g" \
 		$(abs_srcdir)/$@.in > $@-t; \
 	fi; \
 	if [ -z "$(CI_BRANCH)" ]; then \

--- a/configure.ac
+++ b/configure.ac
@@ -196,6 +196,13 @@ AC_ARG_WITH([pcsd-default-cipherlist],
 	[PCSD_DEFAULT_CIPHERLIST="DEFAULT:!RC4:!3DES:@STRENGTH"])
 AC_SUBST([PCSD_DEFAULT_CIPHERLIST])
 
+AC_ARG_WITH([python-version],
+	[AS_HELP_STRING([--with-python-version=X.Y], [Set an alternative Python interpreter version for generated rpm.])],
+	[PYVERSION="$withval"],
+	[PYVERSION=""])
+AC_SUBST([PYVERSION])
+
+
 if test "x$cache_only" != "xyes"; then
 	AC_CHECK_PROGS([WGET], [wget])
 	if test "x$WGET" = "x"; then

--- a/rpm/pcs.spec.in
+++ b/rpm/pcs.spec.in
@@ -41,6 +41,22 @@ License: GPL-2.0-only AND Apache-2.0 AND MIT AND BSD-2-Clause AND BSD-3-Clause A
 URL: https://github.com/ClusterLabs/pcs
 Summary: Pacemaker/Corosync Configuration System
 
+# Modification for running with alternative Python interpreter in CI
+# This defines macros that influence all other Python rpm macros
+# Borrowed from vapor spec file
+%if "@pyversion@" != ""
+# This always contains the major.minor version (with dots), default for
+# %%python3_version.
+%define __default_python3_version @pyversion@
+
+# Define the Python interpreter paths in the SRPM macros so that:
+# - they can be used in Build/Requires
+# - they can be used in non-Python packages where requiring pythonX-devel would
+#   be an overkill
+# use the underscored macros to redefine the behavior of %%python3_version etc.
+%define __python3 %{_bindir}/python@pyversion@
+%endif
+
 %global pcs_snmp_pkg_name  pcs-snmp
 %global pcs_standalone_webui_provider_pkg_name  pcs-standalone-webui-provider
 
@@ -59,7 +75,11 @@ Source41: pyagentx-%{pyagentx_version}.tar.gz
 @gemsrc@
 
 # python for pcs
-BuildRequires: python3-devel
+BuildRequires: python%{python3_version}-devel
+
+# Modification for running with alternative Python interpreter in CI
+# These dependencies are installed in a virtual environment and are not packaged
+%if "@pyversion@" == ""
 BuildRequires: python3-pip >= 23
 BuildRequires: python3-setuptools >= 66.1
 
@@ -76,12 +96,16 @@ BuildRequires: python3-pyparsing >= 3.0.0
 # required to pass ./configure
 BuildRequires: python3-wheel
 BuildRequires: python3-lxml
+%endif
+
 # pycurl is not distributed in rhel 10
 %if 0%{?rhel} >= 10
 BuildRequires: libcurl-devel
 BuildRequires: openssl-devel
 %else
+%if "@pyversion@" == ""
 BuildRequires: python3-pycurl
+%endif
 %endif
 
 # gcc for compiling custom rubygems
@@ -120,6 +144,7 @@ BuildRequires: mozilla-nss-tools
 BuildRequires: nss-tools
 %endif
 
+%if "@pyversion@" == ""
 Requires: python3-cryptography
 Requires: python3-lxml
 # pycurl is not distributed in rhel 10
@@ -128,6 +153,7 @@ Requires: python3-lxml
 Requires: python3-pycurl
 %endif
 Requires: python3-pyparsing >= 3.0.0
+%endif
 # ruby and gems for pcsd
 Requires: ruby >= 3.1
 Requires: rubygems
@@ -210,7 +236,8 @@ rubyver=`pkg-config --variable=ruby_version $rubymod`
 %build
 %define debug_package %{nil}
 ./autogen.sh
-%{configure} --enable-local-build --enable-use-local-cache-only --enable-individual-bundling --enable-webui
+%{configure} --enable-local-build --enable-use-local-cache-only \
+  --enable-individual-bundling --enable-webui --with-python-version=@pyversion@
 make all
 
 %install


### PR DESCRIPTION
This patch should allow upstream CI to run pcs-0.12 on RHEL 9 builders if configure is ran with `--with-python-version=3.12`.