### PR TITLE
fix url /add_meta_attr_remote for stonith [pcs-0.11]

### DIFF
--- a/pcsd/capabilities.xml.in
+++ b/pcsd/capabilities.xml.in
@@ -1589,6 +1589,14 @@
         daemon urls: add_meta_attr_remote
       </description>
     </capability>
+    <capability id="pcmk.resource.update-meta.stonith" in-pcs="0" in-pcsd="1">
+      <description>
+        The add_meta_attr_remote url also supports stonith when called with
+        an explicit is-stonith flag.
+
+        daemon urls: add_meta_attr_remote
+      </description>
+    </capability>
     <capability id="pcmk.resource.update-meta.list" in-pcs="1" in-pcsd="0">
       <description>
         Update several meta attributes of a resource at once.

--- a/pcsd/pcs.rb
+++ b/pcsd/pcs.rb
@@ -63,8 +63,9 @@ def add_node_attr(auth_user, node, key, value)
   return retval
 end
 
-def add_meta_attr(auth_user, resource, key, value)
-  cmd = ["resource", "meta", resource, key.to_s + "=" + value.to_s]
+def add_meta_attr(auth_user, resource, key, value, is_stonith)
+  resource_or_stonith = if is_stonith then "stonith" else "resource" end
+  cmd = [resource_or_stonith, "meta", resource, key.to_s + "=" + value.to_s]
   flags = []
   if ["remote-node", "remote-addr"].include?(key.to_s)
     # --force is a workaround for missing guest node management in the web ui

--- a/pcsd/remote.rb
+++ b/pcsd/remote.rb
@@ -1160,7 +1160,11 @@ def add_meta_attr_remote(params, request, auth_user)
     return 403, 'Permission denied'
   end
   retval = add_meta_attr(
-    auth_user, params["res_id"], params["key"],params["value"]
+    auth_user,
+    params["res_id"],
+    params["key"],
+    params["value"],
+    params["is-stonith"] == "true"
   )
   if retval == 0
     return [200, "Successfully added meta attribute"]


### PR DESCRIPTION
The internal separation of resources and stonith caused that the url `/managec/cluster-name/add_meta_attr_remote` is refusing to work with stonith (the handler calls CLI commands that now refuses to work with stonith).
Because alternative paths (APIv2) for this task are not currently feasible, the handler is fixed to accept stonith but only with explicit `is-stonith` parameter.