### PR TITLE
[pcs-0.11] fix tmt plan for centos-stream distro

### DIFF
--- a/plans.fmf
+++ b/plans.fmf
@@ -8,7 +8,7 @@ prepare:
   # https://docs.testing-farm.io/Testing%20Farm/0.1/test-environment.html#_tag_repository
   - name: Disable testing-farm RHEL repos that may contain packages of
           different versions than we want
-    when: distro == rhel
+    when: distro == rhel, centos-stream
     how: shell
     script:
       - |
@@ -21,14 +21,17 @@ prepare:
         done
 
   - name: Enable testing-farm HighAvailability RHEL repo
-    when: distro == rhel
+    when: distro == rhel, centos-stream
     how: shell
     script:
       - |
-        if dnf repolist --disabled -v |
-            grep "^Repo-id\s*:\s*rhel-HighAvailability$"; then
-          dnf config-manager --set-enabled rhel-HighAvailability
-        fi
+        for repo in rhel-HighAvailability \
+            highavailability; do
+          if dnf repolist --disabled -v |
+              grep "^Repo-id\s*:\s*${repo}$"; then
+            dnf config-manager --set-enabled "${repo}"
+          fi;
+        done
 
   - name: Install common packages required for pcs
     how: install
@@ -89,14 +92,14 @@ prepare:
       - booth-site
 
   - name: Install python3-pycurl system package
-    when: distro == fedora, rhel-9
+    when: distro == fedora, rhel-9, centos-stream-9
     how: install
     package:
       - python3-pycurl
 
   - name: Install dependencies for bundled python3-pycurl
     # autotools_rpmbuild also bundles pycurl on fedora
-    when: distro >= rhel-10, fedora
+    when: distro >= rhel-10, fedora, centos-stream-10
     how: install
     package:
       - libcurl
@@ -104,7 +107,7 @@ prepare:
       - openssl-devel
 
   - name: Install dependencies for bundled rubygem-ffi
-    when: distro == rhel-9, rhel-10
+    when: distro == rhel-9, rhel-10, centos-stream-10, centos-stream-9
     how: install
     package:
       - gcc
@@ -125,6 +128,17 @@ prepare:
       - rubygem-rack-test
       - rubygem-sinatra
       - rubygem-tilt
+
+  - name: Install corosync-qdevice-devel on CentOS-Stream-9
+    # required dependency for the rpm build on CentOS-Stream9 / RHEL-9.*
+    # provided by rhel-buildroot repository on RHEL-9.*
+    # missing in standard CentOS-Stream-9 repositories
+    # installing from 'testing-farm-tag-repository'
+    when: distro == centos-stream-9
+    how: shell
+    script:
+      - dnf install -y --enablerepo=testing-farm-tag-repository
+        corosync-qdevice-devel
 
 # https://tmt.readthedocs.io/en/stable/spec/plans.html#execute
 execute:


### PR DESCRIPTION


<!-- testing-farm = {"lock":"false","comment-id":"4353579692","data":[{"id":"a968ce50-886f-4486-9ab0-86bdffd49181","name":"CentOS-Stream-9","runTime":445.298327,"created":"2026-04-30T14:53:28.739361","updated":"2026-04-30T14:53:28.739367","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/a968ce50-886f-4486-9ab0-86bdffd49181\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a968ce50-886f-4486-9ab0-86bdffd49181/pipeline.log\">pipeline</a>"]}]} -->