### PR TITLE
Do not require wheel when setuptools is new enough

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Apart from the dependencies listed above, these are also required for
 installation:
 
 * python development files (packages python3-devel, python3-setuptools 66.1+,
-  python3-pip, python3-wheel)
+  python3-pip, python3-wheel if python3-setuptools < 71)
 * ruby development files (package ruby-devel)
 * rubygems
 * rubygem bundler (package rubygem-bundler or ruby-bundler or bundler)

--- a/configure.ac
+++ b/configure.ac
@@ -347,12 +347,15 @@ AC_SUBST([PYAGENTX_VERSION])
 
 # pip 19.0 required for PEP517 support
 PCS_CHECK_PYMOD([pip], [>= 23.0])
-# pip builds a wheel first
-PCS_CHECK_PYMOD([wheel])
 
 if test "x$tests_only" != "xyes"; then
 	# setuptools 61.0.0 required for PEP621 support
 	PCS_CHECK_PYMOD([setuptools], [>= 66.1])
+	# wheel is required if setuptools < 71
+	AC_PIP_MODULE([setuptools], [>= 71], [], [], [need_wheel=yes])
+	if test "x$need_wheel" = "xyes"; then
+		PCS_CHECK_PYMOD([wheel])
+	fi
 	PCS_CHECK_PYMOD([cryptography])
 	PCS_CHECK_PYMOD([lxml])
 	PCS_CHECK_PYMOD([pyparsing], [>= 3.0.0])

--- a/rpm/pcs.spec.in
+++ b/rpm/pcs.spec.in
@@ -86,7 +86,7 @@ BuildRequires: python%{python3_version}-pip >= 23
 BuildRequires: python%{python3_version}-setuptools >= 66.1
 
 # for building wheel during make install
-BuildRequires: python%{python3_version}-wheel
+BuildRequires: (python%{python3_version}-wheel if python%{python3_version}-setuptools < 71)
 
 # for bundling dateutil
 %if "@cirpmworkarounds@" != "yes"


### PR DESCRIPTION
The current version of setuptools creates wheels on its own.

[In Fedora ELN, I'd like to get rid of wheel](https://github.com/fedora-eln/eln/issues/284).

This is my untested attempt to get rid of the dependency. I don't do much m4 nowadays, so forgive me if it's not correct. I am opening this as a draft to see what the CI says.