### PR TITLE
 Update changelog and pcs_test/Makefile.am

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Fixed a crash in `pcs resource | stonith list` commands ([rhbz#2458608])
 - `pcs constraint config` (and its variants for each constraint type) now list
   resources in sets in the order defined in the CIB, instead of sorting them
-  alphabetically ([rhbz#2461143])
+  alphabetically ([rhbz#2461143]) ([RHEL-176475])
 
 ### Deprecated
 - Commands `pcs pcsd certkey` and `pcs pcsd sync-certificates` ([RHEL-149608])
@@ -31,6 +31,7 @@
 [RHEL-7604]: https://issues.redhat.com/browse/RHEL-7604
 [RHEL-84511]: https://issues.redhat.com/browse/RHEL-84511
 [RHEL-149608]: https://issues.redhat.com/browse/RHEL-149608
+[RHEL-176475]: https://redhat.atlassian.net/browse/RHEL-176475
 [rhbz#2458608]: https://bugzilla.redhat.com/show_bug.cgi?id=2458608
 [rhbz#2461143]: https://bugzilla.redhat.com/show_bug.cgi?id=2461143
 

--- a/pcs_test/Makefile.am
+++ b/pcs_test/Makefile.am
@@ -100,7 +100,9 @@ EXTRA_DIST		= \
 			  tier0/cli/constraint/__init__.py \
 			  tier0/cli/constraint/location/__init__.py \
 			  tier0/cli/constraint/location/test_command.py \
+			  tier0/cli/constraint/output/__init__.py \
 			  tier0/cli/constraint/output/test_all.py \
+			  tier0/cli/constraint/output/test_set.py \
 			  tier0/cli/constraint/test_command.py \
 			  tier0/cli/constraint/test_parse_args.py \
 			  tier0/cli/constraint_colocation/__init__.py \


### PR DESCRIPTION
PR https://github.com/ClusterLabs/pcs/pull/1123 did not introduce changes to `pcs_test/Makefile.am`. This PR fixes it. Also I updated changelog with Jira ticket.

<!-- testing-farm = {"lock":"false","comment-id":"4479584754","data":[{"id":"af1e1331-c319-48cc-886f-14a9b99a732c","name":"CentOS-Stream-10","runTime":536.445627,"created":"2026-05-18T16:03:22.206731","updated":"2026-05-18T16:03:22.206740","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/af1e1331-c319-48cc-886f-14a9b99a732c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/af1e1331-c319-48cc-886f-14a9b99a732c/pipeline.log\">pipeline</a>"]}]} -->