### PR TITLE
Revert "spec: pyparsing is always required"

### DIFF
--- a/rpm/pcs.spec.in
+++ b/rpm/pcs.spec.in
@@ -160,7 +160,9 @@ Requires: python%{python3_version}-lxml
 Requires: python%{python3_version}-pycurl
 %endif
 %endif
+%if "@cirpmworkarounds@" != "yes"
 Requires: python%{python3_version}-pyparsing >= 3.0.0
+%endif
 
 # ruby and gems for pcsd
 Requires: ruby >= 3.1


### PR DESCRIPTION
While pyparsing is always required, this is rightfully excluded for CI workarounds. We now require pyparsing > 3 which is not packaged in RHEL 9 and is installed from pip.