### PR TITLE
ci: add check for the same repo PR for testing-farm-apikey env

### DIFF
--- a/.github/workflows/testing-farm.yml
+++ b/.github/workflows/testing-farm.yml
@@ -105,11 +105,12 @@ jobs:
         ))
 
     # Select environment using short-circuit evaluation. If the user who
-    # triggered the event has write access (owner or member), the
-    # "testing-farm-apikey" environment is selected, which does not require
-    # approval. Otherwise, the "testing-farm-approval" environment is
-    # selected, which requires manual approval. This is typically the case
-    # when the workflow is triggered by pull requests from forks.
+    # triggered the event has write access (owner or member) and the PR
+    # is from the same repository (not a fork), the "testing-farm-apikey"
+    # environment is selected, which does not require approval. Otherwise,
+    # the "testing-farm-approval" environment is selected, which requires
+    # manual approval. This is typically the case when the workflow is
+    # triggered by pull requests from forks.
     environment: >-
       ${{
         (
@@ -118,6 +119,8 @@ jobs:
         )
         || (
           github.event_name == 'pull_request_target'
+          && github.event.pull_request.head.repo.full_name
+            == github.repository
           && contains(
             fromJson('["OWNER", "MEMBER"]'),
             github.event.pull_request.author_association


### PR DESCRIPTION


<!-- testing-farm = {"lock":"false","comment-id":"4369614841","data":[{"id":"68b8d1ae-fea7-4a1a-94ac-253a909c6ffc","name":"CentOS-Stream-10","runTime":530.661679,"created":"2026-05-04T08:55:21.838518","updated":"2026-05-04T08:55:21.838524","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/68b8d1ae-fea7-4a1a-94ac-253a909c6ffc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/68b8d1ae-fea7-4a1a-94ac-253a909c6ffc/pipeline.log\">pipeline</a>"]}]} -->