### PR TITLE
Fix pcs installation on Debian-like distros

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -169,7 +169,7 @@ endif
 # files are moved manually. Some of the folders do not exist in DESTDIR or
 # prefix locations, so they need to be created first, otherwise mv fails
 install-exec-local: install_python_embedded_mods stamps/install_ruby_deps_local
-	if $$(python -c "import sys; exit(sys.base_prefix == sys.prefix)"); then \
+	if $$(${PYTHON} -c "import sys; exit(sys.base_prefix == sys.prefix)"); then \
 		echo "WARNING: Virtual environment is activated, shebangs in Python " \
 		"entry points will point to this virtual environment. Fix shebangs " \
 		"manually to use the system interpreter. Entry points in rpm will be " \

--- a/Makefile.am
+++ b/Makefile.am
@@ -182,12 +182,14 @@ install-exec-local: install_python_embedded_mods stamps/install_ruby_deps_local
 	${PIP} ${pipopts} install ${pipinstallopts} \
 		--root=$(or ${DESTDIR}, /) \
 		--prefix=${prefix} ${EXTRA_SETUP_OPTS} .
-	mv ${DESTDIR}/$(prefix)/bin/pcs_internal ${DESTDIR}/$(LIB_DIR)/pcs/
-	mv ${DESTDIR}/$(prefix)/bin/pcs_snmp_agent ${DESTDIR}/$(LIB_DIR)/pcs/
 	mv ${DESTDIR}/$(prefix)/bin/pcs ${DESTDIR}/$(SBINDIR)/ || \
 		mv ${DESTDIR}/$(prefix)/local/bin/pcs ${DESTDIR}/${prefix}/local/sbin/
 	mv ${DESTDIR}/$(prefix)/bin/pcsd ${DESTDIR}/$(SBINDIR)/ || \
 		mv ${DESTDIR}/$(prefix)/local/bin/pcsd ${DESTDIR}/${prefix}/local/sbin/
+	mv ${DESTDIR}/$(prefix)/bin/pcs_internal ${DESTDIR}/$(LIB_DIR)/pcs/ || \
+		mv ${DESTDIR}/$(prefix)/local/bin/pcs_internal ${DESTDIR}/${LIB_DIR}/pcs/
+	mv ${DESTDIR}/$(prefix)/bin/pcs_snmp_agent ${DESTDIR}/$(LIB_DIR)/pcs/ || \
+		mv ${DESTDIR}/$(prefix)/local/bin/pcs_snmp_agent ${DESTDIR}/${LIB_DIR}/pcs/
 
 # * Uses PEP627 RECORD file - CSV, first column is a path relative to dist-info,
 # the path differs on Debian-like distros because packages that use system
@@ -207,13 +209,13 @@ install-exec-local: install_python_embedded_mods stamps/install_ruby_deps_local
 # which are untouched by make install.
 uninstall-local:
 	rm -rf ${DESTDIR}/$(PCS_BUNDLED_DIR)
-	mv ${DESTDIR}/$(LIB_DIR)/pcs/pcs_internal ${DESTDIR}/$(prefix)/bin || :
-	mv ${DESTDIR}/$(LIB_DIR)/pcs/pcs_snmp_agent ${DESTDIR}/$(prefix)/bin || :
 	recordfile=$$(echo ${DESTDIR}/$(PYTHON_SITELIB)/pcs*.dist-info/RECORD); \
 	find ${DESTDIR}/$(prefix)/local/sbin -name pcs -type f -delete || \
 		rm -fv ${DESTDIR}/$(SBINDIR)/pcs
 	find ${DESTDIR}/$(prefix)/local/sbin -name pcsd -type f -delete || \
 		rm -fv ${DESTDIR}/$(SBINDIR)/pcsd
+	rm -fv ${DESTDIR}/$(LIB_DIR)/pcs/pcs_internal
+	rm -fv ${DESTDIR}/$(LIB_DIR)/pcs/pcs_snmp_agent
 	while read fname; do \
 	  rm -rf $$(echo "${DESTDIR}/$(PYTHON_SITELIB)/$$fname" | cut -d',' -f1); \
 	done < $$recordfile

--- a/Makefile.am
+++ b/Makefile.am
@@ -182,25 +182,38 @@ install-exec-local: install_python_embedded_mods stamps/install_ruby_deps_local
 	${PIP} ${pipopts} install ${pipinstallopts} \
 		--root=$(or ${DESTDIR}, /) \
 		--prefix=${prefix} ${EXTRA_SETUP_OPTS} .
-	mv ${DESTDIR}/$(prefix)/bin/pcs ${DESTDIR}/$(SBINDIR)/
-	mv ${DESTDIR}/$(prefix)/bin/pcsd ${DESTDIR}/$(SBINDIR)/
 	mv ${DESTDIR}/$(prefix)/bin/pcs_internal ${DESTDIR}/$(LIB_DIR)/pcs/
 	mv ${DESTDIR}/$(prefix)/bin/pcs_snmp_agent ${DESTDIR}/$(LIB_DIR)/pcs/
+	mv ${DESTDIR}/$(prefix)/bin/pcs ${DESTDIR}/$(SBINDIR)/ || \
+		mv ${DESTDIR}/$(prefix)/local/bin/pcs ${DESTDIR}/${prefix}/local/sbin/
+	mv ${DESTDIR}/$(prefix)/bin/pcsd ${DESTDIR}/$(SBINDIR)/ || \
+		mv ${DESTDIR}/$(prefix)/local/bin/pcsd ${DESTDIR}/${prefix}/local/sbin/
 
