### PR TITLE
fix permissions for get_cibsecrets command

### DIFF
--- a/pcs/daemon/async_tasks/worker/command_mapping.py
+++ b/pcs/daemon/async_tasks/worker/command_mapping.py
@@ -441,7 +441,7 @@ COMMAND_MAP: Mapping[str, _Cmd] = {
     ),
     "resource.get_cibsecrets": _Cmd(
         cmd=resource.get_cibsecrets,
-        required_permission=p.READ,
+        required_permission=p.SUPERUSER,
     ),
     "resource.get_configured_resources": _Cmd(
         cmd=resource.get_configured_resources,


### PR DESCRIPTION


<!-- testing-farm = {"lock":"false","comment-id":"4613858896","data":[{"id":"a813e18a-60a5-4365-b381-40027f06ae43","name":"CentOS-Stream-10","runTime":593.318377,"created":"2026-06-03T15:01:08.425069","updated":"2026-06-03T15:01:08.425076","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/a813e18a-60a5-4365-b381-40027f06ae43\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a813e18a-60a5-4365-b381-40027f06ae43/pipeline.log\">pipeline</a>"]}]} -->