### PR TITLE
format pcsd configs the same way in both ruby and python

### DIFF
--- a/pcsd/config.rb
+++ b/pcsd/config.rb
@@ -124,9 +124,9 @@ class PCSConfig
 
   def text()
     out_hash = Hash.new
-    out_hash['format_version'] = CURRENT_FORMAT
-    out_hash['data_version'] = @data_version
     out_hash['clusters'] = []
+    out_hash['data_version'] = @data_version
+    out_hash['format_version'] = CURRENT_FORMAT
     out_hash['permissions'] = Hash.new
     out_hash['permissions']['local_cluster'] = []
 
@@ -139,7 +139,7 @@ class PCSConfig
 
     out_hash['permissions']['local_cluster'] = @permissions_local.to_hash()
 
-    return JSON.pretty_generate(out_hash)
+    return JSON.pretty_generate(out_hash, {indent: '    '})
   end
 
   def remove_cluster(cluster_name)
@@ -253,11 +253,11 @@ class CfgKnownHosts
       }
     }
     out_hash = {
-      'format_version' => CURRENT_FORMAT,
       'data_version' => @data_version,
+      'format_version' => CURRENT_FORMAT,
       'known_hosts' => out_hosts,
     }
-    return JSON.pretty_generate(out_hash)
+    return JSON.pretty_generate(out_hash, {indent: '    '})
   end
 end
 

--- a/pcsd/permissions.rb
+++ b/pcsd/permissions.rb
@@ -103,9 +103,9 @@ module Permissions
 
     def to_hash()
       perm_hash = Hash.new
-      perm_hash['type'] = @type
-      perm_hash['name'] = @name
       perm_hash['allow'] = @allow_list.uniq.sort
+      perm_hash['name'] = @name
+      perm_hash['type'] = @type
       return perm_hash
     end
   end

--- a/pcsd/test/test_cfgsync.rb
+++ b/pcsd/test/test_cfgsync.rb
@@ -161,9 +161,9 @@ class TestPcsdSettings < Test::Unit::TestCase
     # https://bugzilla.redhat.com/show_bug.cgi?id=2331005
     old_rubygem = JSON.pretty_generate([]) == "[\n\n]"
     if old_rubygem
-      expected_hash = '26579b79a27f9f56e1acd398eb761d2eb1872c6d'
+      expected_hash = '50939a7d12d2411020f9fb42b0c411add2db39ca'
     else
-      expected_hash = 'db2b44331c63c25874ec30398fa82decd740fef4'
+      expected_hash = '47fdd9bd32d9771f66685664cb0e7d20c4609f25'
     end
 
     cfg.version = 4
@@ -234,7 +234,7 @@ class TestPcsdKnownHosts < Test::Unit::TestCase
 
     cfg.version = 3
     assert_equal(3, cfg.version)
-    assert_equal('146e2be5708980d47bceb531729ba4f6a6e4a4e8', cfg.hash)
+    assert_equal('c55f29f635525d22f2935a2e26998f5ba468bbb0', cfg.hash)
 
     cfg.text = template % 4
     assert_equal(4, cfg.version)
