### PR TITLE
Various Makefile fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - It is now possible to override errors when editing cluster properties in web
   UI
 - Display node-attribute in colocation constraints configuration ([RHEL-81938])
+- Make install no longer fails on systems with merged /usr/sbin and /usr/bin
 
 [RHEL-22423]: https://issues.redhat.com/browse/RHEL-22423
 [RHEL-44347]: https://issues.redhat.com/browse/RHEL-44347

--- a/Makefile.am
+++ b/Makefile.am
@@ -187,7 +187,7 @@ install-exec-local: install_python_embedded_mods stamps/install_ruby_deps_local
 	${PIP} ${pipopts} install ${pipinstallopts} \
 		--root=$(or ${DESTDIR}, /) \
 		--prefix=${prefix} ${EXTRA_SETUP_OPTS} .
-	if test "${DESTDIR}/$(prefix)/bin/" != "${DESTDIR}/$(SBINDIR)/"; then \
+	if test "$$(realpath ${DESTDIR}/$(prefix)/bin)" != "$$(realpath ${DESTDIR}/$(SBINDIR))"; then \
 		mv ${DESTDIR}/$(prefix)/bin/pcs ${DESTDIR}/$(SBINDIR)/ || \
 			mv ${DESTDIR}/$(prefix)/local/bin/pcs ${DESTDIR}/${prefix}/local/sbin/; \
 		mv ${DESTDIR}/$(prefix)/bin/pcsd ${DESTDIR}/$(SBINDIR)/ || \
@@ -216,7 +216,7 @@ install-exec-local: install_python_embedded_mods stamps/install_ruby_deps_local
 # which are untouched by make install.
 uninstall-local:
 	rm -rf ${DESTDIR}/$(PCS_BUNDLED_DIR)
-	if test "${DESTDIR}/$(prefix)/bin/" != "${DESTDIR}/$(SBINDIR)/"; then \
+	if test "$$(realpath ${DESTDIR}/$(prefix)/bin)" != "$$(realpath ${DESTDIR}/$(SBINDIR))"; then \
 		if ls ${DESTDIR}/$(prefix)/local/sbin/pcs; then \
 			rm -fv ${DESTDIR}/$(prefix)/local/sbin/pcs \
 				${DESTDIR}/$(prefix)/local/sbin/pcsd; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -229,7 +229,7 @@ uninstall-local:
 	rm -fv ${DESTDIR}/$(LIB_DIR)/pcs/pcs_snmp_agent
 	sitelib=${DESTDIR}/${prefix}/local/lib/python*/dist-packages; \
 	recordfile=$$(echo $${sitelib}/pcs*.dist-info/RECORD); \
-	if test -n "$$recordfile"; then \
+	if ! stat "$$recordfile"; then \
 		sitelib=${DESTDIR}/$(PYTHON_SITELIB); \
 		recordfile=$$(echo $${sitelib}/pcs*.dist-info/RECORD); \
 	fi; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -389,7 +389,7 @@ check-local: check-local-deps test-tree-prep typos_check ruff_lint ruff_isort_ch
 # New setuptools use the build directory to build wheels
 clean-local: test-tree-clean
 	rm -rf ./*.pyc ./*.egg-info ./*.dist-info build/
-	rm -rf $(PCS_BUNDLED_DIR)/*
+	rm -rf ${abs_top_builddir}/${PCS_BUNDLED_DIR_LOCAL} ${abs_top_builddir}/${PCSD_BUNDLED_DIR_ROOT_LOCAL}
 	rm -rf Gemfile.lock .bundle pcs_test/resources/temp
 	rm -rf $(PACKAGE_NAME)-$(VERSION).tar.* rpm/*tar* rpm/*.gem rpm/*.rpm
 	rm -rf stamps/*

--- a/rpm/pcs.spec.in
+++ b/rpm/pcs.spec.in
@@ -115,7 +115,9 @@ BuildRequires: python%{python3_version}-pycurl
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: make
-# printf, realpath from coreutils is used in makefile, head is used in spec
+# coreutils usages:
+# Makefile: printf, realpath, stat
+# spec: head
 BuildRequires: coreutils
 # find is used in Makefile and also somewhere else
 BuildRequires: findutils

--- a/rpm/pcs.spec.in
+++ b/rpm/pcs.spec.in
@@ -115,7 +115,7 @@ BuildRequires: python%{python3_version}-pycurl
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: make
-# printf from coreutils is used in makefile, head is used in spec
+# printf, realpath from coreutils is used in makefile, head is used in spec
 BuildRequires: coreutils
 # find is used in Makefile and also somewhere else
 BuildRequires: findutils


### PR DESCRIPTION
- `make install` didn't work on systems where `/usr/sbin` -> `/bin` -> `/usr/bin` without `./configure ... --sbindir=/usr/bin`
- `make uninstall` didn't work on Ubuntu because of broken logic in detecting where recordfile is
- `make clean` was removing bundled packages for pcs from system locations (wrong variable used in Makefile)