### PR TITLE
impove operations validation in pcs commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add validation for cluster name length. Corosync can not process too long
   names. The maximum length is set to 256 chars to prevent this error.
 - Add validation for operations in `pcs resource update`, `pcs resource op add`,
-  `pcs stonith update`, and `pcs stonith op add commands`. Operation names are
+  `pcs stonith update`, and `pcs stonith op add` commands. Operation names are
   now validated against agent metadata, and operation option values are also
   verified ([RHEL-169571])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   resource | stonith config` commands ([RHEL-7604])
 - Add validation for cluster name length. Corosync can not process too long
   names. The maximum length is set to 256 chars to prevent this error.
+- Add validation for operations in `pcs resource update`, `pcs resource op add`,
+  `pcs stonith update`, and `pcs stonith op add commands`. Operation names are
+  now validated against agent metadata, and operation option values are also
+  verified ([RHEL-169571])
 
 ### Fixed
 - Upgrade CIB schema version when creating a colocation constraint with
@@ -31,6 +35,7 @@
 [RHEL-7604]: https://issues.redhat.com/browse/RHEL-7604
 [RHEL-84511]: https://issues.redhat.com/browse/RHEL-84511
 [RHEL-149608]: https://issues.redhat.com/browse/RHEL-149608
+[RHEL-169571]: https://redhat.atlassian.net/browse/RHEL-169571
 [RHEL-176475]: https://redhat.atlassian.net/browse/RHEL-176475
 [rhbz#2458608]: https://bugzilla.redhat.com/show_bug.cgi?id=2458608
 [rhbz#2461143]: https://bugzilla.redhat.com/show_bug.cgi?id=2461143

--- a/pcs/lib/cib/resource/operations.py
+++ b/pcs/lib/cib/resource/operations.py
@@ -109,16 +109,16 @@ def prepare(
     allowed_operation_name_list -- operation names defined by a resource agent
     allow_invalid -- flag for validation skipping
     """
-    operations_to_validate = _operations_to_normalized(raw_operation_list)
+    operations_to_validate = operations_to_normalized(raw_operation_list)
 
     report_list: ReportItemList = []
     report_list.extend(
-        _validate_operation_list(
+        validate_operation_list(
             operations_to_validate, allowed_operation_name_list, allow_invalid
         )
     )
 
-    operation_list = _normalized_to_operations(
+    operation_list = normalized_to_operations(
         operations_to_validate, new_role_names_supported
     )
 
@@ -146,7 +146,7 @@ def prepare(
     ]
 
 
-def _operations_to_normalized(
+def operations_to_normalized(
     raw_operation_list: Iterable[ResourceOperationFilteredIn],
 ) -> List[validate.TypeOptionNormalizedMap]:
     return [
@@ -154,7 +154,7 @@ def _operations_to_normalized(
     ]
 
 
-def _normalized_to_operations(
+def normalized_to_operations(
     normalized_pairs: Iterable[validate.TypeOptionNormalizedMap],
     new_role_names_supported: bool,
 ) -> List[ResourceOperationFilteredOut]:
@@ -170,7 +170,7 @@ def _normalized_to_operations(
     ]
 
 
-def _validate_operation_list(
+def validate_operation_list(
     operation_list, allowed_operation_name_list, allow_invalid=False
 ):
     severity = reports.item.get_severity(reports.codes.FORCE, allow_invalid)
@@ -179,12 +179,21 @@ def _validate_operation_list(
     validators = [
         validate.NamesIn(ATTRIBUTES, option_type=option_type),
         validate.IsRequiredAll(["name"], option_type=option_type),
-        validate.ValueIn(
-            "name",
-            allowed_operation_name_list,
-            option_name_for_report="operation name",
-            severity=severity,
-        ),
+    ]
+    # None means agent metadata failed to load in pcs resource update or
+    # pcs resource op add - skip name validation for backward compatibility.
+    # pcs resource create always passes a list - empty for void agent when
+    # agent loading error is forced.
+    if allowed_operation_name_list is not None:
+        validators.append(
+            validate.ValueIn(
+                "name",
+                allowed_operation_name_list,
+                option_name_for_report="operation name",
+                severity=severity,
+            ),
+        )
+    validators += [
         validate.ValueIn("role", const.PCMK_ROLES),
         validate.ValueIn("on-fail", ON_FAIL_VALUES),
         validate.ValuePcmkBoolean("record-pending"),

--- a/pcs/lib/cib/resource/operations.py
+++ b/pcs/lib/cib/resource/operations.py
@@ -1,34 +1,18 @@
 from collections import defaultdict
 from dataclasses import replace as dt_replace
-from typing import (
-    Iterable,
-    List,
-    Optional,
-    Tuple,
-    cast,
-)
+from typing import Iterable, List, Optional, Tuple, cast
 
 from lxml import etree
 from lxml.etree import _Element
 
-from pcs.common import (
-    const,
-    pacemaker,
-    reports,
-)
+from pcs.common import const, pacemaker, reports
 from pcs.common.pacemaker.resource.operations import CibResourceOperationDto
-from pcs.common.reports import (
-    ReportItemList,
-    ReportProcessor,
-)
+from pcs.common.reports import ReportItemList, ReportProcessor
 from pcs.common.reports.item import ReportItem
 from pcs.common.tools import timeout_to_seconds
 from pcs.common.types import StringCollection
 from pcs.lib import validate
-from pcs.lib.cib import (
-    nvpair_multi,
-    rule,
-)
+from pcs.lib.cib import nvpair_multi, rule
 from pcs.lib.cib.nvpair import append_new_instance_attributes
 from pcs.lib.cib.resource.agent import (
     complete_operations_options,
@@ -171,19 +155,31 @@ def normalized_to_operations(
 
 
 def validate_operation_list(
-    operation_list, allowed_operation_name_list, allow_invalid=False
-):
+    operation_list: Iterable[validate.TypeOptionNormalizedMap],
+    allowed_operation_name_list: Optional[StringCollection],
+    allow_invalid: bool = False,
+) -> ReportItemList:
+    """
+    Validate given operation list and return a list of report items.
+
+    operation_list -- operations with normalized option names and values
+    allowed_operation_name_list -- operation names defined by a resource agent,
+        or None if agent metadata failed to load (in pcs resource update or
+        pcs resource op add). When None, operation name validation is skipped
+        for backward compatibility - the user should still be able to configure
+        operations even when the agent metadata is unavailable.
+        In pcs resource create, a list is always passed (empty for a void agent
+        when an agent loading error is forced).
+    allow_invalid -- if True, downgrade unknown operation name errors to
+        warnings (i.e. allow forcing)
+    """
     severity = reports.item.get_severity(reports.codes.FORCE, allow_invalid)
     option_type = "resource operation"
 
-    validators = [
+    validators: list[validate.ValidatorInterface] = [
         validate.NamesIn(ATTRIBUTES, option_type=option_type),
         validate.IsRequiredAll(["name"], option_type=option_type),
     ]
-    # None means agent metadata failed to load in pcs resource update or
-    # pcs resource op add - skip name validation for backward compatibility.
-    # pcs resource create always passes a list - empty for void agent when
-    # agent loading error is forced.
     if allowed_operation_name_list is not None:
         validators.append(
             validate.ValueIn(

--- a/pcs/resource.py
+++ b/pcs/resource.py
@@ -27,7 +27,7 @@ from pcs.cli.common.parse_args import (
 from pcs.cli.common.tools import print_to_stderr, timeout_to_seconds_legacy
 from pcs.cli.nvset import filter_out_expired_nvset, nvset_dto_list_to_lines
 from pcs.cli.reports import process_library_reports
-from pcs.cli.reports.output import error, warn
+from pcs.cli.reports.output import deprecation_warning, error, warn
 from pcs.cli.resource.common import check_is_not_stonith
 from pcs.cli.resource.output import (
     operation_defaults_to_cmd,
@@ -49,9 +49,8 @@ from pcs.common.pacemaker.defaults import CibDefaultsDto
 from pcs.common.pacemaker.resource.operations import (
     OCF_CHECK_LEVEL_INSTANCE_ATTRIBUTE_NAME,
 )
-from pcs.common.str_tools import format_list_custom_last_separator
 from pcs.lib.cib import const as cib_const
-from pcs.lib.cib.resource import guest_node, primitive
+from pcs.lib.cib.resource import guest_node, operations, primitive
 from pcs.lib.cib.tools import get_resources
 from pcs.lib.commands.resource import (
     _get_nodes_to_validate_against,
@@ -426,8 +425,37 @@ def resource_op_add(argv: Argv, modifiers: InputModifiers) -> None:
     if dom is None:
         dom = utils.get_cib_dom()
 
-    # add the requested operation
-    utils.replace_cib_configuration(resource_operation_add(dom, res_id, argv))
+    res_el = utils.dom_get_resource(dom, res_id)
+    if not res_el:
+        utils.err("Unable to find resource: %s" % res_id)
+
+    allowed_operation_name_list = None
+    agent_name = _get_resource_agent_name_from_rsc_el(res_el)
+    try:
+        agent_facade = _get_resource_agent_facade(agent_name)
+        allowed_operation_name_list = [
+            op.name for op in agent_facade.metadata.actions
+        ]
+    except lib_ra.ResourceAgentError as e:
+        # Do not fail with an error to keep backward compatibility.
+        # NOTE: Reconsider when moving operation commands to pcs.lib.
+        process_library_reports(
+            [
+                lib_ra.resource_agent_error_to_report_item(
+                    e,
+                    reports.ReportItemSeverity.warning(),
+                )
+            ]
+        )
+
+    utils.replace_cib_configuration(
+        resource_operation_add(
+            dom,
+            res_id,
+            argv,
+            allowed_operation_name_list=allowed_operation_name_list,
+        )
+    )
 
 
 def op_delete_cmd(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:
@@ -990,8 +1018,12 @@ def resource_update(args: Argv, modifiers: InputModifiers) -> None:  # noqa: PLR
     params = utils.convert_args_to_tuples(ra_values)
 
     agent_name = _get_resource_agent_name_from_rsc_el(resource)
+    allowed_operation_name_list = None
     try:
         agent_facade = _get_resource_agent_facade(agent_name)
+        allowed_operation_name_list = [
+            op.name for op in agent_facade.metadata.actions
+        ]
         report_list = primitive.validate_resource_instance_attributes_update(
             utils.cmd_runner(),
             agent_facade,
@@ -1106,6 +1138,7 @@ def resource_update(args: Argv, modifiers: InputModifiers) -> None:  # noqa: PLR
             op_argv,
             validate_strict=False,
             before_op=updating_op_before,
+            allowed_operation_name_list=allowed_operation_name_list,
         )
 
     utils.replace_cib_configuration(dom)
@@ -1189,7 +1222,12 @@ def transform_master_to_clone(master_element):
 
 
 def resource_operation_add(  # noqa: PLR0912, PLR0915
-    dom, res_id, argv, validate_strict=True, before_op=None
+    dom,
+    res_id,
+    argv,
+    validate_strict=True,
+    before_op=None,
+    allowed_operation_name_list=None,
 ):
     """
     Commandline options:
@@ -1210,35 +1248,6 @@ def resource_operation_add(  # noqa: PLR0912, PLR0915
 
     if "=" in op_name:
         utils.err("%s does not appear to be a valid operation action" % op_name)
-    if "--force" not in utils.pcs_options:
-        valid_attrs = [
-            "id",
-            "name",
-            "interval",
-            "description",
-            "start-delay",
-            "interval-origin",
-            "timeout",
-            "enabled",
-            "record-pending",
-            "role",
-            "on-fail",
-            OCF_CHECK_LEVEL_INSTANCE_ATTRIBUTE_NAME,
-        ]
-        for key, value in op_properties:
-            if key not in valid_attrs:
-                utils.err(
-                    "%s is not a valid op option (use --force to override)"
-                    % key
-                )
-            if key == "role" and value not in const.PCMK_ROLES:
-                utils.err(
-                    "role must be: {} (use --force to override)".format(
-                        format_list_custom_last_separator(
-                            const.PCMK_ROLES, " or "
-                        )
-                    )
-                )
 
     interval = None
     for key, val in op_properties:
@@ -1249,8 +1258,31 @@ def resource_operation_add(  # noqa: PLR0912, PLR0915
         interval = "60s" if op_name == "monitor" else "0s"
         op_properties.append(("interval", interval))
 
-    op_properties.sort(key=lambda a: a[0])
-    op_properties.insert(0, ("name", op_name))
+    op_dict = dict(op_properties)
+    if "name" in op_dict:
+        deprecation_warning(
+            "Specifying an operation name with 'name=<value>' syntax "
+            "is deprecated and might be removed in a future release. "
+            "Use the operation name as the first argument instead."
+        )
+    op_dict.setdefault("name", op_name)
+
+    normalized = operations.operations_to_normalized([op_dict])
+    report_list = operations.validate_operation_list(
+        normalized,
+        allowed_operation_name_list,
+        allow_invalid="--force" in utils.pcs_options,
+    )
+    if report_list:
+        process_library_reports(report_list)
+
+    new_role_names_supported = utils.isCibVersionSatisfied(
+        dom, const.PCMK_NEW_ROLES_CIB_VERSION
+    )
+    op_normalized = operations.normalized_to_operations(
+        normalized, new_role_names_supported
+    )[0]
+    op_properties = sorted(op_normalized.items())
 
     generate_id = True
     for name, value in op_properties:
@@ -1285,26 +1317,16 @@ def resource_operation_add(  # noqa: PLR0912, PLR0915
                 "id", utils.find_unique_id(dom, "-".join((op_id, key, val)))
             )
             attrib_el.appendChild(nvpair_el)
-        elif key == "role" and "--force" not in utils.pcs_options:
-            op_el.setAttribute(
-                key,
-                pacemaker.role.get_value_for_cib(
-                    val,
-                    utils.isCibVersionSatisfied(
-                        dom, const.PCMK_NEW_ROLES_CIB_VERSION
-                    ),
-                ),
-            )
         else:
             op_el.setAttribute(key, val)
 
-    operations = res_el.getElementsByTagName("operations")
-    if not operations:
-        operations = dom.createElement("operations")
-        res_el.appendChild(operations)
+    operations_el = res_el.getElementsByTagName("operations")
+    if not operations_el:
+        operations_el = dom.createElement("operations")
+        res_el.appendChild(operations_el)
     else:
-        operations = operations[0]
-        duplicate_op_list = utils.operation_exists(operations, op_el)
+        operations_el = operations_el[0]
+        duplicate_op_list = utils.operation_exists(operations_el, op_el)
         if duplicate_op_list:
             utils.err(
                 "operation %s with interval %ss already specified for %s:\n%s"
@@ -1319,7 +1341,7 @@ def resource_operation_add(  # noqa: PLR0912, PLR0915
             )
         if validate_strict and "--force" not in utils.pcs_options:
             duplicate_op_list = utils.operation_exists_by_name(
-                operations, op_el
+                operations_el, op_el
             )
             if duplicate_op_list:
                 msg = (
@@ -1339,7 +1361,7 @@ def resource_operation_add(  # noqa: PLR0912, PLR0915
                     )
                 )
 
-    operations.insertBefore(op_el, before_op)
+    operations_el.insertBefore(op_el, before_op)
     return dom
 
 

--- a/pcs/resource.py
+++ b/pcs/resource.py
@@ -1084,12 +1084,12 @@ def resource_update(args: Argv, modifiers: InputModifiers) -> None:  # noqa: PLR
         resource, utils.convert_args_to_tuples(meta_values)
     )
 
-    operations = resource.getElementsByTagName("operations")
-    if not operations:
-        operations = dom.createElement("operations")
-        resource.appendChild(operations)
+    operations_el = resource.getElementsByTagName("operations")
+    if not operations_el:
+        operations_el = dom.createElement("operations")
+        resource.appendChild(operations_el)
     else:
-        operations = operations[0]
+        operations_el = operations_el[0]
 
     get_role = partial(
         pacemaker.role.get_value_for_cib,
@@ -1120,7 +1120,7 @@ def resource_update(args: Argv, modifiers: InputModifiers) -> None:  # noqa: PLR
 
         updating_op = None
         updating_op_before = None
-        for existing_op in operations.getElementsByTagName("op"):
+        for existing_op in operations_el.getElementsByTagName("op"):
             if updating_op:
                 updating_op_before = existing_op
                 break
@@ -1249,23 +1249,16 @@ def resource_operation_add(  # noqa: PLR0912, PLR0915
     if "=" in op_name:
         utils.err("%s does not appear to be a valid operation action" % op_name)
 
-    interval = None
-    for key, val in op_properties:
-        if key == "interval":
-            interval = val
-            break
-    if not interval:
-        interval = "60s" if op_name == "monitor" else "0s"
-        op_properties.append(("interval", interval))
-
     op_dict = dict(op_properties)
     if "name" in op_dict:
+        # deprecated since pcs-0.12.3
         deprecation_warning(
             "Specifying an operation name with 'name=<value>' syntax "
             "is deprecated and might be removed in a future release. "
             "Use the operation name as the first argument instead."
         )
-    op_dict.setdefault("name", op_name)
+    else:
+        op_dict["name"] = op_name
 
     normalized = operations.operations_to_normalized([op_dict])
     report_list = operations.validate_operation_list(
@@ -1283,6 +1276,15 @@ def resource_operation_add(  # noqa: PLR0912, PLR0915
         normalized, new_role_names_supported
     )[0]
     op_properties = sorted(op_normalized.items())
+
+    interval = None
+    for key, val in op_properties:
+        if key == "interval":
+            interval = val
+            break
+    if not interval:
+        interval = "60s" if op_name == "monitor" else "0s"
+        op_properties.append(("interval", interval))
 
     generate_id = True
     for name, value in op_properties:

--- a/pcs_test/tier0/lib/cib/test_resource_operations.py
+++ b/pcs_test/tier0/lib/cib/test_resource_operations.py
@@ -297,12 +297,23 @@ class Normalize(TestCase):
 
 
 class ValidateOperation(TestCase):
-    def assert_operation_produces_report(self, operation, report_list):
+    _DEFAULT = object()
+
+    def assert_operation_produces_report(
+        self,
+        operation,
+        report_list,
+        allowed_operation_name_list=_DEFAULT,
+        allow_invalid=False,
+    ):
         # pylint: disable=no-self-use
+        if allowed_operation_name_list is self._DEFAULT:
+            allowed_operation_name_list = ["monitor"]
         assert_report_item_list_equal(
             operations.validate_operation_list(
                 [operation],
-                ["monitor"],
+                allowed_operation_name_list,
+                allow_invalid=allow_invalid,
             ),
             report_list,
         )
@@ -520,6 +531,44 @@ class ValidateOperation(TestCase):
                     None,
                 ),
             ],
+        )
+
+    def test_skip_name_validation_when_allowed_list_is_none(self):
+        self.assert_operation_produces_report(
+            {"name": "unknown_op"}, [], allowed_operation_name_list=None
+        )
+
+    def test_return_error_on_invalid_name_with_empty_allowed_list(self):
+        self.assert_operation_produces_report(
+            {"name": "monitor"},
+            [
+                fixture.error(
+                    report_codes.INVALID_OPTION_VALUE,
+                    force_code=report_codes.FORCE,
+                    option_value="monitor",
+                    option_name="operation name",
+                    allowed_values=[],
+                    cannot_be_empty=False,
+                    forbidden_characters=None,
+                ),
+            ],
+            allowed_operation_name_list=[],
+        )
+
+    def test_invalid_name_forced(self):
+        self.assert_operation_produces_report(
+            {"name": "unknown_op"},
+            [
+                fixture.warn(
+                    report_codes.INVALID_OPTION_VALUE,
+                    option_value="unknown_op",
+                    option_name="operation name",
+                    allowed_values=["monitor"],
+                    cannot_be_empty=False,
+                    forbidden_characters=None,
+                ),
+            ],
+            allow_invalid=True,
         )
 
 

--- a/pcs_test/tier0/lib/cib/test_resource_operations.py
+++ b/pcs_test/tier0/lib/cib/test_resource_operations.py
@@ -41,9 +41,9 @@ patch_operations = create_patcher("pcs.lib.cib.resource.operations")
 @patch_operations("_get_remaining_defaults")
 @patch_operations("complete_operations_options")
 @patch_operations("validate_different_intervals")
-@patch_operations("_validate_operation_list")
-@patch_operations("_normalized_to_operations")
-@patch_operations("_operations_to_normalized")
+@patch_operations("validate_operation_list")
+@patch_operations("normalized_to_operations")
+@patch_operations("operations_to_normalized")
 class Prepare(TestCase):
     def test_prepare(
         self,
@@ -299,9 +299,8 @@ class Normalize(TestCase):
 class ValidateOperation(TestCase):
     def assert_operation_produces_report(self, operation, report_list):
         # pylint: disable=no-self-use
-        # pylint: disable=protected-access
         assert_report_item_list_equal(
-            operations._validate_operation_list(
+            operations.validate_operation_list(
                 [operation],
                 ["monitor"],
             ),

--- a/pcs_test/tier1/cib_resource/test_operation_add.py
+++ b/pcs_test/tier1/cib_resource/test_operation_add.py
@@ -159,7 +159,9 @@ class OperationAdd(TestCase, get_assert_pcs_effect_mixin(get_cib_resources)):
         self.assert_pcs_fail(
             "resource op add R start timeout=30 requires=quorum".split(),
             (
-                "Error: requires is not a valid op option (use --force to "
-                "override)\n"
+                "Error: invalid resource operation option 'requires', allowed "
+                "options are: 'OCF_CHECK_LEVEL', 'description', 'enabled', "
+                "'id', 'interval', 'interval-origin', 'name', 'on-fail', "
+                "'record-pending', 'role', 'start-delay', 'timeout'\n"
             ),
         )

--- a/pcs_test/tier1/cib_resource/test_operation_add.py
+++ b/pcs_test/tier1/cib_resource/test_operation_add.py
@@ -165,3 +165,53 @@ class OperationAdd(TestCase, get_assert_pcs_effect_mixin(get_cib_resources)):
                 "'record-pending', 'role', 'start-delay', 'timeout'\n"
             ),
         )
+
+    def _invalid_operations(self, force=False):
+        forceable = "Warning" if force else "Error"
+        force_opt = "--force" if force else ""
+        use_force = ", use --force to override" if not force else ""
+
+        self.assert_pcs_fail(
+            (
+                "resource op add R status "
+                "id=ab#cd enabled=invalid-bool interval=invalid-number "
+                "interval-origin=value name=status on-fail=invalid-on-fail "
+                "record-pending=invalid-bool role=invalid-role "
+                f"start-delay=value timeout=invalid-timeout {force_opt}"
+            ).split(),
+            (
+                "Deprecation Warning: Specifying an operation name with "
+                "'name=<value>' syntax is deprecated and might be removed in a "
+                "future release. Use the operation name as the first argument "
+                "instead.\n"
+                f"{forceable}: 'status' is not a valid operation name value, "
+                "use 'meta-data', 'migrate_from', 'migrate_to', 'monitor', "
+                "'reload', 'reload-agent', 'start', 'stop', 'validate-all'"
+                f"{use_force}\n"
+                "Error: 'invalid-role' is not a valid role value, use "
+                "'Promoted', 'Started', 'Stopped', 'Unpromoted'\n"
+                "Error: 'invalid-on-fail' is not a valid on-fail value, use "
+                "'block', 'demote', 'fence', 'ignore', 'restart', "
+                "'restart-container', 'standby', 'stop'\n"
+                "Error: 'invalid-bool' is not a valid record-pending value, "
+                "use a pacemaker boolean value: '0', '1', 'false', 'n', 'no', "
+                "'off', 'on', 'true', 'y', 'yes'\n"
+                "Error: 'invalid-bool' is not a valid enabled value, use a "
+                "pacemaker boolean value: '0', '1', 'false', 'n', 'no', 'off', "
+                "'on', 'true', 'y', 'yes'\n"
+                "Error: Only one of resource operation options "
+                "'interval-origin' and 'start-delay' can be used\n"
+                "Error: invalid operation id 'ab#cd', '#' is not a valid "
+                "character for a operation id\n"
+                "Error: 'invalid-number' is not a valid interval value, use "
+                "time interval (e.g. 1, 2s, 3m, 4h, ...)\n"
+                "Error: 'invalid-timeout' is not a valid timeout value, use "
+                "time interval (e.g. 1, 2s, 3m, 4h, ...)\n"
+            ),
+        )
+
+    def test_invalid_operations(self):
+        self._invalid_operations(force=False)
+
+    def test_invalid_operations_force(self):
+        self._invalid_operations(force=True)

--- a/pcs_test/tier1/cib_resource/test_update.py
+++ b/pcs_test/tier1/cib_resource/test_update.py
@@ -14,6 +14,7 @@ from pcs_test.tools.fixture_cib import modify_cib_file
 from pcs_test.tools.misc import (
     get_test_resource,
     get_tmp_file,
+    skip_unless_pacemaker_supports_op_onfail_demote,
     write_data_to_tmpfile,
 )
 from pcs_test.tools.pcs_runner import PcsRunner
@@ -263,3 +264,418 @@ class ResourceMetaBundle(ResourceMetaBaseMixin, TestCase):
 
     def test_invalid_attribute(self):
         self._invalid_attribute(warning_message=self.bundle_clone_meta_warning)
+
+
+def fixture_instance_attrs(parent_id, *nvpairs):
+    nvpairs_xml = "\n".join(
+        f'<nvpair id="{parent_id}-{name}-{value}" name="{name}" value="{value}"/>'
+        for name, value in nvpairs
+    )
+    return dedent(
+        f"""\
+        <instance_attributes id="params-{parent_id}">
+            {nvpairs_xml}
+        </instance_attributes>"""
+    )
+
+
+def fixture_op(  # noqa: PLR0913
+    op_id,
+    name,
+    interval,
+    description=None,
+    enabled=None,
+    inner_xml="",
+    interval_origin=None,
+    on_fail=None,
+    record_pending=None,
+    role=None,
+    start_delay=None,
+    timeout=None,
+):
+    attrs = [
+        f'id="{op_id}"',
+        f'interval="{interval}"',
+        f'name="{name}"',
+    ]
+    if description:
+        attrs.append(f'description="{description}"')
+    if enabled:
+        attrs.append(f'enabled="{enabled}"')
+    if interval_origin:
+        attrs.append(f'interval-origin="{interval_origin}"')
+    if on_fail:
+        attrs.append(f'on-fail="{on_fail}"')
+    if record_pending:
+        attrs.append(f'record-pending="{record_pending}"')
+    if role:
+        attrs.append(f'role="{role}"')
+    if start_delay:
+        attrs.append(f'start-delay="{start_delay}"')
+    if timeout:
+        attrs.append(f'timeout="{timeout}"')
+    if inner_xml:
+        return f"<op {' '.join(attrs)}>\n{inner_xml}\n</op>"
+    return f"<op {' '.join(attrs)}/>"
+
+
+def fixture_operations(*ops_xml):
+    ops = "\n".join(ops_xml)
+    return f"""
+        <operations>
+          {ops}
+        </operations>
+    """
+
+
+FIXTURE_EXISTING_OP_MONITOR = fixture_op(
+    "R-monitor-interval-10s",
+    "monitor",
+    "10s",
+    timeout="20s",
+    on_fail="restart",
+    enabled="1",
+)
+FIXTURE_EXISTING_OP_RELOAD = fixture_op(
+    "R-restart-interval-10s", "reload", "10s", timeout="20s", role="Started"
+)
+FIXTURE_EXISTING_OP_CIB = fixture_resources(
+    fixture_primitive(
+        "R",
+        inner_xml=fixture_operations(
+            FIXTURE_EXISTING_OP_MONITOR,
+            FIXTURE_EXISTING_OP_RELOAD,
+        ),
+    )
+)
+
+
+class ResourceUpdateOperations(
+    TestCase, get_assert_pcs_effect_mixin(get_cib_resources)
+):
+    def setUp(self):
+        self.temp_cib = get_tmp_file("tier1_test_resource_update_operations")
+        self.pcs_runner = PcsRunner(self.temp_cib.name)
+        self.pcs_runner.mock_settings = get_mock_settings()
+        write_data_to_tmpfile(
+            modify_cib_file(
+                get_test_resource("cib-empty.xml"),
+                resources=FIXTURE_EXISTING_OP_CIB,
+            ),
+            self.temp_cib,
+        )
+
+    def tearDown(self):
+        self.temp_cib.close()
+
+    def _fixture_primitive_with_ops(self, *ops_xml):
+        return fixture_resources(
+            fixture_primitive("R", inner_xml=fixture_operations(*ops_xml))
+        )
+
+    def test_no_op_args(self):
+        self.assert_effect(
+            "resource update R op".split(),
+            FIXTURE_EXISTING_OP_CIB,
+        )
+
+    def test_op_name_only(self):
+        self.assert_effect(
+            "resource update R op monitRO".split(),
+            FIXTURE_EXISTING_OP_CIB,
+        )
+
+    def test_add_single_operation(self):
+        self.assert_effect(
+            "resource update R op start interval=20s".split(),
+            self._fixture_primitive_with_ops(
+                FIXTURE_EXISTING_OP_MONITOR,
+                FIXTURE_EXISTING_OP_RELOAD,
+                fixture_op("R-start-interval-20s", "start", "20s"),
+            ),
+        )
+
+    def test_update_existing_operation_not_specified_options_are_deleted(self):
+        self.assert_effect(
+            (
+                "resource update R op monitor interval=10s timeout=30s "
+                "description=desc"
+            ).split(),
+            self._fixture_primitive_with_ops(
+                fixture_op(
+                    "R-monitor-interval-10s",
+                    "monitor",
+                    "10s",
+                    timeout="30s",
+                    description="desc",
+                ),
+                FIXTURE_EXISTING_OP_RELOAD,
+            ),
+        )
+
+    def test_update_existing_operation_add_role_fails(self):
+        self.assert_pcs_fail(
+            (
+                "resource update R op monitor interval=10s timeout=20s "
+                "role=Started"
+            ).split(),
+            (
+                "Error: operation monitor with interval 10s already specified"
+                " for R:\n"
+                "monitor enabled=1 interval=10s on-fail=restart timeout=20s "
+                "(R-monitor-interval-10s)\n"
+            ),
+        )
+        self.assert_resources_xml_in_cib(FIXTURE_EXISTING_OP_CIB)
+
+    def test_update_existing_op_with_role_without_specifying_role_fails(self):
+        self.assert_pcs_fail(
+            (
+                "resource update R op reload interval=10s timeout=30s "
+                "description=desc"
+            ).split(),
+            (
+                "Error: operation reload with interval 10s already specified"
+                " for R:\n"
+                "reload interval=10s role=Started timeout=20s "
+                "(R-restart-interval-10s)\n"
+            ),
+        )
+        self.assert_resources_xml_in_cib(FIXTURE_EXISTING_OP_CIB)
+
+    def test_update_existing_operation_with_role_success(self):
+        self.assert_effect(
+            (
+                "resource update R op reload interval=10s timeout=30s "
+                "role=Started description=desc"
+            ).split(),
+            self._fixture_primitive_with_ops(
+                FIXTURE_EXISTING_OP_MONITOR,
+                fixture_op(
+                    "R-reload-interval-10s",
+                    "reload",
+                    "10s",
+                    timeout="30s",
+                    role="Started",
+                    description="desc",
+                ),
+            ),
+        )
+
+    def test_update_existing_add_new(self):
+        self.assert_effect(
+            (
+                "resource update R op monitor interval=5s start interval=0 "
+                "timeout=20 "
+            ).split(),
+            self._fixture_primitive_with_ops(
+                fixture_op("R-monitor-interval-5s", "monitor", "5s"),
+                FIXTURE_EXISTING_OP_RELOAD,
+                fixture_op("R-start-interval-0", "start", "0", timeout="20"),
+            ),
+        )
+
+    def test_same_operation_different_interval_same_role(self):
+        self.assert_effect(
+            (
+                "resource update R op meta-data interval=10 timeout=20 "
+                "enabled=1 meta-data interval=20 timeout=30"
+            ).split(),
+            self._fixture_primitive_with_ops(
+                FIXTURE_EXISTING_OP_MONITOR,
+                FIXTURE_EXISTING_OP_RELOAD,
+                fixture_op(
+                    "R-meta-data-interval-20", "meta-data", "20", timeout="30"
+                ),
+            ),
+        )
+
+    def test_same_operation_different_interval_different_role(self):
+        self.assert_effect(
+            (
+                "resource update R op meta-data interval=10 timeout=20 "
+                "enabled=1 meta-data interval=20 timeout=30 role=Stopped"
+            ).split(),
+            self._fixture_primitive_with_ops(
+                FIXTURE_EXISTING_OP_MONITOR,
+                FIXTURE_EXISTING_OP_RELOAD,
+                fixture_op(
+                    "R-meta-data-interval-10",
+                    "meta-data",
+                    "10",
+                    timeout="20",
+                    enabled="1",
+                ),
+                fixture_op(
+                    "R-meta-data-interval-20",
+                    "meta-data",
+                    "20",
+                    timeout="30",
+                    role="Stopped",
+                ),
+            ),
+        )
+
+    def test_duplicate_op_id(self):
+        self.assert_pcs_fail_regardless_of_force(
+            "resource update R op monitor interval=30 id=R".split(),
+            "Error: id 'R' is already in use, please specify another one\n",
+        )
+        self.assert_resources_xml_in_cib(FIXTURE_EXISTING_OP_CIB)
+
+    def _invalid_operations(self, force=False):
+        forceable = "Warning" if force else "Error"
+        force_opt = "--force" if force else ""
+        use_force = ", use --force to override" if not force else ""
+
+        self.assert_pcs_fail(
+            (
+                "resource update R op monitor interval=5s "
+                "status id=ab#cd enabled=invalid-bool interval=invalid-number "
+                "interval-origin=value name=status on-fail=invalid-on-fail "
+                "record-pending=invalid-bool role=invalid-role "
+                f"start-delay=value timeout=invalid-timeout {force_opt}"
+            ).split(),
+            (
+                "Deprecation Warning: Specifying an operation name with "
+                "'name=<value>' syntax is deprecated and might be removed in a "
+                "future release. Use the operation name as the first argument "
+                "instead.\n"
+                f"{forceable}: 'status' is not a valid operation name value, "
+                "use 'meta-data', 'migrate_from', 'migrate_to', 'monitor', "
+                "'reload', 'reload-agent', 'start', 'stop', 'validate-all'"
+                f"{use_force}\n"
+                "Error: 'invalid-role' is not a valid role value, use "
+                "'Promoted', 'Started', 'Stopped', 'Unpromoted'\n"
+                "Error: 'invalid-on-fail' is not a valid on-fail value, use "
+                "'block', 'demote', 'fence', 'ignore', 'restart', "
+                "'restart-container', 'standby', 'stop'\n"
+                "Error: 'invalid-bool' is not a valid record-pending value, "
+                "use a pacemaker boolean value: '0', '1', 'false', 'n', 'no', "
+                "'off', 'on', 'true', 'y', 'yes'\n"
+                "Error: 'invalid-bool' is not a valid enabled value, use a "
+                "pacemaker boolean value: '0', '1', 'false', 'n', 'no', 'off', "
+                "'on', 'true', 'y', 'yes'\n"
+                "Error: Only one of resource operation options "
+                "'interval-origin' and 'start-delay' can be used\n"
+                "Error: invalid operation id 'ab#cd', '#' is not a valid "
+                "character for a operation id\n"
+                "Error: 'invalid-number' is not a valid interval value, use "
+                "time interval (e.g. 1, 2s, 3m, 4h, ...)\n"
+                "Error: 'invalid-timeout' is not a valid timeout value, use "
+                "time interval (e.g. 1, 2s, 3m, 4h, ...)\n"
+            ),
+        )
+        self.assert_resources_xml_in_cib(FIXTURE_EXISTING_OP_CIB)
+
+    def test_invalid_operations(self):
+        self._invalid_operations(force=False)
+
+    def test_invalid_operations_force(self):
+        self._invalid_operations(force=True)
+
+    def test_add_operation_with_ocf_check_level(self):
+        self.assert_effect(
+            "resource update R op monitor OCF_CHECK_LEVEL=1".split(),
+            self._fixture_primitive_with_ops(
+                fixture_op(
+                    "R-monitor-interval-60s",
+                    "monitor",
+                    "60s",
+                    inner_xml=fixture_instance_attrs(
+                        "R-monitor-interval-60s",
+                        ("OCF_CHECK_LEVEL", "1"),
+                    ),
+                ),
+                FIXTURE_EXISTING_OP_RELOAD,
+            ),
+        )
+
+    @skip_unless_pacemaker_supports_op_onfail_demote()
+    def test_add_operation_onfail_demote_upgrade_cib(self):
+        write_data_to_tmpfile(
+            modify_cib_file(
+                get_test_resource("cib-empty-3.3.xml"),
+                resources=FIXTURE_EXISTING_OP_CIB,
+            ),
+            self.temp_cib,
+        )
+        self.assert_effect(
+            "resource update R op start on-fail=demote".split(),
+            self._fixture_primitive_with_ops(
+                FIXTURE_EXISTING_OP_MONITOR,
+                FIXTURE_EXISTING_OP_RELOAD,
+                fixture_op(
+                    "R-start-interval-0s",
+                    "start",
+                    "0s",
+                    on_fail="demote",
+                ),
+            ),
+            stderr_full="Cluster CIB has been upgraded to latest version\n",
+        )
+
+    def test_duplicate_operation_same_interval(self):
+        fixture_cib = fixture_resources(
+            fixture_primitive(
+                "R",
+                inner_xml=fixture_operations(
+                    fixture_op(
+                        "R-monitor-interval-10",
+                        "monitor",
+                        "10",
+                    ),
+                    fixture_op(
+                        "R-monitor-interval-20",
+                        "monitor",
+                        "20",
+                    ),
+                ),
+            )
+        )
+        write_data_to_tmpfile(
+            modify_cib_file(
+                get_test_resource("cib-empty.xml"),
+                resources=fixture_cib,
+            ),
+            self.temp_cib,
+        )
+        self.assert_pcs_fail(
+            "resource update R op monitor interval=20".split(),
+            (
+                "Error: operation monitor with interval 20s already specified"
+                " for R:\n"
+                "monitor interval=20 (R-monitor-interval-20)\n"
+            ),
+        )
+        self.assert_resources_xml_in_cib(fixture_cib)
+
+
+class ResourceUpdateCloneOperations(
+    TestCase, get_assert_pcs_effect_mixin(get_cib_resources)
+):
+    def setUp(self):
+        self.temp_cib = get_tmp_file(
+            "tier1_test_resource_update_clone_operations"
+        )
+        self.pcs_runner = PcsRunner(self.temp_cib.name)
+        self.pcs_runner.mock_settings = get_mock_settings()
+        write_data_to_tmpfile(
+            modify_cib_file(
+                get_test_resource("cib-empty.xml"),
+                resources=fixture_resources(fixture_clone("R-clone")),
+            ),
+            self.temp_cib,
+        )
+
+    def tearDown(self):
+        self.temp_cib.close()
+
+    def test_clone_rejects_op_keyword(self):
+        self.assert_pcs_fail(
+            "resource update R-clone op monitor interval=20s".split(),
+            stderr_full=(
+                "Error: op settings must be changed on base resource,"
+                " not the clone\n"
+            ),
+        )

--- a/pcs_test/tier1/legacy/test_resource.py
+++ b/pcs_test/tier1/legacy/test_resource.py
@@ -8,7 +8,6 @@ from pcs import resource, utils
 from pcs.common import const
 from pcs.common.str_tools import (
     format_list,
-    format_list_custom_last_separator,
     format_plural,
 )
 from pcs.constraint import LOCATION_NODE_VALIDATION_SKIP_MSG
@@ -719,10 +718,6 @@ class Resource(TestCase, AssertPcsMixin):
         )
 
         self.assert_pcs_success(
-            "resource op add state monitor interval=15 role=Master --force".split()
-        )
-
-        self.assert_pcs_success(
             "resource config state".split(),
             dedent(
                 f"""\
@@ -732,8 +727,6 @@ class Resource(TestCase, AssertPcsMixin):
                       interval=10s timeout=20s role={const.PCMK_ROLE_PROMOTED}
                     monitor: state-monitor-interval-11s
                       interval=11s timeout=20s role={const.PCMK_ROLE_UNPROMOTED}
-                    monitor: state-monitor-interval-15
-                      interval=15 role={const.PCMK_ROLE_PROMOTED}
                 """
             ),
         )
@@ -1172,8 +1165,8 @@ class Resource(TestCase, AssertPcsMixin):
 
         self.assert_pcs_fail(
             "resource update B op monitor interval=100 role=Master".split(),
-            "Error: role must be: {} (use --force to override)\n".format(
-                format_list_custom_last_separator(const.PCMK_ROLES, " or ")
+            "Error: 'Master' is not a valid role value, use {}\n".format(
+                format_list(const.PCMK_ROLES)
             ),
         )
 
@@ -2552,7 +2545,12 @@ class Resource(TestCase, AssertPcsMixin):
 
         self.assert_pcs_fail(
             "resource update B ocf:pcsmock:minimal op monitor interval=30s blah=blah".split(),
-            "Error: blah is not a valid op option (use --force to override)\n",
+            (
+                "Error: invalid resource operation option 'blah', allowed "
+                "options are: 'OCF_CHECK_LEVEL', 'description', 'enabled', "
+                "'id', 'interval', 'interval-origin', 'name', 'on-fail', "
+                "'record-pending', 'role', 'start-delay', 'timeout'\n"
+            ),
         )
 
         self.assert_pcs_success(
@@ -2561,13 +2559,18 @@ class Resource(TestCase, AssertPcsMixin):
 
         self.assert_pcs_fail(
             "resource op add C monitor interval=30s blah=blah".split(),
-            "Error: blah is not a valid op option (use --force to override)\n",
+            (
+                "Error: invalid resource operation option 'blah', allowed "
+                "options are: 'OCF_CHECK_LEVEL', 'description', 'enabled', "
+                "'id', 'interval', 'interval-origin', 'name', 'on-fail', "
+                "'record-pending', 'role', 'start-delay', 'timeout'\n"
+            ),
         )
 
         self.assert_pcs_fail(
             "resource op add C monitor interval=60 role=role".split(),
-            "Error: role must be: {} (use --force to override)\n".format(
-                format_list_custom_last_separator(const.PCMK_ROLES, " or ")
+            "Error: 'role' is not a valid role value, use {}\n".format(
+                format_list(const.PCMK_ROLES)
             ),
         )
 
@@ -2589,16 +2592,13 @@ class Resource(TestCase, AssertPcsMixin):
 
         self.assert_pcs_fail(
             "resource update B op monitor interval=30s monitor interval=31s role=Master".split(),
-            "Error: role must be: {} (use --force to override)\n".format(
-                format_list_custom_last_separator(const.PCMK_ROLES, " or ")
+            "Error: 'Master' is not a valid role value, use {}\n".format(
+                format_list(const.PCMK_ROLES)
             ),
         )
 
-        self.assert_pcs_fail(
+        self.assert_pcs_success(
             "resource update B op monitor interval=30s monitor interval=31s role=promoted".split(),
-            "Error: role must be: {} (use --force to override)\n".format(
-                format_list_custom_last_separator(const.PCMK_ROLES, " or ")
-            ),
         )
 
         self.assert_pcs_success(

--- a/pcsd/capabilities.xml.in
+++ b/pcsd/capabilities.xml.in
@@ -1786,17 +1786,6 @@
         pcs commands: resource op add
       </description>
     </capability>
-    <capability id="pcmk.resource.update-operations.validation" in-pcs="1" in-pcsd="0">
-      <description>
-        Validation of operation name based on agent metadata and options values.
-
-        pcs commands:
-          resource update
-          resource op add
-          stonith update
-          stonith op add
-      </description>
-    </capability>
 
     <capability id="pcmk.resource.group" in-pcs="1" in-pcsd="1">
       <description>

--- a/pcsd/capabilities.xml.in
+++ b/pcsd/capabilities.xml.in
@@ -1786,6 +1786,17 @@
         pcs commands: resource op add
       </description>
     </capability>
+    <capability id="pcmk.resource.update-operations.validation" in-pcs="1" in-pcsd="0">
+      <description>
+        Validation of operation name based on agent metadata and options values.
+
+        pcs commands:
+          resource update
+          resource op add
+          stonith update
+          stonith op add
+      </description>
+    </capability>
 
     <capability id="pcmk.resource.group" in-pcs="1" in-pcsd="1">
       <description>


### PR DESCRIPTION


<!-- testing-farm = {"lock":"false","comment-id":"4577827958","data":[{"id":"50891a5d-46c3-47ff-b016-0539c5e11e9a","name":"CentOS-Stream-10","runTime":519.805066,"created":"2026-05-29T16:58:11.883417","updated":"2026-05-29T16:58:11.883423","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/50891a5d-46c3-47ff-b016-0539c5e11e9a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/50891a5d-46c3-47ff-b016-0539c5e11e9a/pipeline.log\">pipeline</a>"]}]} -->