-# * Uses PEP627 RECORD file - CSV, first column is a path relative to dist-info
-# * Before uninstallation, the manually moved scripts need to go back where pip
-# installed them - that's what's written in the RECORD file
+# * Uses PEP627 RECORD file - CSV, first column is a path relative to dist-info,
+# the path differs on Debian-like distros because packages that use system
+# Python are placed in dist-packages
+# * Before uninstallation, the manually moved scripts are deleted and not moved
+# to the original paths in the RECORD file. This is done because pcs installs
+# into different directories under different distros and the original location
+# cannot be determined easily.
 # * RECORD file only contains files not directories - deleting empty directory
 # tree by find is needed afterwards
 # * dist-info folder needs to be deleted for the same reason, pip uses it to
 # detect installed packages and if it's empty, pip reports error on every run
+# * On Debian-like distros, pcs is installed into /usr/local and the
+# uninstall also needs to handle that case. First we try to uninstall the
+# ${prefix}/local and only if nothing is there, try to uninstall from the
+# system. This is to prevent messing up system installation in these ditros
+# which are untouched by make install.
 uninstall-local:
 	rm -rf ${DESTDIR}/$(PCS_BUNDLED_DIR)
-	mv ${DESTDIR}/$(SBINDIR)/pcs ${DESTDIR}/$(prefix)/bin || :
-	mv ${DESTDIR}/$(SBINDIR)/pcsd ${DESTDIR}/$(prefix)/bin || :
 	mv ${DESTDIR}/$(LIB_DIR)/pcs/pcs_internal ${DESTDIR}/$(prefix)/bin || :
 	mv ${DESTDIR}/$(LIB_DIR)/pcs/pcs_snmp_agent ${DESTDIR}/$(prefix)/bin || :
 	recordfile=$$(echo ${DESTDIR}/$(PYTHON_SITELIB)/pcs*.dist-info/RECORD); \
+	find ${DESTDIR}/$(prefix)/local/sbin -name pcs -type f -delete || \
+		rm -fv ${DESTDIR}/$(SBINDIR)/pcs
+	find ${DESTDIR}/$(prefix)/local/sbin -name pcsd -type f -delete || \
+		rm -fv ${DESTDIR}/$(SBINDIR)/pcsd
 	while read fname; do \
 	  rm -rf $$(echo "${DESTDIR}/$(PYTHON_SITELIB)/$$fname" | cut -d',' -f1); \
 	done < $$recordfile

--- a/Makefile.am
+++ b/Makefile.am
@@ -229,8 +229,10 @@ uninstall-local:
 	fi
 	find ${DESTDIR}/$(LIB_DIR)/pcs -empty -type d -delete
 	find ${DESTDIR}/$(LIB_DIR)/pcsd -empty -type d -delete
-	find ${DESTDIR}/${PYTHON_SITELIB}/pcs -empty -type d -delete
-	rmdir ${DESTDIR}/$(PYTHON_SITELIB)/pcs*.dist-info
+	find ${DESTDIR}/${PYTHON_SITELIB}/pcs -empty -type d -delete || :
+	find ${DESTDIR}/${prefix}/local/lib/python*/dist-packages/pcs -empty -type d -delete || :
+	rmdir ${DESTDIR}/$(PYTHON_SITELIB)/pcs*.dist-info || :
+	rmdir ${DESTDIR}/${prefix}/local/lib/python*/dist-packages/pcs*.dist-info || :
 
 dist_doc_DATA	= README.md CHANGELOG.md
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -209,15 +209,20 @@ install-exec-local: install_python_embedded_mods stamps/install_ruby_deps_local
 # which are untouched by make install.
 uninstall-local:
 	rm -rf ${DESTDIR}/$(PCS_BUNDLED_DIR)
-	recordfile=$$(echo ${DESTDIR}/$(PYTHON_SITELIB)/pcs*.dist-info/RECORD); \
 	find ${DESTDIR}/$(prefix)/local/sbin -name pcs -type f -delete || \
 		rm -fv ${DESTDIR}/$(SBINDIR)/pcs
 	find ${DESTDIR}/$(prefix)/local/sbin -name pcsd -type f -delete || \
 		rm -fv ${DESTDIR}/$(SBINDIR)/pcsd
 	rm -fv ${DESTDIR}/$(LIB_DIR)/pcs/pcs_internal
 	rm -fv ${DESTDIR}/$(LIB_DIR)/pcs/pcs_snmp_agent
+	sitelib=${DESTDIR}/${prefix}/local/lib/python*/dist-packages; \
+	recordfile=$$(echo $${sitelib}/pcs*.dist-info/RECORD); \
+	if test -n "$$recordfile"; then \
+		sitelib=${DESTDIR}/$(PYTHON_SITELIB); \
+		recordfile=$$(echo $${sitelib}/pcs*.dist-info/RECORD); \
+	fi; \
 	while read fname; do \
-	  rm -rf $$(echo "${DESTDIR}/$(PYTHON_SITELIB)/$$fname" | cut -d',' -f1); \
+	  rm -rf $$(echo "$$sitelib/$$fname" | cut -d',' -f1); \
 	done < $$recordfile
 	if test -n "${DESTDIR}" || test "${prefix}" != "/usr"; then \
 		rmdir ${DESTDIR}/$(SBINDIR); \

--- a/pyproject.toml.in
+++ b/pyproject.toml.in
@@ -30,6 +30,7 @@ include-package-data = false
 [tool.setuptools.packages.find]
 exclude = [
   "pcs_*",
+  "build*",
   "@PACKAGE_WEBUI_BACKEND@",
 ]
 


### PR DESCRIPTION
Allows for installation of pcs into `/usr/local` on Debian-like distros.