### PR TITLE
Handle unknown enum values in APIv2

### DIFF
--- a/pcs/common/interface/dto.py
+++ b/pcs/common/interface/dto.py
@@ -36,12 +36,22 @@ SerializableType = Union[
 ]
 
 T = TypeVar("T")
+E = TypeVar("E", bound=Enum)
 
 ToDictMetaKey = NewType("ToDictMetaKey", str)
 META_NAME = ToDictMetaKey("META_NAME")
 
 
-E = TypeVar("E", bound=Enum)
+class PayloadConversionError(Exception):
+    pass
+
+
+class _UnionNotAllowed(Exception):
+    pass
+
+
+class DataTransferObject(DataclassInstance):
+    pass
 
 
 def _safe_enum_cast(enum_class: type[E]) -> Callable[[Any], E]:
@@ -52,7 +62,7 @@ def _safe_enum_cast(enum_class: type[E]) -> Callable[[Any], E]:
             valid_values = format_list([f.value for f in enum_class])
             raise PayloadConversionError(
                 f"Invalid value '{value}' for Enum '{enum_class.__name__}', "
-                f"use one of {valid_values}"
+                f"expected one of {valid_values}"
             ) from e
 
     return _cast_value
@@ -97,18 +107,6 @@ DTO_TYPE_HOOKS_MAP: dict[type[Any], Callable[[Any], Any]] = {
     #   queries: Sequence[tuple[str, str]]
     tuple[str, str]: lambda v: tuple(v) if isinstance(v, list) else v,
 }
-
-
-class PayloadConversionError(Exception):
-    pass
-
-
-class _UnionNotAllowed(Exception):
-    pass
-
-
-class DataTransferObject(DataclassInstance):
-    pass
 
 
 def meta(name: str) -> dict[str, str]:

--- a/pcs/common/interface/dto.py
+++ b/pcs/common/interface/dto.py
@@ -19,6 +19,7 @@ import dacite
 import pcs.common.async_tasks.types as async_tasks_types
 import pcs.common.permissions.types as permissions_types
 from pcs.common import types
+from pcs.common.str_tools import format_list
 
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance  # pylint: disable=import-error
@@ -40,7 +41,47 @@ ToDictMetaKey = NewType("ToDictMetaKey", str)
 META_NAME = ToDictMetaKey("META_NAME")
 
 