@@ -754,32 +754,32 @@ class TestMergeKnownHosts < Test::Unit::TestCase
   def fixture_old_cfg()
     return (
 '{
-  "format_version": 1,
-  "data_version": 5,
-  "known_hosts": {
-    "node1": {
-      "dest_list": [
-        {
-          "addr": "10.0.1.1",
-          "port": 2224
-        }
-      ],
-      "token": "token1"
-    },
-    "node2": {
-      "dest_list": [
-        {
-          "addr": "10.0.1.2",
-          "port": 2234
+    "data_version": 5,
+    "format_version": 1,
+    "known_hosts": {
+        "node1": {
+            "dest_list": [
+                {
+                    "addr": "10.0.1.1",
+                    "port": 2224
+                }
+            ],
+            "token": "token1"
         },
-        {
-          "addr": "10.0.2.2",
-          "port": 2235
+        "node2": {
+            "dest_list": [
+                {
+                    "addr": "10.0.1.2",
+                    "port": 2234
+                },
+                {
+                    "addr": "10.0.2.2",
+                    "port": 2235
+                }
+            ],
+            "token": "token2"
         }
-      ],
-      "token": "token2"
     }
-  }
 }')
   end
 
@@ -827,37 +827,37 @@ class TestMergeKnownHosts < Test::Unit::TestCase
   def fixture_new_cfg(version=5)
     return (
 '{
-  "format_version": 1,
-  "data_version": %d,
-  "known_hosts": {
-    "node1": {
-      "dest_list": [
-        {
-          "addr": "10.0.1.1",
-          "port": 2224
+    "data_version": %d,
+    "format_version": 1,
+    "known_hosts": {
+        "node1": {
+            "dest_list": [
+                {
+                    "addr": "10.0.1.1",
+                    "port": 2224
+                }
+            ],
+            "token": "token1"
+        },
+        "node2": {
+            "dest_list": [
+                {
+                    "addr": "10.0.1.2",
+                    "port": 2224
+                }
+            ],
+            "token": "token2a"
+        },
+        "node3": {
+            "dest_list": [
+                {
+                    "addr": "10.0.1.3",
+                    "port": 2224
+                }
+            ],
+            "token": "token3"
         }
-      ],
-      "token": "token1"
-    },
-    "node2": {
-      "dest_list": [
-        {
-          "addr": "10.0.1.2",
-          "port": 2224
-        }
-      ],
-      "token": "token2a"
-    },
-    "node3": {
-      "dest_list": [
-        {
-          "addr": "10.0.1.3",
-          "port": 2224
-        }
-      ],
-      "token": "token3"
     }
-  }
 }' % version)
   end
 
@@ -884,18 +884,19 @@ class TestMergeKnownHosts < Test::Unit::TestCase
   def fixture_old_text()
     return (
 '{
-  "format_version": 1,
-  "data_version": 2,
-  "known_hosts": {
-    "node1": {
-      "dest_list": [
-        {
-          "addr": "10.0.1.1",
-          "port": 2224
+    "data_version": 2,
+    "format_version": 1,
+    "known_hosts": {
+        "node1": {
+            "dest_list": [
+                {
+                    "addr": "10.0.1.1",
+                    "port": 2224
+                }
+            ],
+            "token": "token1a"
         }
-      ],
-      "token": "token1a"
-  }
+    }
 }')
   end
 

--- a/pcsd/test/test_config.rb
+++ b/pcsd/test/test_config.rb
@@ -22,21 +22,21 @@ class TestConfig < Test::Unit::TestCase
   def fixture_nil_config()
     return (
 '{
-  "format_version": 2,
-  "data_version": 0,
   "clusters": [
 
   ],
+  "data_version": 0,
+  "format_version": 2,
   "permissions": {
     "local_cluster": [
       {
-        "type": "group",
-        "name": "haclient",
         "allow": [
           "grant",
           "read",
           "write"
-        ]
+        ],
+        "name": "haclient",
+        "type": "group"
       }
     ]
   }
@@ -46,11 +46,11 @@ class TestConfig < Test::Unit::TestCase
   def fixture_empty_config()
     return (
 '{
-  "format_version": 2,
-  "data_version": 0,
   "clusters": [
 
   ],
+  "data_version": 0,
+  "format_version": 2,
   "permissions": {
     "local_cluster": [
 
@@ -146,21 +146,21 @@ class TestConfig < Test::Unit::TestCase
     assert_equal(0, cfg.clusters.length)
     assert_equal_json(
 '{
-  "format_version": 2,
-  "data_version": 0,
   "clusters": [
 
   ],
+  "data_version": 0,
+  "format_version": 2,
   "permissions": {
     "local_cluster": [
       {
-        "type": "group",
-        "name": "haclient",
         "allow": [
           "grant",
           "read",
           "write"
-        ]
+        ],
+        "name": "haclient",
+        "type": "group"
       }
     ]
   }
@@ -187,8 +187,6 @@ class TestConfig < Test::Unit::TestCase
     assert_equal(["rh71-node1", "rh71-node2"], cfg.clusters[0].nodes)
     assert_equal_json(
 '{
-  "format_version": 2,
-  "data_version": 0,
   "clusters": [
     {
       "name": "cluster71",
@@ -198,16 +196,18 @@ class TestConfig < Test::Unit::TestCase
       ]
     }
   ],
+  "data_version": 0,
+  "format_version": 2,
   "permissions": {
     "local_cluster": [
       {
-        "type": "group",
-        "name": "haclient",
         "allow": [
           "grant",
           "read",
           "write"
-        ]
+        ],
+        "name": "haclient",
+        "type": "group"
       }
     ]
   }
@@ -232,8 +232,6 @@ class TestConfig < Test::Unit::TestCase
   def test_parse_format2_one_cluster()
     text =
 '{
-  "format_version": 2,
-  "data_version": 9,
   "clusters": [
     {
       "name": "cluster71",
@@ -243,6 +241,8 @@ class TestConfig < Test::Unit::TestCase
       ]
     }
   ],
+  "data_version": 9,
+  "format_version": 2,
   "permissions": {
     "local_cluster": [
 
@@ -300,8 +300,6 @@ class TestConfig < Test::Unit::TestCase
     )
     out_text =
 '{
-  "format_version": 2,
-  "data_version": 9,
   "clusters": [
     {
       "name": "cluster71",
@@ -320,6 +318,8 @@ class TestConfig < Test::Unit::TestCase
       ]
     }
   ],
+  "data_version": 9,
+  "format_version": 2,
   "permissions": {
     "local_cluster": [
 
@@ -357,8 +357,6 @@ class TestConfig < Test::Unit::TestCase
     assert_equal(["rh71-node1", "rh71-node2"], cfg.clusters[0].nodes)
     assert_equal_json(
 '{
-  "format_version": 2,
-  "data_version": 9,
   "clusters": [
     {
       "name": "cluster71",
@@ -368,6 +366,8 @@ class TestConfig < Test::Unit::TestCase
       ]
     }
   ],
+  "data_version": 9,
+  "format_version": 2,
   "permissions": {
     "local_cluster": [
 
@@ -434,8 +434,6 @@ class TestConfig < Test::Unit::TestCase
 }'
     out_text =
 '{
-  "format_version": 2,
-  "data_version": 9,
   "clusters": [
     {
       "name": "cluster71",
@@ -445,39 +443,41 @@ class TestConfig < Test::Unit::TestCase
       ]
     }
   ],
+  "data_version": 9,
+  "format_version": 2,
   "permissions": {
     "local_cluster": [
       {
-        "type": "group",
-        "name": "group1",
         "allow": [
           "full",
           "write"
-        ]
+        ],
+        "name": "group1",
+        "type": "group"
       },
       {
-        "type": "group",
-        "name": "group2",
         "allow": [
           "grant",
           "read"
-        ]
+        ],
+        "name": "group2",
+        "type": "group"
       },
       {
-        "type": "user",
-        "name": "user1",
         "allow": [
           "grant",
           "read",
           "write"
-        ]
+        ],
+        "name": "user1",
+        "type": "user"
       },
       {
-        "type": "user",
-        "name": "user2",
         "allow": [
 
-        ]
+        ],
+        "name": "user2",
+        "type": "user"
       }
     ]
   }
@@ -680,8 +680,8 @@ class TestCfgKnownHosts < Test::Unit::TestCase
   def fixture_empty_config()
     return(
 '{
-  "format_version": 1,
   "data_version": 0,
+  "format_version": 1,
   "known_hosts": {
   }
 }'
@@ -746,8 +746,8 @@ class TestCfgKnownHosts < Test::Unit::TestCase
   def test_parse_format1_simple()
     text =
 '{
-  "format_version": 1,
   "data_version": 2,
+  "format_version": 1,
   "known_hosts": {
     "node1": {
       "dest_list": [
@@ -779,8 +779,8 @@ class TestCfgKnownHosts < Test::Unit::TestCase
   def test_parse_format1_complex()
     text =
 '{
-  "format_version": 1,
   "data_version": 2,
+  "format_version": 1,
   "known_hosts": {
     "node1": {
       "dest_list": [
@@ -899,8 +899,8 @@ class TestCfgKnownHosts < Test::Unit::TestCase
     assert_equal_json(
       cfg.text,
 '{
-  "format_version": 1,
   "data_version": 3,
+  "format_version": 1,
   "known_hosts": {
     "node1": {
       "dest_list": [


### PR DESCRIPTION
With default settings, Python exports JSON data a bit differently than Ruby. After pcsd config sync was partially overhauled to python in aa500adc, format of pcsd config files depended on pcsd part that saved them (python vs. ruby). This might caused issues in config syncing - even though the configs held the same data, their plaintext representation was different.

With this fix, ruby part formats the files the same way python part does.