### PR TITLE
Validate cluster name length

### DIFF
--- a/pcs/lib/corosync/config_validators.py
+++ b/pcs/lib/corosync/config_validators.py
@@ -277,9 +277,6 @@ def _get_cluster_name_validators(
     force_cluster_name: bool,
 ) -> list[validate.ValidatorInterface]:
     return [
-        validate.ValueNotEmpty(
-            "name", None, option_name_for_report="cluster name"
-        ),
         _ClusterNameGfs2Validator(
             "name",
             option_name_for_report="cluster name",
@@ -289,6 +286,12 @@ def _get_cluster_name_validators(
         ),
         validate.ValueCorosyncValue(
             "name", option_name_for_report="cluster name"
+        ),
+        validate.ValueStringLength(
+            "name",
+            option_name_for_report="cluster name",
+            min_len=1,
+            max_len=constants.CLUSTER_NAME_LENGTH_MAX,
         ),
     ]
 

--- a/pcs/lib/corosync/constants.py
+++ b/pcs/lib/corosync/constants.py
@@ -114,3 +114,9 @@ QUORUM_OPTIONS_INCOMPATIBLE_WITH_QDEVICE = (
 
 OPTION_NAME_RE = re.compile(r"^[-_/a-zA-Z0-9]+$")
 QUORUM_DEVICE_HEURISTICS_EXEC_NAME_RE = re.compile(r"^exec_[-_/a-zA-Z0-9]+$")
+
+# Length of the line within config is 512 characters.
+# However, we do not know the offset of the line and cluster name length.
+# Therefore I am setting the limit to 256,
+# which should be more than enough for a cluster name.
+CLUSTER_NAME_LENGTH_MAX = 256

--- a/pcs/lib/validate.py
+++ b/pcs/lib/validate.py
@@ -895,11 +895,13 @@ class ValueStringLength(ValuePredicateBase):
         )
         self._min_len = min_len
         self._max_len = max_len
-        self._value_cannot_be_empty = (
-            self._min_len is not None and self._min_len > 0
-        )
 
     def _is_valid(self, value: TypeOptionValue) -> bool:
+        self._value_cannot_be_empty = (
+            self._min_len is not None
+            and self._min_len > 0
+            and is_empty_string(value)
+        )
         return is_string_length(value, self._min_len, self._max_len)
 
     def _get_allowed_values(self) -> Any:

--- a/pcs_test/tier0/lib/auth/test_validations.py
+++ b/pcs_test/tier0/lib/auth/test_validations.py
@@ -94,7 +94,7 @@ class ValidateHostsWithToken(TestCase):
                     option_name="token",
                     option_value=bad_token,
                     allowed_values="a string (min length: 1) (max length: 512)",
-                    cannot_be_empty=True,
+                    cannot_be_empty=False,
                     forbidden_characters=None,
                 )
             ],

--- a/pcs_test/tier0/lib/commands/cluster/test_rename.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_rename.py
@@ -7,6 +7,7 @@ from pcs import settings
 from pcs.common import reports
 from pcs.common.reports import codes as report_codes
 from pcs.lib.commands import cluster
+from pcs.lib.corosync.constants import CLUSTER_NAME_LENGTH_MAX
 
 from pcs_test.tools import fixture
 from pcs_test.tools.command_env import get_env_tools
@@ -147,7 +148,36 @@ class RenameCluster(FixtureMixin, TestCase):
             + self.fixture_remove_name_prop_reports()
         )
 
-    def test_invalid_name(self):
+    def test_name_too_long_force(self):
+        cluster_name = (CLUSTER_NAME_LENGTH_MAX + 1) * "x"
+
+        self.env_assist.assert_raise_library_error(
+            lambda: cluster.rename(
+                self.env_assist.get_env(),
+                cluster_name,
+                force_flags=[report_codes.FORCE],
+            )
+        )
+        self.env_assist.assert_reports(
+            [
+                fixture.warn(
+                    report_codes.COROSYNC_CLUSTER_NAME_INVALID_FOR_GFS2,
+                    cluster_name=cluster_name,
+                    max_length=32,
+                    allowed_characters="a-z A-Z 0-9 _-",
+                ),
+                fixture.error(
+                    report_codes.INVALID_OPTION_VALUE,
+                    option_name="cluster name",
+                    option_value=cluster_name,
+                    allowed_values="a string (min length: 1) (max length: 256)",
+                    cannot_be_empty=False,
+                    forbidden_characters=None,
+                ),
+            ]
+        )
+
+    def test_empty_name(self):
         self.env_assist.assert_raise_library_error(
             lambda: cluster.rename(self.env_assist.get_env(), "")
         )