+E = TypeVar("E", bound=Enum)
+
+
+def _safe_enum_cast(enum_class: type[E]) -> Callable[[Any], E]:
+    def _cast_value(value: Any) -> E:
+        try:
+            return enum_class(value)
+        except ValueError as e:
+            valid_values = format_list([f.value for f in enum_class])
+            raise PayloadConversionError(
+                f"Invalid value '{value}' for Enum '{enum_class.__name__}', "
+                f"use one of {valid_values}"
+            ) from e
+
+    return _cast_value
+
+
 DTO_TYPE_HOOKS_MAP: dict[type[Any], Callable[[Any], Any]] = {
+    # Dacite does not convert Enums automatically. We previously used simple
+    # casting: https://github.com/konradhalas/dacite#casting, but that is not
+    # sufficient, since it does not do proper handling of values that cannot
+    # be converted to enums.
+    #
+    # All enum types used in lib command parameters must be listed here!
+    **{
+        enum_type: _safe_enum_cast(enum_type)
+        for enum_type in [
+            types.CibRuleExpressionType,
+            types.CibRuleInEffectStatus,
+            types.CorosyncNodeAddressType,
+            types.CorosyncTransportType,
+            types.DrRole,
+            types.ResourceRelationType,
+            async_tasks_types.TaskFinishType,
+            async_tasks_types.TaskState,
+            async_tasks_types.TaskKillReason,
+            permissions_types.PermissionGrantedType,
+            permissions_types.PermissionTargetType,
+        ]
+    },
+    #
     # JSON does not support tuples, only lists. However, tuples are
     # used e.g. to express fixed-length structures. If a tuple is
     # expected and a list is provided, we convert it to a tuple.
@@ -250,22 +291,7 @@ def from_dict(
     return dacite.from_dict(
         data_class=cls,
         data=_convert_payload(cls, data),
-        # NOTE: all enum types has to be listed here in key cast
-        # see: https://github.com/konradhalas/dacite#casting
         config=dacite.Config(
-            cast=[
-                types.CibRuleExpressionType,
-                types.CibRuleInEffectStatus,
-                types.CorosyncNodeAddressType,
-                types.CorosyncTransportType,
-                types.DrRole,
-                types.ResourceRelationType,
-                async_tasks_types.TaskFinishType,
-                async_tasks_types.TaskState,
-                async_tasks_types.TaskKillReason,
-                permissions_types.PermissionGrantedType,
-                permissions_types.PermissionTargetType,
-            ],
             type_hooks=DTO_TYPE_HOOKS_MAP,
             strict=strict,
         ),

--- a/pcs/daemon/async_tasks/worker/executor.py
+++ b/pcs/daemon/async_tasks/worker/executor.py
@@ -185,7 +185,7 @@ def task_executor(task: WorkerCommand) -> None:
                 TaskFinished(TaskFinishType.FAIL, None),
             )
         )
-        logger.exception("Task %s raised a LibraryError.", task.task_ident)
+        logger.error("Task %s raised a LibraryError: %s.", task.task_ident, e)
         _pause_worker()
         return
     except Exception as e:  # pylint: disable=broad-except

--- a/pcs/daemon/async_tasks/worker/executor.py
+++ b/pcs/daemon/async_tasks/worker/executor.py
@@ -184,15 +184,9 @@ def task_executor(task: WorkerCommand) -> None:
                 command_dto.params,
                 strict=True,
             ).__dict__  # type: ignore
-        except dacite.DaciteError as e:
+        except (dacite.DaciteError, dto.PayloadConversionError) as e:
             # TODO: make custom message from exception without mentioning
             # dataclasses and fields
