### PR TITLE
fix tests for tornado-6.5

### DIFF
--- a/pcs_test/tier0/daemon/test_ruby_pcsd.py
+++ b/pcs_test/tier0/daemon/test_ruby_pcsd.py
@@ -37,7 +37,6 @@ def create_http_request():
         uri="/pcsd/uri",
         headers=HTTPHeaders({"Cookie": "cookie1=first;cookie2=second"}),
         body=str.encode(urlencode({"post-key": "post-value"})),
-        host="pcsd-host:2224",
     )
 
 


### PR DESCRIPTION
* since tornado-6.5, the host value for HTTPServerRequest should come from http header 'Host'
* https://www.tornadoweb.org/en/stable/releases/v6.5.0.html#tornado-httputil
* https://github.com/tornadoweb/tornado/commit/4ce700affdd23631a0514d1a0460c0854b0687fe