### PR TITLE
fix resource update validation with cibsecret values

### DIFF
--- a/pcs/cli/resource/output.py
+++ b/pcs/cli/resource/output.py
@@ -16,7 +16,10 @@ from pcs.cli.nvset import nvset_dto_to_lines
 from pcs.cli.reports.output import warn
 from pcs.cli.resource_agent import is_stonith
 from pcs.common import resource_agent
-from pcs.common.pacemaker.cibsecret import CibResourceSecretListDto
+from pcs.common.pacemaker.cibsecret import (
+    CIBSECRET_MARK_VALUE,
+    CibResourceSecretListDto,
+)
 from pcs.common.pacemaker.defaults import CibDefaultsDto
 from pcs.common.pacemaker.nvset import CibNvsetDto
 from pcs.common.pacemaker.resource.bundle import (
@@ -319,12 +322,11 @@ class ResourcesConfigurationFacade:
             CibResourceBundleDto,
         ],
     ) -> dict[str, dict[str, Optional[str]]]:
-        _CIBSECRET_MARK_VALUE = "lrm://"
         return {
             resource_dto.id: {
                 nvpair_dto.name: None
                 for nvpair_dto in resource_dto.instance_attributes[0].nvpairs
-                if nvpair_dto.value == _CIBSECRET_MARK_VALUE
+                if nvpair_dto.value == CIBSECRET_MARK_VALUE
             }
             for resource_dto in resource_dtos
             if resource_dto.instance_attributes

--- a/pcs/common/pacemaker/cibsecret.py
+++ b/pcs/common/pacemaker/cibsecret.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
+from typing import Final
 
 from pcs.common.interface.dto import DataTransferObject
+
+CIBSECRET_MARK_VALUE: Final = "lrm://"
 
 
 @dataclass(frozen=True)

--- a/pcs/lib/pacemaker/live.py
+++ b/pcs/lib/pacemaker/live.py
@@ -2,18 +2,14 @@ import os.path
 import re
 from hashlib import md5
 from pathlib import Path
-from typing import (
-    Mapping,
-    Optional,
-    Union,
-    cast,
-)
+from typing import Mapping, Optional, Union, cast
 
 from lxml import etree
 from lxml.etree import _Element
 
 from pcs import settings
 from pcs.common import reports
+from pcs.common.pacemaker.cibsecret import CIBSECRET_MARK_VALUE
 from pcs.common.reports import ReportProcessor
 from pcs.common.reports.item import ReportItem
 from pcs.common.str_tools import join_multilines
@@ -1119,16 +1115,46 @@ def validate_resource_instance_attributes_via_pcmk(
     resource_agent_name: ResourceAgentName,
     instance_attributes: Mapping[str, str],
 ) -> tuple[Optional[bool], str]:
+    # If CIBSECRET_MARK_VALUE is passed to the validation, then the validation
+    # fails to run, because pacemaker tries to load the secret value and fails.
+    # To read the secret value, pacemaker needs to know the resource ID. But
+    # the pacemaker tool doesn't accept resource ID as an input in case of
+    # instance attributes validation.
+    #
+    # We cannot load the real secret value and pass it to the validation
+    # either, as that could leak the value in debug output, error messages, or
+    # logs. We cannot omit it either, as that would produce false results in
+    # case it is a mandatory parameter.
+    #
+    # Loading a secret value is only accessible to root user. To read it here,
+    # this code would need to run with root privileges, i.e. in the pcsd
+    # process, which is not currently the case.
+    #
+    # To work around this, we replace CIBSECRET_MARK_VALUE with an arbitrary
+    # string to prevent pacemaker from loading the secret value and failing.
+    #
+    # Passing this arbitrary value is suboptimal, as it may produce false
+    # validation results. On the other hand, the validation is currently on a
+    # best-effort basis (agents are not ready to be used like this, yet) and it
+    # produces merely warnings, not errors.
+    #
+    # This only matters to resource update commands. Resource create commands
+    # are not affected - the resource is just being created, it is not possible
+    # for it to have secret values already defined.
+    instance_attributes_modified = {
+        key: "secret-value" if value == CIBSECRET_MARK_VALUE else value
+        for key, value in instance_attributes.items()
+    }
     if resource_agent_name.is_stonith:
         return _validate_stonith_instance_attributes_via_pcmk(
             cmd_runner,
             resource_agent_name,
-            instance_attributes,
+            instance_attributes_modified,
         )
     return _validate_resource_instance_attributes_via_pcmk(
         cmd_runner,
         resource_agent_name,
-        instance_attributes,
+        instance_attributes_modified,
     )
 
 

--- a/pcs_test/tier0/lib/pacemaker/test_live.py
+++ b/pcs_test/tier0/lib/pacemaker/test_live.py
@@ -1977,11 +1977,13 @@ class HandleInstanceAttributesValidateViaPcmkTest(TestCase):
         )
 
 
