### PR TITLE
improve acl validation messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   `pcs cluster node delete-remote|remove-remote|delete-guest|remove-guest`
   now warn about omitting live cluster actions when '-f' is used ([RHEL-76157])
 
+### Fixed
+- Commands `pcs acl role create` and `pcs acl permission add` now print
+  specific error messages in case of invalid input instead of command usage
+
 ### Changed
 - Lib command `cib.remove_elements` does not stop resources before deletion.
   The resources should be stopped before calling this command

--- a/pcs/acl.py
+++ b/pcs/acl.py
@@ -121,8 +121,7 @@ def argv_to_permission_info_list(argv):
 
     # wrapping by list,
     # because in python3 zip() returns an iterator instead of a list
-    # and the loop below makes iteration over it
-    permission_info_list = list(
+    return list(
         zip(
             [permission.lower() for permission in argv[::3]],
             [scope_type.lower() for scope_type in argv[1::3]],
@@ -130,15 +129,6 @@ def argv_to_permission_info_list(argv):
             strict=False,
         )
     )
-
-    for permission, scope_type, _ in permission_info_list:
-        if permission not in ["read", "write", "deny"] or scope_type not in [
-            "xpath",
-            "id",
-        ]:
-            raise CmdLineInputError()
-
-    return permission_info_list
 
 
 def role_create(lib, argv, modifiers):

--- a/pcs_test/tier1/legacy/test_acl.py
+++ b/pcs_test/tier1/legacy/test_acl.py
@@ -526,11 +526,17 @@ class ACLTest(TestCase, AssertPcsMixin):
         )
         self.assert_pcs_fail(
             "acl role create role0 readX xpath //resources".split(),
-            stderr_start="\nUsage: pcs acl role create...",
+            (
+                "Error: 'readx' is not a valid permission value, use 'deny', 'read', 'write'\n"
+                + ERRORS_HAVE_OCCURRED
+            ),
         )
         self.assert_pcs_fail(
             "acl role create role0 read xpathX //resources".split(),
-            stderr_start="\nUsage: pcs acl role create...",
+            (
+                "Error: 'xpathx' is not a valid scope type value, use 'id', 'xpath'\n"
+                + ERRORS_HAVE_OCCURRED
+            ),
         )
         self.assert_pcs_fail(
             "acl role create role0 description=test read".split(),
@@ -550,11 +556,17 @@ class ACLTest(TestCase, AssertPcsMixin):
         )
         self.assert_pcs_fail(
             "acl role create role0 description=test readX xpath //resources".split(),
-            stderr_start="\nUsage: pcs acl role create...",
+            (
+                "Error: 'readx' is not a valid permission value, use 'deny', 'read', 'write'\n"
+                + ERRORS_HAVE_OCCURRED
+            ),
         )
         self.assert_pcs_fail(
             "acl role create role0 description=test read xpathX //resources".split(),
-            stderr_start="\nUsage: pcs acl role create...",
+            (
+                "Error: 'xpathx' is not a valid scope type value, use 'id', 'xpath'\n"
+                + ERRORS_HAVE_OCCURRED
+            ),
         )
         self.assert_pcs_fail(
             "acl role create role0 desc=test read".split(),
@@ -562,15 +574,27 @@ class ACLTest(TestCase, AssertPcsMixin):
         )
         self.assert_pcs_fail(
             "acl role create role0 desc=test read //resources".split(),
-            stderr_start="\nUsage: pcs acl role create...",
+            (
+                "Error: 'desc=test' is not a valid permission value, use 'deny', 'read', 'write'\n"
+                "Error: 'read' is not a valid scope type value, use 'id', 'xpath'\n"
+                + ERRORS_HAVE_OCCURRED
+            ),
         )
         self.assert_pcs_fail(
             "acl role create role0 desc=test read xpath".split(),
-            stderr_start="\nUsage: pcs acl role create...",
+            (
+                "Error: 'desc=test' is not a valid permission value, use 'deny', 'read', 'write'\n"
+                "Error: 'read' is not a valid scope type value, use 'id', 'xpath'\n"
+                + ERRORS_HAVE_OCCURRED
+            ),
         )
         self.assert_pcs_fail(
             "acl role create role0 desc=test read id".split(),
-            stderr_start="\nUsage: pcs acl role create...",
+            (
+                "Error: 'desc=test' is not a valid permission value, use 'deny', 'read', 'write'\n"
+                "Error: 'read' is not a valid scope type value, use 'id', 'xpath'\n"
+                + ERRORS_HAVE_OCCURRED
+            ),
         )
         self.assert_pcs_fail(
             "acl role create role0 desc=test readX xpath //resources".split(),
@@ -806,11 +830,17 @@ class ACLTest(TestCase, AssertPcsMixin):
         )
         self.assert_pcs_fail(
             "acl permission add role1 readX xpath //resources".split(),
-            stderr_start="\nUsage: pcs acl permission add...",
+            (
+                "Error: 'readx' is not a valid permission value, use 'deny', 'read', 'write'\n"
+                + ERRORS_HAVE_OCCURRED
+            ),
         )
         self.assert_pcs_fail(
             "acl permission add role1 read xpathX //resources".split(),
-            stderr_start="\nUsage: pcs acl permission add...",
+            (
+                "Error: 'xpathx' is not a valid scope type value, use 'id', 'xpath'\n"
+                + ERRORS_HAVE_OCCURRED
+            ),
         )
         self.assert_pcs_fail(
             "acl permission add role1 read id dummy read".split(),
@@ -830,11 +860,19 @@ class ACLTest(TestCase, AssertPcsMixin):
         )
         self.assert_pcs_fail(
             "acl permission add role1 read id dummy readX xpath //resources".split(),
-            stderr_start="\nUsage: pcs acl permission add...",
+            (
+                "Error: id 'dummy' does not exist\n"
+                "Error: 'readx' is not a valid permission value, use 'deny', 'read', 'write'\n"
+                + ERRORS_HAVE_OCCURRED
+            ),
         )
         self.assert_pcs_fail(
             "acl permission add role1 read id dummy read xpathX //resources".split(),
-            stderr_start="\nUsage: pcs acl permission add...",
+            (
+                "Error: id 'dummy' does not exist\n"
+                "Error: 'xpathx' is not a valid scope type value, use 'id', 'xpath'\n"
+                + ERRORS_HAVE_OCCURRED
+            ),
         )
         self.assert_pcs_success(
             ["acl"],


### PR DESCRIPTION
Drop client-side validation, which printed command usage in case of invalid input. As a result, lib-side validation is used, which prints specific error messages.