### PR TITLE
fix rpm version on tagged commits

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -452,8 +452,8 @@ $(SPEC): $(SPEC).in .version config.status stamps/download_python_deps stamps/do
 	if [ "$$numcomm" = "0" ]; then \
 		sed \
 			-e "s#@version@#$$rpmver#g" \
-			-e "s#%glo.*alpha.*##g" \
-			-e "s#%glo.*numcomm.*##g" \
+			-e "s#%global\s\+alphatag.*##g" \
+			-e "s#%global\s\+numcomm.*##g" \
 			-e "s#@dirty@#$$dirty#g" \
 			-e "s#@date@#$$date#g" \
 			-e "s#@pcs_bundled_dir@#${PCS_BUNDLED_DIR_LOCAL}#g" \


### PR DESCRIPTION
Sed expression `"s#%glo.*alpha.*##g"` was matching the following line in `rpm/pcs.spec.in`:
`%global rpm_version %(echo %{clean_version} | sed -e 's/\\([[:alpha:]]\\)/~\\1/')`

As a result, the line got removed. This lead to `rpm_version` variable to be undefined in the spec file. Rpm files and tarballs built from such a spec file were named incorrectly: `pcs-%{rpm_version}-99+git.*.rpm`