@@ -157,10 +187,10 @@ class RenameCluster(FixtureMixin, TestCase):
                     report_codes.INVALID_OPTION_VALUE,
                     option_name="cluster name",
                     option_value="",
-                    allowed_values=None,
+                    allowed_values="a string (min length: 1) (max length: 256)",
                     cannot_be_empty=True,
                     forbidden_characters=None,
-                )
+                ),
             ]
         )
 

--- a/pcs_test/tier0/lib/commands/cluster/test_setup.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_setup.py
@@ -10,6 +10,7 @@ from pcs.common.host import Destination
 from pcs.common.ssl import dump_cert, dump_key, generate_cert, generate_key
 from pcs.lib.commands import cluster
 from pcs.lib.corosync import constants
+from pcs.lib.corosync.constants import CLUSTER_NAME_LENGTH_MAX
 
 from pcs_test.tools import fixture
 from pcs_test.tools.command_env import get_env_tools
@@ -970,7 +971,7 @@ class Validation(TestCase):
                     reports.codes.INVALID_OPTION_VALUE,
                     option_value="",
                     option_name="cluster name",
-                    allowed_values=None,
+                    allowed_values="a string (min length: 1) (max length: 256)",
                     cannot_be_empty=True,
                     forbidden_characters=None,
                 ),
@@ -983,6 +984,46 @@ class Validation(TestCase):
                     forbidden_characters=None,
                 ),
                 fixture.error(reports.codes.COROSYNC_NODES_MISSING),
+            ]
+        )
+
+    def test_cluster_name_too_long_force(self):
+        cluster_name = (CLUSTER_NAME_LENGTH_MAX + 1) * "x"
+
+        self.config.http.host.get_host_info(
+            NODE_LIST,
+            output_data=self.get_host_info_ok,
+        )
+        self.config.fs.isfile(settings.pcsd_config)
+        self.config.fs.open(
+            settings.pcsd_config,
+            mock.mock_open(read_data="PCSD_SSL_CERT_SYNC_ENABLED=false\n")(),
+        )
+
+        self.env_assist.assert_raise_library_error(
+            lambda: cluster.setup(
+                self.env_assist.get_env(),
+                cluster_name,
+                self.command_node_list,
+                force_flags=[reports.codes.FORCE],
+            )
+        )
+        self.env_assist.assert_reports(
+            [
+                fixture.warn(
+                    reports.codes.COROSYNC_CLUSTER_NAME_INVALID_FOR_GFS2,
+                    cluster_name=cluster_name,
+                    max_length=32,
+                    allowed_characters="a-z A-Z 0-9 _-",
+                ),
+                fixture.error(
+                    reports.codes.INVALID_OPTION_VALUE,
+                    option_name="cluster name",
+                    option_value=cluster_name,
+                    allowed_values="a string (min length: 1) (max length: 256)",
+                    cannot_be_empty=False,
+                    forbidden_characters=None,
+                ),
             ]
         )
 
@@ -3577,7 +3618,7 @@ class SetupLocal(TestCase):
                     reports.codes.INVALID_OPTION_VALUE,
                     option_value="",
                     option_name="cluster name",
-                    allowed_values=None,
+                    allowed_values="a string (min length: 1) (max length: 256)",
                     cannot_be_empty=True,
                     forbidden_characters=None,
                 ),

--- a/pcs_test/tier0/lib/corosync/test_config_validators_create.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_create.py
@@ -99,7 +99,7 @@ class Create(TestCase):
                     report_codes.INVALID_OPTION_VALUE,
                     option_value="",
                     option_name="cluster name",
-                    allowed_values=None,
+                    allowed_values="a string (min length: 1) (max length: 256)",
                     cannot_be_empty=True,
                     forbidden_characters=None,
                 ),

--- a/pcs_test/tier0/lib/corosync/test_config_validators_rename_cluster.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_rename_cluster.py
@@ -22,10 +22,10 @@ class RenameCluster(TestCase):
                     report_codes.INVALID_OPTION_VALUE,
                     option_name="cluster name",
                     option_value="",