-            raise LibraryError(
-                reports.ReportItem.error(
-                    reports.messages.CommandInvalidPayload(str(e))
-                )
-            ) from e
-        except dto.PayloadConversionError as e:
             raise LibraryError(
                 reports.ReportItem.error(
                     reports.messages.CommandInvalidPayload(str(e))

--- a/pcs/daemon/async_tasks/worker/executor.py
+++ b/pcs/daemon/async_tasks/worker/executor.py
@@ -3,15 +3,8 @@ import inspect
 import multiprocessing as mp
 import os
 import signal
-from logging import (
-    Logger,
-    getLogger,
-)
-from typing import (
-    Any,
-    Tuple,
-    Union,
-)
+from logging import Logger, getLogger
+from typing import Any, Union
 
 import dacite
 
@@ -19,32 +12,18 @@ from pcs.common import reports
 from pcs.common.async_tasks.dto import CommandOptionsDto
 from pcs.common.async_tasks.types import TaskFinishType
 from pcs.common.interface import dto
-from pcs.lib.auth.tools import (
-    DesiredUser,
-    get_effective_user,
-)
+from pcs.lib.auth.tools import DesiredUser, get_effective_user
 from pcs.lib.auth.types import AuthUser
 from pcs.lib.env import LibraryEnvironment
 from pcs.lib.errors import LibraryError
 from pcs.lib.permissions.checker import PermissionsChecker
 from pcs.utils import read_known_hosts_file_not_cached
 
-from .command_mapping import (
-    COMMAND_MAP,
-    LEGACY_API_COMMANDS,
-)
+from .command_mapping import COMMAND_MAP, LEGACY_API_COMMANDS
 from .communicator import WorkerCommunicator
-from .logging import (
-    WORKER_LOGGER,
-    setup_worker_logger,
-)
+from .logging import WORKER_LOGGER, setup_worker_logger
 from .report_processor import WorkerReportProcessor
-from .types import (
-    Message,
-    TaskExecuted,
-    TaskFinished,
-    WorkerCommand,
-)
+from .types import Message, TaskExecuted, TaskFinished, WorkerCommand
 
 worker_com: WorkerCommunicator
 
@@ -234,7 +213,7 @@ def task_executor(task: WorkerCommand) -> None:
 
 def _param_to_field_tuple(
     param: inspect.Parameter,
-) -> Union[Tuple[str, Any], Tuple[str, Any, dataclasses.Field]]:
+) -> Union[tuple[str, Any], tuple[str, Any, dataclasses.Field]]:
     field_type = Any
     if param.annotation != inspect.Parameter.empty:
         field_type = param.annotation

--- a/pcs/daemon/async_tasks/worker/executor.py
+++ b/pcs/daemon/async_tasks/worker/executor.py
@@ -195,7 +195,7 @@ def task_executor(task: WorkerCommand) -> None:
         except dto.PayloadConversionError as e:
             raise LibraryError(
                 reports.ReportItem.error(
-                    reports.messages.CommandInvalidPayload("")
+                    reports.messages.CommandInvalidPayload(str(e))
                 )
             ) from e
 

--- a/pcs_test/tier0/common/interface/test_dto.py
+++ b/pcs_test/tier0/common/interface/test_dto.py
@@ -10,6 +10,7 @@ from dacite.exceptions import WrongTypeError
 import pcs
 from pcs.common.interface.dto import (
     DataTransferObject,
+    PayloadConversionError,
     from_dict,
     meta,
     to_dict,
@@ -66,6 +67,14 @@ class TypeHooksDto(DataTransferObject):
     list_of_tuple_str_str_str: list[tuple[str, str, str]]
     sequence_of_tuple_str_str: Sequence[tuple[str, str]]
     optional_tuple_str_str: Optional[tuple[str, str]]
+
+
+@dataclass
+class EnumDto(DataTransferObject):
+    field_a: CorosyncNodeAddressType
+    field_b: list[CorosyncNodeAddressType]
+    field_c: dict[str, CorosyncNodeAddressType]
+    field_d: Optional[CorosyncNodeAddressType]
 
 
 class DictName(TestCase):
@@ -184,6 +193,40 @@ class FromDictConversion(TestCase):
                 # misleading messages for type hook failures
                 with self.assertRaises(WrongTypeError):
                     from_dict(TypeHooksDto, payload)
+
+
+class FromDictEnumConversion(TestCase):
+    _VALID_PAYLOAD = dict(
+        field_a="IPv4",
+        field_b=["IPv6", "FQDN"],
+        field_c=dict(foo="unresolvable"),
+        field_d="IPv4",
+    )
+
+    def test_success_from_raw_values(self):
+        self.assertEqual(
+            EnumDto(
+                CorosyncNodeAddressType.IPV4,
+                [CorosyncNodeAddressType.IPV6, CorosyncNodeAddressType.FQDN],
+                {"foo": CorosyncNodeAddressType.UNRESOLVABLE},
+                CorosyncNodeAddressType.IPV4,
+            ),
+            from_dict(EnumDto, self._VALID_PAYLOAD),
+        )
+
+    def test_error_bad_value(self):
+        bad_values = dict(
+            field_a="bad value",
+            field_b=["IPv6", "bad value"],
+            field_c=dict(foo="bad value"),
+            field_d="bad value",
+        )
+
+        for field_name, bad_value in bad_values.items():
+            with self.subTest(field=field_name):
+                payload = {**self._VALID_PAYLOAD, field_name: bad_value}
+                with self.assertRaises(PayloadConversionError):
+                    from_dict(EnumDto, payload)
 
 
 @dataclass

--- a/pcs_test/tier0/common/interface/test_dto.py
+++ b/pcs_test/tier0/common/interface/test_dto.py
@@ -69,14 +69,6 @@ class TypeHooksDto(DataTransferObject):
     optional_tuple_str_str: Optional[tuple[str, str]]
 
 
-@dataclass
-class EnumDto(DataTransferObject):
-    field_a: CorosyncNodeAddressType
-    field_b: list[CorosyncNodeAddressType]
-    field_c: dict[str, CorosyncNodeAddressType]
-    field_d: Optional[CorosyncNodeAddressType]
-
-
 class DictName(TestCase):
     maxDiff = None
     simple_dto = MyDto1(1, 2, 3)
@@ -193,6 +185,14 @@ class FromDictConversion(TestCase):
                 # misleading messages for type hook failures
                 with self.assertRaises(WrongTypeError):
                     from_dict(TypeHooksDto, payload)
+
+
+@dataclass
+class EnumDto(DataTransferObject):
+    field_a: CorosyncNodeAddressType
+    field_b: list[CorosyncNodeAddressType]
+    field_c: dict[str, CorosyncNodeAddressType]
+    field_d: Optional[CorosyncNodeAddressType]
 
 
 class FromDictEnumConversion(TestCase):

--- a/pcs_test/tier0/daemon/async_tasks/test_command_mapping.py
+++ b/pcs_test/tier0/daemon/async_tasks/test_command_mapping.py
@@ -43,9 +43,7 @@ def _get_generic(annotation):
     return getattr(annotation, "__origin__", None)
 
 
-def _find_disallowed_types(
-    _type, allowed_types, hooked_generic_origins, _seen=None
-):
+def _find_disallowed_types(_type, allowed_types, _seen=None):
     if _seen is None:
         _seen = set()
     type_id = id(_type)
@@ -60,22 +58,15 @@ def _find_disallowed_types(
         if isinstance(_type, EnumType) and _type not in allowed_types:
             disallowed.add(_type)
     else:
-        # flag as disallowed if types' origin needs a hook but this specific
-        # instantiation does not have a type hook
-        # e.g. we found a tuple, that does not have explicit type hook, so
-        # we flag it as disallowed
+        # tuples apart from tuple with ellipsis must have explicit type hooks
         if (
-            generic in hooked_generic_origins
+            generic is tuple
             and Ellipsis not in get_args(_type)
             and _type not in allowed_types
         ):
             disallowed.add(_type)
         for arg in get_args(_type):
-            disallowed.update(
-                _find_disallowed_types(
-                    arg, allowed_types, hooked_generic_origins, _seen
-                )
-            )
+            disallowed.update(_find_disallowed_types(arg, allowed_types, _seen))
 
     if is_dataclass(_type):
         # resolve forward references in type hints, because type-detecting
@@ -84,10 +75,7 @@ def _find_disallowed_types(
         for field in fields(_type):
             disallowed.update(
                 _find_disallowed_types(
-                    type_hints[field.name],
-                    allowed_types,
-                    hooked_generic_origins,
-                    _seen,
+                    type_hints[field.name], allowed_types, _seen
                 )
             )
     return disallowed
@@ -113,11 +101,6 @@ class DaciteTypingCompatibilityTest(TestCase):
 
     def test_check_type_hooks_map_types_in_commands(self):
         allowed_types = set(DTO_TYPE_HOOKS_MAP.keys())
-        hooked_generic_origins = {
-            origin
-            for _type in allowed_types
-            if (origin := get_origin(_type)) is not None
-        }
         for cmd_name, cmd in COMMAND_MAP.items():
             for param in list(inspect.signature(cmd.cmd).parameters.values())[
                 1:
@@ -125,7 +108,7 @@ class DaciteTypingCompatibilityTest(TestCase):
                 if param.annotation == inspect.Parameter.empty:
                     continue
                 disallowed = _find_disallowed_types(
-                    param.annotation, allowed_types, hooked_generic_origins
+                    param.annotation, allowed_types
                 )
                 self.assertFalse(
                     disallowed,

--- a/pcs_test/tier0/daemon/async_tasks/test_command_mapping.py
+++ b/pcs_test/tier0/daemon/async_tasks/test_command_mapping.py
@@ -3,6 +3,7 @@ from dataclasses import (
     fields,
     is_dataclass,
 )
+from enum import EnumType
 from typing import (
     Container,
     Iterable,
@@ -42,7 +43,9 @@ def _get_generic(annotation):
     return getattr(annotation, "__origin__", None)
 
 
-def _find_disallowed_types(_type, allowed_types, hooked_origins, _seen=None):
+def _find_disallowed_types(
+    _type, allowed_types, hooked_generic_origins, _seen=None
+):
     if _seen is None:
         _seen = set()
     type_id = id(_type)
@@ -52,19 +55,28 @@ def _find_disallowed_types(_type, allowed_types, hooked_origins, _seen=None):
 
     disallowed = set()
     generic = get_origin(_type)
-    if (
-        generic in hooked_origins
-        and Ellipsis not in get_args(_type)
-        and _type not in allowed_types
-    ):
-        disallowed.add(_type)
-    if generic:
+
+    if generic is None:
+        if isinstance(_type, EnumType) and _type not in allowed_types:
+            disallowed.add(_type)
+    else:
+        # flag as disallowed if types' origin needs a hook but this specific
+        # instantiation does not have a type hook
+        # e.g. we found a tuple, that does not have explicit type hook, so
+        # we flag it as disallowed
+        if (
+            generic in hooked_generic_origins
+            and Ellipsis not in get_args(_type)
+            and _type not in allowed_types
+        ):
+            disallowed.add(_type)
         for arg in get_args(_type):
             disallowed.update(
                 _find_disallowed_types(
-                    arg, allowed_types, hooked_origins, _seen
+                    arg, allowed_types, hooked_generic_origins, _seen
                 )
             )
+
     if is_dataclass(_type):
         # resolve forward references in type hints, because type-detecting
         # functions do not work with forward references
@@ -72,7 +84,10 @@ def _find_disallowed_types(_type, allowed_types, hooked_origins, _seen=None):
         for field in fields(_type):
             disallowed.update(
                 _find_disallowed_types(
-                    type_hints[field.name], allowed_types, hooked_origins, _seen
+                    type_hints[field.name],
+                    allowed_types,
+                    hooked_generic_origins,
+                    _seen,
                 )
             )
     return disallowed
@@ -98,7 +113,11 @@ class DaciteTypingCompatibilityTest(TestCase):
 
     def test_check_type_hooks_map_types_in_commands(self):
         allowed_types = set(DTO_TYPE_HOOKS_MAP.keys())
-        hooked_origins = {get_origin(_type) for _type in allowed_types}
+        hooked_generic_origins = {
+            origin
+            for _type in allowed_types
+            if (origin := get_origin(_type)) is not None
+        }
         for cmd_name, cmd in COMMAND_MAP.items():
             for param in list(inspect.signature(cmd.cmd).parameters.values())[
                 1:
@@ -106,7 +125,7 @@ class DaciteTypingCompatibilityTest(TestCase):
                 if param.annotation == inspect.Parameter.empty:
                     continue
                 disallowed = _find_disallowed_types(
-                    param.annotation, allowed_types, hooked_origins
+                    param.annotation, allowed_types, hooked_generic_origins
                 )
                 self.assertFalse(
                     disallowed,


### PR DESCRIPTION
Closes #1095 

Curl command to test fix:
```
$ curl -k -X POST http://192.168.122.3:2224/remote/set_permissions \
    --unix-socket /var/run/pcsd.socket \
    --data-urlencode 'json_data={
      "permissions": {
        "0": {"name": "foo", "type": "user", "allow": {"BAD": "1"}}
      }
    }'
```

The fix also updates existing test to fail when APIv2 command uses Enum in parameters, and there is no dacite typehook for the Enum.