### PR TITLE
Fix out of tree installation on Debian and its derivatives

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -182,6 +182,7 @@ install-exec-local: install_python_embedded_mods stamps/install_ruby_deps_local
 	if test -n "${DESTDIR}" || test "${prefix}" != "/usr"; then \
 		$(MKDIR_P) ${DESTDIR}/$(LIB_DIR)/pcs/; \
 		$(MKDIR_P) ${DESTDIR}/$(SBINDIR); \
+		$(MKDIR_P) ${DESTDIR}/${prefix}/local/sbin/; \
 	fi
 	${PIP} ${pipopts} install ${pipinstallopts} \
 		--root=$(or ${DESTDIR}, /) \
@@ -233,6 +234,7 @@ uninstall-local:
 	  rm -rf $$(echo "$$sitelib/$$fname" | cut -d',' -f1); \
 	done < $$recordfile
 	if test -n "${DESTDIR}" || test "${prefix}" != "/usr"; then \
+		rmdir ${DESTDIR}/${prefix}/local/sbin; \
 		rmdir ${DESTDIR}/$(SBINDIR); \
 	fi
 	find ${DESTDIR}/$(LIB_DIR)/pcs -empty -type d -delete

--- a/Makefile.am
+++ b/Makefile.am
@@ -217,10 +217,13 @@ install-exec-local: install_python_embedded_mods stamps/install_ruby_deps_local
 uninstall-local:
 	rm -rf ${DESTDIR}/$(PCS_BUNDLED_DIR)
 	if test "${DESTDIR}/$(prefix)/bin/" != "${DESTDIR}/$(SBINDIR)/"; then \
-		find ${DESTDIR}/$(prefix)/local/sbin -name pcs -type f -delete || \
-			rm -fv ${DESTDIR}/$(SBINDIR)/pcs; \
-		find ${DESTDIR}/$(prefix)/local/sbin -name pcsd -type f -delete || \
-			rm -fv ${DESTDIR}/$(SBINDIR)/pcsd; \
+		if ls ${DESTDIR}/$(prefix)/local/sbin/pcs; then \
+			rm -fv ${DESTDIR}/$(prefix)/local/sbin/pcs \
+				${DESTDIR}/$(prefix)/local/sbin/pcsd; \
+		else \
+			rm -fv ${DESTDIR}/$(SBINDIR)/pcs \
+				${DESTDIR}/$(SBINDIR)/pcsd; \
+		fi \
 	fi
 	rm -fv ${DESTDIR}/$(LIB_DIR)/pcs/pcs_internal
 	rm -fv ${DESTDIR}/$(LIB_DIR)/pcs/pcs_snmp_agent


### PR DESCRIPTION
With Debian/Ubuntu downstream Python patches that force the prefix to
contain the local folder, pcs failed to move its binaries to sbin
because it only created <prefix>/sbin folder. Now we also create the
<prefix>/local/sbin folder to have the install working both in the
system and out of tree.

I was unable to reproduce this on an Ubuntu 24.04 VM, but I'm following the lead from system roles CI here: https://github.com/linux-system-roles/ha_cluster/actions/runs/12947217946/job/36113316201?pr=253#step:6:1663