-                    allowed_values=None,
+                    allowed_values="a string (min length: 1) (max length: 256)",
                     cannot_be_empty=True,
                     forbidden_characters=None,
-                )
+                ),
             ],
         )
 

--- a/pcs_test/tier0/lib/test_validate.py
+++ b/pcs_test/tier0/lib/test_validate.py
@@ -1476,6 +1476,21 @@ class ValueStringLength(TestCase):
                     [],
                 )
 
+    def test_report_invalid_value_cannot_be_empty(self):
+        assert_report_item_list_equal(
+            validate.ValueStringLength("key", 2, 3).validate({"key": ""}),
+            [
+                fixture.error(
+                    reports.codes.INVALID_OPTION_VALUE,
+                    option_name="key",
+                    option_value="",
+                    allowed_values="a string (min length: 2) (max length: 3)",
+                    cannot_be_empty=True,
+                    forbidden_characters=None,
+                ),
+            ],
+        )
+
     def test_report_invalid_value_min_max(self):
         for value in ["a", "aaaa"]:
             with self.subTest(value=value):
@@ -1489,7 +1504,7 @@ class ValueStringLength(TestCase):
                             option_name="key",
                             option_value=value,
                             allowed_values="a string (min length: 2) (max length: 3)",
-                            cannot_be_empty=True,
+                            cannot_be_empty=False,
                             forbidden_characters=None,
                         ),
                     ],
@@ -1504,7 +1519,7 @@ class ValueStringLength(TestCase):
                     option_name="key",
                     option_value="a",
                     allowed_values="a string (min length: 2)",
-                    cannot_be_empty=True,
+                    cannot_be_empty=False,
                     forbidden_characters=None,
                 ),
             ],

--- a/pcs_test/tier1/cluster/test_cluster_rename.py
+++ b/pcs_test/tier1/cluster/test_cluster_rename.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from pcs.lib.corosync.constants import CLUSTER_NAME_LENGTH_MAX
+
 from pcs_test.tools.assertions import AssertPcsMixin
 from pcs_test.tools.misc import get_test_resource
 from pcs_test.tools.pcs_runner import PcsRunner
@@ -13,6 +15,20 @@ class ClusterRename(AssertPcsMixin, TestCase):
         self.assert_pcs_fail(
             ["cluster", "rename"],
             stderr_start="\nUsage: pcs cluster rename...\n",
+        )
+
+    def test_too_long_arg(self):
+        cluster_name_too_long = (CLUSTER_NAME_LENGTH_MAX + 1) * "x"
+        self.assert_pcs_fail(
+            [
+                "cluster",
+                "rename",
+                cluster_name_too_long,
+            ],
+            stderr_regexp=(
+                f"Error: '{cluster_name_too_long}' is not a valid cluster name"
+                r" value, use a string \(min length: 1\) \(max length: 256\)"
+            ),
         )
 
     def test_too_many_args(self):

--- a/pcs_test/tier1/cluster/test_setup_local.py
+++ b/pcs_test/tier1/cluster/test_setup_local.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 from unittest import TestCase
 
 from pcs import settings
+from pcs.lib.corosync.constants import CLUSTER_NAME_LENGTH_MAX
 
 from pcs_test.tools.assertions import AssertPcsMixin
 from pcs_test.tools.misc import (
@@ -290,6 +291,21 @@ class SetupLocal(AssertPcsMixin, TestCase):
                 Error: If quorum option 'last_man_standing_window' is enabled, quorum option 'last_man_standing' must be enabled as well
                 Error: Errors have occurred, therefore pcs is unable to continue
                 """
+            ),
+        )
+        self.assertEqual(self.corosync_conf_file.read(), "")
+
+    def test_long_cluster_name(self):
+        self.fixture_known_hosts([])
+        cluster_name_too_long = (CLUSTER_NAME_LENGTH_MAX + 1) * "x"
+        self.assert_pcs_fail(
+            (
+                f"cluster setup {cluster_name_too_long} "
+                "node1 node2 --force --overwrite --no-cluster-uuid"
+            ).split(),
+            stderr_regexp=(
+                f"Error: '{cluster_name_too_long}' is not a valid cluster name"
+                r" value, use a string \(min length: 1\) \(max length: 256\)"
             ),
         )
         self.assertEqual(self.corosync_conf_file.read(), "")


### PR DESCRIPTION
Corosync can parse limited length of cluster name. In this PR I introduce cluster name length check.