### PR TITLE
fix rpm version on tagged commits

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -381,8 +381,8 @@ $(SPEC): $(SPEC).in .version config.status stamps/download_python_deps stamps/do
 	if [ "$$numcomm" = "0" ]; then \
 		sed \
 			-e "s#@version@#$$rpmver#g" \
-			-e "s#%glo.*alpha.*##g" \
-			-e "s#%glo.*numcomm.*##g" \
+			-e "s#%global\s\+alphatag.*##g" \
+			-e "s#%global\s\+numcomm.*##g" \
 			-e "s#@dirty@#$$dirty#g" \
 			-e "s#@date@#$$date#g" \
 			-e "s#@pcs_bundled_dir@#${PCS_BUNDLED_DIR_LOCAL}#g" \


### PR DESCRIPTION
Sed expression `"s#%glo.*alpha.*##g"` was too generic and could match and remove other lines in rpm/pcs.spec.in, such as: `%global rpm_version %(echo %{clean_version} | sed -e 's/\\([[:alpha:]]\\)/~\\1/')`