-class ValidateResourceInstanceAttributesViaPcmkTest(TestCase):
-    # pylint: disable=protected-access
+class ValidateResourceInstanceAttributesViaPcmk(TestCase):
     def setUp(self):
         self.runner = mock.Mock()
-        self.attrs = dict(attra="val1", attrb="val2")
+        self.attrs_input = dict(attra="val1", attrb="lrm://", attrc="val3")
+        self.attrs_validate = dict(
+            attra="val1", attrb="secret-value", attrc="val3"
+        )
         patcher = mock.patch(
             "pcs.lib.pacemaker.live._handle_instance_attributes_validation_via_pcmk"
         )
@@ -1990,13 +1992,13 @@ class ValidateResourceInstanceAttributesViaPcmkTest(TestCase):
         self.ret_val = "ret val"
         self.mock_handler.return_value = self.ret_val
 
-    def test_with_provider(self):
+    def test_resource_with_provider(self):
         agent = ResourceAgentName(
             standard="ocf", provider="pacemaker", type="Dummy"
         )
         self.assertEqual(
-            lib._validate_resource_instance_attributes_via_pcmk(
-                self.runner, agent, self.attrs
+            lib.validate_resource_instance_attributes_via_pcmk(
+                self.runner, agent, self.attrs_input
             ),
             self.ret_val,
         )
@@ -2015,16 +2017,16 @@ class ValidateResourceInstanceAttributesViaPcmkTest(TestCase):
                 "pacemaker",
             ],
             "./resource-agent-action/command/output",
-            self.attrs,
+            self.attrs_validate,
         )
 
-    def test_without_provider(self):
+    def test_resource_without_provider(self):
         agent = ResourceAgentName(
             standard="standard", provider=None, type="Agent"
         )
         self.assertEqual(
-            lib._validate_resource_instance_attributes_via_pcmk(
-                self.runner, agent, self.attrs
+            lib.validate_resource_instance_attributes_via_pcmk(
+                self.runner, agent, self.attrs_input
             ),
             self.ret_val,
         )
@@ -2041,31 +2043,16 @@ class ValidateResourceInstanceAttributesViaPcmkTest(TestCase):
                 "Agent",
             ],
             "./resource-agent-action/command/output",
-            self.attrs,
+            self.attrs_validate,
         )
 
-
-class ValidateStonithInstanceAttributesViaPcmkTest(TestCase):
-    # pylint: disable=protected-access
-
-    def setUp(self):
-        self.runner = mock.Mock()
-        self.attrs = dict(attra="val1", attrb="val2")
-        patcher = mock.patch(
-            "pcs.lib.pacemaker.live._handle_instance_attributes_validation_via_pcmk"
-        )
-        self.mock_handler = patcher.start()
-        self.addCleanup(patcher.stop)
-        self.ret_val = "ret val"
-        self.mock_handler.return_value = self.ret_val
-
-    def test_success(self):
+    def test_stonith(self):
         agent = ResourceAgentName(
             standard="stonith", provider=None, type="Agent"
         )
         self.assertEqual(
-            lib._validate_stonith_instance_attributes_via_pcmk(
-                self.runner, agent, self.attrs
+            lib.validate_resource_instance_attributes_via_pcmk(
+                self.runner, agent, self.attrs_input
             ),
             self.ret_val,
         )
@@ -2080,7 +2067,7 @@ class ValidateStonithInstanceAttributesViaPcmkTest(TestCase):
                 "Agent",
             ],
             "./validate/command/output",
-            self.attrs,
+            self.attrs_validate,
         )
 
 


### PR DESCRIPTION


<!-- testing-farm = {"lock":"false","comment-id":"4647222389","data":[{"id":"d412c01f-b0cc-453e-b74a-c60b3370c94f","name":"CentOS-Stream-10","runTime":568.731839,"created":"2026-06-08T09:11:42.252809","updated":"2026-06-08T09:11:42.252817","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/d412c01f-b0cc-453e-b74a-c60b3370c94f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d412c01f-b0cc-453e-b74a-c60b3370c94f/pipeline.log\">pipeline</a>"]}]} -->