### PR TITLE
[pcs-0.11] Small fixes to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,17 @@ Web UI frontend is no longer part of pcs sources. You can get it at
 To install pcs and pcsd run the following in terminal:
 ```shell
 ./autogen.sh
-./configure
-# alternatively, './configure --enable-local-build' can be used to also download
-# missing dependencies
+./configure [--enable-local-build] [--enable-individual-bundling]
 make
 make install
 ```
+
+**Common configure options**:
+* `--enable-local-build` - downloads all Python dependencies which can be
+  bundled - see macros `PCS_CHECK_PYMOD` with 3rd argument `[yes]` in
+  `configure.ac`
+* `--enable-individual-bundling` - downloads only dependencies (both Python and
+  rubygems) which are not installed on the system
 
 If you are using GNU/Linux with systemd, it is now time to:
 ```shell

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ These are the runtime dependencies of pcs and pcsd:
 * killall (package psmisc)
 * corosync 3.x
 * pacemaker 2.1
+* certutil (package nss-tools or mozilla-nss-tools)
 
 ## Installation from Source
 


### PR DESCRIPTION
- Added certutil as a dependency.
- Better explaining the most used configure options for building pcs. Most installation problems can be resolved by using combinations of `--enable-local-build` and `--enable-individual-bundling`. To effectively do that, I thought that we could better explain what they do. 