### PR TITLE
Follow-up to Replace deprecated aliases from typing module

### DIFF
--- a/pcs/cli/common/completion.py
+++ b/pcs/cli/common/completion.py
@@ -40,14 +40,14 @@ def make_suggestions(
     suggestion_tree -- {'acl': {'role': {'create': ...}}}...
     """
     if not has_applicable_environment(environment):
-        raise EnvironmentError("Environment is not completion ready")
+        raise OSError("Environment is not completion ready")
 
     try:
         typed_word_list = _split_words(
             environment["COMP_WORDS"],
             environment["COMP_LENGTHS"].split(" "),
         )
-    except EnvironmentError:
+    except OSError:
         return ""
 
     return "\n".join(
@@ -65,24 +65,20 @@ def _split_words(joined_words: str, word_lengths: StringSequence) -> list[str]:
         try:
             next_position = cursor_position + int(length)
         except ValueError as e:
-            raise EnvironmentError(
-                f"Length of word '{length}' is not digit"
-            ) from e
+            raise OSError(f"Length of word '{length}' is not digit") from e
         if next_position > words_string_len:
-            raise EnvironmentError(
-                "Expected lengths are bigger than word lengths"
-            )
+            raise OSError("Expected lengths are bigger than word lengths")
         if (
             next_position != words_string_len
             and not joined_words[next_position].isspace()
         ):
-            raise EnvironmentError("Words separator is not expected space")
+            raise OSError("Words separator is not expected space")
 
         word_list.append(joined_words[cursor_position:next_position])
         cursor_position = next_position + 1
 
     if words_string_len > next_position:
-        raise EnvironmentError("Expected lengths are smaller then word lengths")
+        raise OSError("Expected lengths are smaller then word lengths")
 
     return word_list
 

--- a/pcs/cli/common/middleware.py
+++ b/pcs/cli/common/middleware.py
@@ -33,7 +33,7 @@ def cib(filename, touch_cib_file):
                     # the with statement
                     fcntl.flock(cib_file.fileno(), fcntl.LOCK_SH)
                     original_content = cib_file.read()
-            except EnvironmentError as e:
+            except OSError as e:
                 raise error(f"Cannot read cib file '{filename}': '{e}'") from e
             env.cib_data = original_content
 
@@ -46,7 +46,7 @@ def cib(filename, touch_cib_file):
                     # the with statement
                     fcntl.flock(cib_file.fileno(), fcntl.LOCK_EX)
                     cib_file.write(env.cib_data)
-            except EnvironmentError as e:
+            except OSError as e:
                 raise error(f"Cannot write cib file '{filename}': '{e}'") from e
 
         return result_of_next
@@ -63,7 +63,7 @@ def corosync_conf_existing(local_file_path):
                     # the with statement
                     fcntl.flock(local_file.fileno(), fcntl.LOCK_SH)
                     original_content = local_file.read()
-            except EnvironmentError as e:
+            except OSError as e:
                 raise error(
                     f"Unable to read {local_file_path}: {e.strerror}"
                 ) from e
@@ -78,7 +78,7 @@ def corosync_conf_existing(local_file_path):
                     # the with statement
                     fcntl.flock(local_file.fileno(), fcntl.LOCK_EX)
                     local_file.write(env.corosync_conf_data)
-            except EnvironmentError as e:
+            except OSError as e:
                 raise error(
                     f"Unable to write {local_file_path}: {e.strerror}"
                 ) from e

--- a/pcs/cli/common/tools.py
+++ b/pcs/cli/common/tools.py
@@ -3,9 +3,7 @@ import sys
 from pcs.common.tools import timeout_to_seconds
 
 
-def timeout_to_seconds_legacy(
-    timeout: int | str,
-) -> int | str | None:
+def timeout_to_seconds_legacy(timeout: int | str) -> int | str | None:
     """
     Transform pacemaker style timeout to number of seconds. If timeout is not
     valid then `timeout` is returned.

--- a/pcs/cli/query/resource.py
+++ b/pcs/cli/query/resource.py
@@ -68,10 +68,8 @@ def _handle_query_exception(e: QueryException) -> None:
         )
     if isinstance(e, InstancesQuantifierUnsupportedException):
         raise CmdLineInputError(
-            (
-                "'instances' quantifier can be used only on clone resources "
-                "and their instances, or on bundle resources and their replicas"
-            )
+            "'instances' quantifier can be used only on clone resources and "
+            "their instances, or on bundle resources and their replicas"
         )
     raise CmdLineInputError(
         "Unknown error with the query", show_both_usage_and_message=True

--- a/pcs/cli/resource/output.py
+++ b/pcs/cli/resource/output.py
@@ -1,6 +1,6 @@
 import shlex
 from collections import defaultdict
-from collections.abc import Container, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.common.output import (
@@ -364,7 +364,7 @@ class ResourcesConfigurationFacade:
             )
 
     @property
-    def filtered_ids(self) -> Container[str]:
+    def filtered_ids(self) -> frozenset[str]:
         return self._filtered_ids
 
     @property

--- a/pcs/common/node_communicator.py
+++ b/pcs/common/node_communicator.py
@@ -169,7 +169,7 @@ class Request:
         return cookies
 
     def __repr__(self) -> str:
-        return str("Request({0}, {1})").format(self._target, self._data)
+        return "Request({0}, {1})".format(self._target, self._data)
 
 
 class Response:

--- a/pcs/common/ssl.py
+++ b/pcs/common/ssl.py
@@ -18,7 +18,7 @@ def check_cert_key(cert_path: str, key_path: str) -> list[str]:
         ssl_context.load_cert_chain(cert_path, key_path)
     except ssl.SSLError as e:
         errors.append(f"SSL certificate does not match the key: {e}")
-    except EnvironmentError as e:
+    except OSError as e:
         errors.append(f"Unable to load SSL certificate and/or key: {e}")
     return errors
 

--- a/pcs/config.py
+++ b/pcs/config.py
@@ -282,7 +282,7 @@ def config_backup_local():
                 ):
                     continue
                 tarball.add(path_info["path"], tar_path)
-    except (tarfile.TarError, EnvironmentError) as e:
+    except (tarfile.TarError, OSError) as e:
         utils.err("unable to create tarball: %s" % e)
 
     tar = tar_data.getvalue()
@@ -358,7 +358,7 @@ def config_restore_remote(infile_name, infile_obj):  # noqa: PLR0912
                     tar_member = tarball.extractfile(tar_member_info)
                     extracted[tar_member_info.name] = tar_member.read()
                     tar_member.close()
-    except (tarfile.TarError, EnvironmentError) as e:
+    except (tarfile.TarError, OSError) as e:
         utils.err("unable to read the tarball: %s" % e)
 
     config_backup_check_version(extracted["version.txt"])
@@ -532,7 +532,7 @@ def config_restore_local(infile_name, infile_obj):  # noqa: PLR0912, PLR0915
                 file_attrs = extract_info["attrs"]
                 os.chmod(path_full, file_attrs["mode"])
                 os.chown(path_full, file_attrs["uid"], file_attrs["gid"])
-    except (tarfile.TarError, EnvironmentError, OSError) as e:
+    except (tarfile.TarError, OSError) as e:
         utils.err("unable to restore the cluster: %s" % e)
     finally:
         if tmp_dir:
@@ -542,7 +542,7 @@ def config_restore_local(infile_name, infile_obj):  # noqa: PLR0912, PLR0915
         sig_path = os.path.join(settings.cib_dir, "cib.xml.sig")
         if os.path.exists(sig_path):
             os.remove(sig_path)
-    except EnvironmentError as e:
+    except OSError as e:
         utils.err("unable to remove %s: %s" % (sig_path, e))
 
 

--- a/pcs/daemon/ruby_pcsd.py
+++ b/pcs/daemon/ruby_pcsd.py
@@ -112,7 +112,7 @@ class RubyDaemonRequest(
                 # this let's keep the original header here in this case.
                 if key.lower() == "content-type" and val == "application/json":
                     headers.add(key, val)
-        return super(RubyDaemonRequest, cls).__new__(
+        return super().__new__(
             cls,
             request_type,
             http_request.path if http_request else "",

--- a/pcs/daemon/systemd.py
+++ b/pcs/daemon/systemd.py
@@ -24,6 +24,6 @@ async def notify(socket_name):
         log.pcsd.error("Unable to notify systemd on '%s': %s", socket_name, e)
 
 
-@lru_cache()
+@lru_cache
 def is_systemd():
     return any(os.path.isdir(path) for path in settings.systemd_unit_path)

--- a/pcs/lib/cib/resource/stonith.py
+++ b/pcs/lib/cib/resource/stonith.py
@@ -491,10 +491,8 @@ def update_scsi_devices_without_restart(
         raise LibraryError(
             ReportItem.error(
                 reports.messages.StonithRestartlessUpdateUnableToPerform(
-                    (
-                        "number of lrm_rsc_op and op elements for monitor "
-                        "operation differs"
-                    )
+                    "number of lrm_rsc_op and op elements for monitor "
+                    "operation differs"
                 )
             )
         )
@@ -522,11 +520,9 @@ def update_scsi_devices_without_restart(
             raise LibraryError(
                 ReportItem.error(
                     reports.messages.StonithRestartlessUpdateUnableToPerform(
-                        (
-                            "monitor lrm_rsc_op element for resource "
-                            f"'{resource_id}', node '{node_name}' and interval "
-                            f"'{monitor_attrs['interval']}' not found"
-                        )
+                        "monitor lrm_rsc_op element for resource "
+                        f"'{resource_id}', node '{node_name}' and interval "
+                        f"'{monitor_attrs['interval']}' not found"
                     )
                 )
             )

--- a/pcs/lib/commands/resource.py
+++ b/pcs/lib/commands/resource.py
@@ -877,7 +877,7 @@ def create_in_group(  # noqa: PLR0913
                 get_root(resources_section), group_id
             )
         except ElementNotFound:
-            group_id_reports: list[ReportItem] = []
+            group_id_reports: ReportItemList = []
             validate_id(
                 group_id, description="group name", reporter=group_id_reports
             )
@@ -1828,7 +1828,7 @@ def group_add(  # noqa: PLR0912
     try:
         group_element = get_element_by_id(get_root(resources_section), group_id)
     except ElementNotFound:
-        group_id_reports: list[ReportItem] = []
+        group_id_reports: ReportItemList = []
         validate_id(
             group_id, description="group name", reporter=group_id_reports
         )

--- a/pcs/lib/corosync/config_parser.py
+++ b/pcs/lib/corosync/config_parser.py
@@ -22,9 +22,9 @@ AttrTuple = tuple[AttrName, AttrValue]
 
 class Section:
     def __init__(self, name: str):
-        self._parent: "Section | None" = None
+        self._parent: Section | None = None
         self._attr_list: list[AttrTuple] = []
-        self._section_list: list["Section"] = []
+        self._section_list: list[Section] = []
         self._name: str = name
 
     @property
@@ -114,7 +114,7 @@ class Section:
         ]
 
     def add_section(self, section: "Section") -> "Section":
-        parent: "Section | None" = self
+        parent: Section | None = self
         while parent:
             if parent == section:
                 raise CircularParentshipException()

--- a/pcs/lib/corosync/live.py
+++ b/pcs/lib/corosync/live.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import Container, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from pcs import settings
@@ -8,6 +8,7 @@ from pcs.common.file import RawFileError
 from pcs.common.reports.item import ReportItem
 from pcs.common.str_tools import format_list
 from pcs.common.tools import Version, get_version_from_string
+from pcs.common.types import StringCollection
 from pcs.lib.errors import LibraryError
 from pcs.lib.external import CommandRunner
 from pcs.lib.file.instance import FileInstance
@@ -121,7 +122,7 @@ class QuorumStatusFacade:
     def qdevice_votes(self) -> int:
         return self._quorum_status.qdevice_votes
 
-    def _get_votes_excluding_nodes(self, node_names: Container[str]) -> int:
+    def _get_votes_excluding_nodes(self, node_names: StringCollection) -> int:
         """
         How many votes do remain if specified nodes are not counted in?
 
@@ -146,7 +147,7 @@ class QuorumStatusFacade:
         )
 
     def stopping_nodes_cause_quorum_loss(
-        self, node_names: Container[str]
+        self, node_names: StringCollection
     ) -> bool:
         """
         Will quorum be lost if specified nodes are stopped?

--- a/pcs/lib/file/toolbox.py
+++ b/pcs/lib/file/toolbox.py
@@ -76,7 +76,7 @@ class NoopExporter(ExporterInterface):
 class NoopFacade(FacadeInterface):
     @classmethod
     def create(cls) -> "NoopFacade":
-        return cls(bytes())
+        return cls(b"")
 
 
 _toolboxes = {

--- a/pcs/lib/pacemaker/api_result.py
+++ b/pcs/lib/pacemaker/api_result.py
@@ -32,7 +32,7 @@ def get_status_from_api_result(dom: _Element) -> Status:
     errors_el = status_el.find("errors")
     if errors_el is not None:
         errors = [
-            str((error_el.text or "")).strip()
+            str(error_el.text or "").strip()
             for error_el in errors_el.iterfind("error")
         ]
     return Status(

--- a/pcs/lib/pacemaker/simulate.py
+++ b/pcs/lib/pacemaker/simulate.py
@@ -1,9 +1,11 @@
 from collections import defaultdict
-from collections.abc import Container, Iterable
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import NewType
 
 from lxml.etree import _Element
+
+from pcs.common.types import StringCollection
 
 SimulationOperationType = NewType("SimulationOperationType", str)
 
@@ -63,7 +65,7 @@ def get_operations_from_transitions(
 
 def get_resources_from_operations(
     operation_list: Iterable[SimulationOperation],
-    exclude_resources: Container[str] | None = None,
+    exclude_resources: StringCollection | None = None,
 ) -> list[str]:
     """
     Get names of all resources from the provided operation list
@@ -83,7 +85,7 @@ def get_resources_from_operations(
 
 def get_resources_left_stopped(
     operation_list: Iterable[SimulationOperation],
-    exclude_resources: Container[str] | None = None,
+    exclude_resources: StringCollection | None = None,
 ) -> list[str]:
     """
     Get names of resources which are left stopped by the provided operation list
@@ -98,7 +100,7 @@ def get_resources_left_stopped(
 
 def get_resources_left_demoted(
     operation_list: Iterable[SimulationOperation],
-    exclude_resources: Container[str] | None = None,
+    exclude_resources: StringCollection | None = None,
 ) -> list[str]:
     """
     Get names of resources which are left demoted by the provided operation list
@@ -115,7 +117,7 @@ def _resources_with_imbalanced_operations(
     operation_list: Iterable[SimulationOperation],
     increment_op: SimulationOperationType,
     decrement_op: SimulationOperationType,
-    exclude_resources: Container[str] | None = None,
+    exclude_resources: StringCollection | None = None,
 ) -> list[str]:
     exclude_resources = exclude_resources or tuple()
     counter: dict[str, int] = defaultdict(int)

--- a/pcs/lib/sbd.py
+++ b/pcs/lib/sbd.py
@@ -250,7 +250,7 @@ def get_local_sbd_config() -> str:
         with open(settings.sbd_config, "r") as sbd_cfg:
             fcntl.flock(sbd_cfg.fileno(), fcntl.LOCK_SH)
             return sbd_cfg.read()
-    except EnvironmentError as e:
+    except OSError as e:
         raise LibraryError(
             reports.ReportItem.error(
                 reports.messages.UnableToGetSbdConfig("local node", str(e))
@@ -271,7 +271,7 @@ def set_local_sbd_config(config: str) -> None:
             # with statement
             fcntl.flock(sbd_cfg.fileno(), fcntl.LOCK_EX)
             sbd_cfg.write(config)
-    except EnvironmentError as e:
+    except OSError as e:
         raise LibraryError(
             reports.ReportItem.error(
                 reports.messages.UnableToSetSbdConfig(str(e))

--- a/pcs/lib/tools.py
+++ b/pcs/lib/tools.py
@@ -120,7 +120,7 @@ def get_tmp_cib(
                 )
             )
             yield tmp_cib_file
-    except EnvironmentError as e:
+    except OSError as e:
         raise LibraryError(
             reports.ReportItem.error(reports.messages.CibSaveTmpError(str(e)))
         ) from e
@@ -141,7 +141,7 @@ def create_tmp_cib(
             )
         )
         return tmp_file
-    except EnvironmentError as e:
+    except OSError as e:
         raise LibraryError(
             reports.ReportItem.error(reports.messages.CibSaveTmpError(str(e)))
         ) from e

--- a/pcs/lib/validate.py
+++ b/pcs/lib/validate.py
@@ -1136,9 +1136,7 @@ def is_string_length(
     )
 
 
-def is_float(
-    value: str | int | float,
-) -> bool:
+def is_float(value: str | int | float) -> bool:
     """
     Check if the specified value is a float number
 

--- a/pcs/pcsd.py
+++ b/pcs/pcsd.py
@@ -56,7 +56,7 @@ def pcsd_certkey_cmd(lib: Any, argv: Argv, modifiers: InputModifiers):
             cert = myfile.read()
         with open(keyfile, "rb") as myfile:
             key = myfile.read()
-    except IOError as e:
+    except OSError as e:
         utils.err(str(e))
     errors = pcs.common.ssl.check_cert_key(certfile, keyfile)
     if errors:
@@ -101,7 +101,7 @@ def pcsd_certkey_cmd(lib: Any, argv: Argv, modifiers: InputModifiers):
         ) as myfile:
             myfile.write(key)
 
-    except IOError as e:
+    except OSError as e:
         utils.err(str(e))
 
     print_to_stderr(
@@ -139,7 +139,7 @@ def pcsd_deauth(lib, argv, modifiers):
         try:
             with open(filepath, "w") as users_file:
                 users_file.write(json.dumps([]))
-        except EnvironmentError as e:
+        except OSError as e:
             utils.err(
                 "Unable to edit data in {file}: {err}".format(
                     file=filepath, err=e
@@ -179,7 +179,7 @@ def pcsd_deauth(lib, argv, modifiers):
         utils.err(
             "Unable to parse data in {file}: {err}".format(file=filepath, err=e)
         )
-    except EnvironmentError as e:
+    except OSError as e:
         utils.err(
             "Unable to edit data in {file}: {err}".format(file=filepath, err=e)
         )

--- a/pcs/snmp/agentx/types.py
+++ b/pcs/snmp/agentx/types.py
@@ -8,14 +8,14 @@ BaseType = namedtuple("BaseType", ["data_type", "value"])
 
 class IntegerType(BaseType):
     def __new__(cls, value):
-        return super(IntegerType, cls).__new__(
+        return super().__new__(
             cls, data_type=pyagentx.TYPE_INTEGER, value=value
         )
 
 
 class StringType(BaseType):
     def __new__(cls, value):
-        return super(StringType, cls).__new__(
+        return super().__new__(
             cls, data_type=pyagentx.TYPE_OCTETSTRING, value=value
         )
 
@@ -40,6 +40,4 @@ class Oid(
     __slots__ = ()
 
     def __new__(cls, oid, str_oid, data_type=None, member_list=None):
-        return super(Oid, cls).__new__(
-            cls, oid, str_oid, data_type, member_list
-        )
+        return super().__new__(cls, oid, str_oid, data_type, member_list)

--- a/pcs/utils.py
+++ b/pcs/utils.py
@@ -295,7 +295,7 @@ def remove_uid_gid_file(uid, gid):
     return file_removed
 
 
-@lru_cache()
+@lru_cache
 def read_known_hosts_file() -> dict[str, PcsKnownHost]:
     return read_known_hosts_file_not_cached()
 

--- a/pcs/utils.py
+++ b/pcs/utils.py
@@ -733,7 +733,7 @@ def getCorosyncConf():
             settings.corosync_conf_file, "r", encoding="utf-8"
         ) as corosync_conf_file:
             corosync_conf_content = corosync_conf_file.read()
-    except IOError as e:
+    except OSError as e:
         err("Unable to read %s: %s" % (settings.corosync_conf_file, e.strerror))
     return corosync_conf_content
 
@@ -800,7 +800,7 @@ def need_to_handle_qdevice_service():
                 ).get_quorum_device_model()
                 is not None
             )
-    except (EnvironmentError, corosync_conf_parser.CorosyncConfParserException):
+    except (OSError, corosync_conf_parser.CorosyncConfParserException):
         # corosync.conf not present or not valid => no qdevice specified
         return False
 
@@ -814,7 +814,7 @@ def touch_cib_file(cib_filename):
     if not os.path.isfile(cib_filename):
         try:
             write_empty_cib(cib_filename)
-        except EnvironmentError as e:
+        except OSError as e:
             err(
                 "Unable to write to file: '{0}': '{1}'".format(
                     cib_filename, str(e)
@@ -2023,7 +2023,7 @@ def write_file(path, data, permissions=0o644, binary=False):
             return False, "'%s' already exists, use --force to overwrite" % path
         try:
             os.remove(path)
-        except EnvironmentError as e:
+        except OSError as e:
             return False, "unable to remove '%s': %s" % (path, e)
     mode = "wb" if binary else "w"
     try:
@@ -2031,7 +2031,7 @@ def write_file(path, data, permissions=0o644, binary=False):
             os.open(path, os.O_WRONLY | os.O_CREAT, permissions), mode
         ) as outfile:
             outfile.write(data)
-    except EnvironmentError as e:
+    except OSError as e:
         return False, "unable to write to '%s': %s" % (path, e)
     return True, ""
 
@@ -2106,7 +2106,7 @@ def simulate_cib(cib_dom):
                 parseString(transitions_file.read()),
                 parseString(new_cib_file.read()),
             )
-    except (EnvironmentError, xml.parsers.expat.ExpatError) as e:
+    except (OSError, xml.parsers.expat.ExpatError) as e:
         return err("Unable to run crm_simulate:\n%s" % e)
     except xml.etree.ElementTree.ParseError as e:
         return err("Unable to run crm_simulate:\n%s" % e)
@@ -2420,7 +2420,7 @@ def get_lib_env() -> LibraryEnvironment:
         try:
             with open(conf) as corosync_conf_file:
                 corosync_conf_data = corosync_conf_file.read()
-        except IOError as e:
+        except OSError as e:
             err("Unable to read %s: %s" % (conf, e.strerror))
 
     return LibraryEnvironment(

--- a/pcs_test/tier0/cli/common/test_completion.py
+++ b/pcs_test/tier0/cli/common/test_completion.py
@@ -107,7 +107,7 @@ class HasCompletionEnvironmentTest(TestCase):
 class MakeSuggestionsEnvironment(TestCase):
     def test_raises_for_incomlete_environment(self):
         self.assertRaises(
-            EnvironmentError,
+            OSError,
             lambda: make_suggestions(
                 {
                     "COMP_CWORD": "1",
@@ -141,24 +141,24 @@ class SplitWordsTest(TestCase):
 
     def test_refuse_when_no_int_in_lengths(self):
         self.assertRaises(
-            EnvironmentError,
+            OSError,
             lambda: _split_words("pcs resource op a", ["3", "8", "2", "A"]),
         )
 
     def test_refuse_when_lengths_are_too_big(self):
         self.assertRaises(
-            EnvironmentError,
+            OSError,
             lambda: _split_words("pcs resource op a", ["3", "8", "2", "10"]),
         )
 
     def test_refuse_when_separator_doesnot_match(self):
         self.assertRaises(
-            EnvironmentError,
+            OSError,
             lambda: _split_words("pc sresource op a", ["3", "8", "2", "1"]),
         )
 
     def test_refuse_when_lengths_are_too_small(self):
         self.assertRaises(
-            EnvironmentError,
+            OSError,
             lambda: _split_words("pcs resource op a ", ["3", "8", "2", "1"]),
         )

--- a/pcs_test/tier0/cli/node/test_command.py
+++ b/pcs_test/tier0/cli/node/test_command.py
@@ -286,10 +286,7 @@ class TestNodeAttributeOutputCmd(NodeOutputCmdBaseMixin, TestCase):
             self.lib, argv, dict_to_modifiers(modifiers or {})
         )
 
-    def _set_config(
-        self,
-        node_config: CibNodeListDto | None = None,
-    ):
+    def _set_config(self, node_config: CibNodeListDto | None = None) -> None:
         self.node.get_config_dto.return_value = FIXTURE_NODE_CONFIG
         if node_config:
             self.node.get_config_dto.return_value = node_config
@@ -331,7 +328,7 @@ class TestNodeUtilizationOutputCmd(NodeOutputCmdBaseMixin, TestCase):
         self,
         node_config: CibNodeListDto | None = None,
         properties_config: ListCibNvsetDto | None = None,
-    ):
+    ) -> None:
         self.node.get_config_dto.return_value = FIXTURE_NODE_CONFIG
         self.cluster_property.get_properties.return_value = (
             FIXTURE_PLACEMENT_STRATEGY_SET

--- a/pcs_test/tier0/daemon/async_tasks/test_command_mapping.py
+++ b/pcs_test/tier0/daemon/async_tasks/test_command_mapping.py
@@ -75,10 +75,12 @@ def _find_disallowed_types(_type, allowed_types, _seen=None):
 class DaciteTypingCompatibilityTest(TestCase):
     def test_all(self):
         prohibited_types = (Iterable, Container)
-        prohibited_types_normalized = [
-            origin if (origin := get_origin(_type)) is not None else _type
-            for _type in prohibited_types
-        ]
+        prohibited_types_normalized = []
+        for _type in prohibited_types:
+            _type_origin = get_origin(_type)
+            prohibited_types_normalized.append(
+                _type_origin if _type_origin is not None else _type
+            )
         for cmd_name, cmd in COMMAND_MAP.items():
             for param in list(inspect.signature(cmd.cmd).parameters.values())[
                 1:

--- a/pcs_test/tier0/daemon/async_tasks/test_task.py
+++ b/pcs_test/tier0/daemon/async_tasks/test_task.py
@@ -88,10 +88,13 @@ class TestReceiveMessage(MockDateTimeNowMixin, TaskBaseTestCase):
         self.mock_datetime_now.assert_called_once()
 
     def test_unsupported_message_type(self):
-        message = Message(TASK_IDENT, 3)
+        payload = 3
+        message = Message(TASK_IDENT, payload)
         with self.assertRaises(tasks.UnknownMessageError) as thrown_exc:
             self.task.receive_message(message)
-        self.assertEqual(type(3).__name__, thrown_exc.exception.payload_type)
+        self.assertEqual(
+            type(payload).__name__, thrown_exc.exception.payload_type
+        )
         self.mock_datetime_now.assert_not_called()
 
 

--- a/pcs_test/tier0/lib/commands/cluster/test_add_nodes.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_add_nodes.py
@@ -2000,12 +2000,12 @@ class FailurePcsdSslCertSync(TestCase):
         self.config.fs.open(
             settings.pcsd_cert_location,
             name="fs.open.pcsd_ssl_cert",
-            side_effect=EnvironmentError(1, "error cert"),
+            side_effect=OSError(1, "error cert"),
         )
         self.config.fs.open(
             settings.pcsd_key_location,
             name="fs.open.pcsd_ssl_key",
-            side_effect=EnvironmentError(1, "error key"),
+            side_effect=OSError(1, "error key"),
         )
 
         self._add_nodes_with_lib_error()
@@ -2207,7 +2207,7 @@ class FailureFilesDistribution(TestCase):
         self.config.fs.open(
             settings.corosync_authkey_file,
             mode="rb",
-            side_effect=EnvironmentError(
+            side_effect=OSError(
                 1, self.err_msg, settings.corosync_authkey_file
             ),
             name="fs.open.corosync_authkey",
@@ -2216,7 +2216,7 @@ class FailureFilesDistribution(TestCase):
         self.config.fs.open(
             settings.pacemaker_authkey_file,
             mode="rb",
-            side_effect=EnvironmentError(
+            side_effect=OSError(
                 1, self.err_msg, settings.pacemaker_authkey_file
             ),
             name="fs.open.pacemaker_authkey",
@@ -2225,7 +2225,7 @@ class FailureFilesDistribution(TestCase):
         self.config.fs.open(
             settings.pcsd_dr_config_location,
             mode="rb",
-            side_effect=EnvironmentError(
+            side_effect=OSError(
                 1, self.err_msg, settings.pcsd_dr_config_location
             ),
             name="fs.open.pcsd_dr_config",
@@ -2274,7 +2274,7 @@ class FailureFilesDistribution(TestCase):
         self.config.fs.open(
             settings.corosync_authkey_file,
             mode="rb",
-            side_effect=EnvironmentError(
+            side_effect=OSError(
                 1, self.err_msg, settings.corosync_authkey_file
             ),
             name="fs.open.corosync_authkey",
@@ -2283,7 +2283,7 @@ class FailureFilesDistribution(TestCase):
         self.config.fs.open(
             settings.pacemaker_authkey_file,
             mode="rb",
-            side_effect=EnvironmentError(
+            side_effect=OSError(
                 1, self.err_msg, settings.pacemaker_authkey_file
             ),
             name="fs.open.pacemaker_authkey",
@@ -2292,7 +2292,7 @@ class FailureFilesDistribution(TestCase):
         self.config.fs.open(
             settings.pcsd_dr_config_location,
             mode="rb",
-            side_effect=EnvironmentError(
+            side_effect=OSError(
                 1, self.err_msg, settings.pcsd_dr_config_location
             ),
             name="fs.open.pcsd_dr_config",
@@ -3607,9 +3607,7 @@ class FailureEnableSbd(TestCase):
         (
             self.config.fs.open(
                 settings.sbd_config,
-                side_effect=EnvironmentError(
-                    1, self.err_msg, settings.sbd_config
-                ),
+                side_effect=OSError(1, self.err_msg, settings.sbd_config),
                 name="fs.open.sbd_config",
             )
         )
@@ -3783,11 +3781,7 @@ class FailureQdevice(TestCase):
         )
         self.config.fs.open(
             pk12_cert_path,
-            side_effect=EnvironmentError(
-                1,
-                self.err_msg,
-                pk12_cert_path,
-            ),
+            side_effect=OSError(1, self.err_msg, pk12_cert_path),
             mode="rb",
             name="fs.open.pk12_cert_read",
         )
@@ -3891,7 +3885,7 @@ class FailureQdevice(TestCase):
         )
         self.config.fs.open(
             cert_req_path,
-            side_effect=EnvironmentError(1, self.err_msg, cert_req_path),
+            side_effect=OSError(1, self.err_msg, cert_req_path),
             mode="rb",
             name="fs.open.cert_req_read",
         )

--- a/pcs_test/tier0/lib/commands/cluster/test_setup.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_setup.py
@@ -3327,7 +3327,7 @@ class SslCertSync(RemoveCallsMixin, TestCase):
     def test_config_unreadable(self):
         self.config.fs.open(
             settings.pcsd_config,
-            side_effect=EnvironmentError(1, "error reading pcsd config"),
+            side_effect=OSError(1, "error reading pcsd config"),
             name="fs.open.pcsd_config",
             instead="fs.open.pcsd_config",
         )

--- a/pcs_test/tier0/lib/commands/test_booth.py
+++ b/pcs_test/tier0/lib/commands/test_booth.py
@@ -675,7 +675,7 @@ class ConfigDestroy(TestCase, FixtureMixin):
         self.config.raw_file.read(
             file_type_codes.BOOTH_CONFIG,
             self.fixture_cfg_path(),
-            content=bytes(),
+            content=b"",
         )
         self.config.raw_file.remove(
             file_type_codes.BOOTH_CONFIG,
@@ -1404,7 +1404,7 @@ class GetConfig(TestCase, FixtureMixin):
         )
 
     def test_success_no_authfile(self):
-        config_content = bytes()
+        config_content = b""
         self.config.raw_file.read(
             file_type_codes.BOOTH_CONFIG,
             self.fixture_cfg_path(),
@@ -3371,11 +3371,11 @@ class ConfigSyncTest(TestCase, FixtureMixin):
         self.config.raw_file.read(
             file_type_codes.BOOTH_CONFIG,
             self.fixture_cfg_path(),
-            content=bytes(),
+            content=b"",
         )
         self.config.http.booth.send_config(
             "booth",
-            bytes().decode("utf-8"),
+            b"".decode("utf-8"),
             node_labels=self.node_list,
         )
         commands.config_sync(self.env_assist.get_env())

--- a/pcs_test/tier0/lib/commands/test_pcsd.py
+++ b/pcs_test/tier0/lib/commands/test_pcsd.py
@@ -301,11 +301,11 @@ class SynchronizeSslCertificates(TestCase):
             self.config.fs.open(
                 settings.pcsd_cert_location,
                 name="fs.open.pcsd_ssl_cert",
-                side_effect=EnvironmentError(1, "error cert"),
+                side_effect=OSError(1, "error cert"),
             ).fs.open(
                 settings.pcsd_key_location,
                 name="fs.open.pcsd_ssl_key",
-                side_effect=EnvironmentError(1, "error key"),
+                side_effect=OSError(1, "error key"),
             )
         )
 

--- a/pcs_test/tier0/lib/commands/test_resource_agent.py
+++ b/pcs_test/tier0/lib/commands/test_resource_agent.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from unittest import TestCase
 
 from pcs.common import const

--- a/pcs_test/tier0/lib/corosync/test_qdevice_net.py
+++ b/pcs_test/tier0/lib/corosync/test_qdevice_net.py
@@ -95,7 +95,7 @@ class QdeviceDestroyTest(TestCase):
 
     def test_cert_dir_rm_error(self, mock_initialized, mock_rmtree):
         mock_initialized.return_value = True
-        mock_rmtree.side_effect = EnvironmentError("test errno", "test message")
+        mock_rmtree.side_effect = OSError("test errno", "test message")
         assert_raise_library_error(
             lib.qdevice_destroy,
             (
@@ -413,7 +413,7 @@ class ClientDestroyTest(TestCase):
 
     def test_cert_dir_rm_error(self, mock_initialized, mock_rmtree):
         mock_initialized.return_value = True
-        mock_rmtree.side_effect = EnvironmentError("test errno", "test message")
+        mock_rmtree.side_effect = OSError("test errno", "test message")
         assert_raise_library_error(
             lib.client_destroy,
             (

--- a/pcs_test/tier0/lib/pacemaker/test_live.py
+++ b/pcs_test/tier0/lib/pacemaker/test_live.py
@@ -419,7 +419,7 @@ class GetCibTest(TestCase):
     # pylint: disable=no-self-use
     def test_success(self):
         xml = "<xml />"
-        assert_xml_equal(xml, str(XmlManipulation((lib.get_cib(xml)))))
+        assert_xml_equal(xml, str(XmlManipulation(lib.get_cib(xml))))
 
     @mock.patch("pcs.lib.pacemaker.live.xml_fromstring")
     def test_invalid_xml(self, xml_fromstring_mock):

--- a/pcs_test/tier0/lib/test_env_cib.py
+++ b/pcs_test/tier0/lib/test_env_cib.py
@@ -292,7 +292,7 @@ class PushLoadedCib(TestCase, ManageCibAssertionMixin):
             [
                 TmpFileCall(
                     self.tmpfile_old,
-                    orig_content=EnvironmentError("test error"),
+                    orig_content=OSError("test error"),
                 ),
             ]
         )

--- a/pcs_test/tier0/test_lint.py
+++ b/pcs_test/tier0/test_lint.py
@@ -20,7 +20,7 @@ class IterableStr(TestCase):
                     with open(file_path) as file:
                         filedata = file.read()
                         if re.search(
-                            r"\b(collection|iterable|sequence)\[\s*str\s*\]",
+                            r"\b(collection|container|iterable|sequence)\[\s*str\s*\]",
                             filedata,
                             re.IGNORECASE,
                         ):
@@ -29,9 +29,10 @@ class IterableStr(TestCase):
             [],
             paths_to_fix,
             (
-                "'Collection[str]' or 'Iterable[str]' or 'Sequence[str]' found "
-                "in these files. Please replace it with StringCollection, "
-                "StringIterable or StringSequence from pcs.common.types. "
-                r"Vim regexp: \(collection\|iterable\|sequence\)\[\s*str\s*\]\c"
+                "'Collection[str]' 'Container[str]' or 'Iterable[str]' or "
+                "'Sequence[str]' found in these files. Please replace it with "
+                "StringCollection, StringIterable or StringSequence from "
+                "pcs.common.types. "
+                r"Vim regexp: \(collection\|container\|iterable\|sequence\)\[\s*str\s*\]\c"
             ),
         )

--- a/pcs_test/tier1/legacy/test_utils.py
+++ b/pcs_test/tier1/legacy/test_utils.py
@@ -1653,7 +1653,7 @@ class TouchCibFile(TestCase):
     @mock.patch("pcs.utils.os.path.isfile", mock.Mock(return_value=False))
     @mock.patch(
         "pcs.utils.write_empty_cib",
-        mock.Mock(side_effect=EnvironmentError("some message")),
+        mock.Mock(side_effect=OSError("some message")),
     )
     @mock.patch("pcs.utils.err")
     def test_exception_is_transformed_correctly(self, err):

--- a/pcs_test/tools/command_env/mock_fcntl.py
+++ b/pcs_test/tools/command_env/mock_fcntl.py
@@ -55,7 +55,7 @@ class Call:
         return self.return_value
 
     def __repr__(self):
-        return str("<Fcntl '{0}' kwargs={1}>").format(
+        return "<Fcntl '{0}' kwargs={1}>".format(
             self.func_name,
             self.call_kwargs,
         )

--- a/pcs_test/tools/command_env/mock_fs.py
+++ b/pcs_test/tools/command_env/mock_fs.py
@@ -77,7 +77,7 @@ class Call:
         return self.return_value
 
     def __repr__(self):
-        return str("<Fs '{0}' kwargs={1}>").format(
+        return "<Fs '{0}' kwargs={1}>".format(
             self.func_name,
             self.call_kwargs,
         )

--- a/pcs_test/tools/command_env/mock_get_local_corosync_conf.py
+++ b/pcs_test/tools/command_env/mock_get_local_corosync_conf.py
@@ -18,7 +18,7 @@ class Call:
         self.exception_msg = exception_msg
 
     def __repr__(self):
-        return str("<GetLocalCorosyncConf>")
+        return "<GetLocalCorosyncConf>"
 
 
 def get_get_local_corosync_conf(call_queue):

--- a/pcs_test/tools/command_env/mock_node_communicator.py
+++ b/pcs_test/tools/command_env/mock_node_communicator.py
@@ -341,7 +341,7 @@ class AddRequestCall:
         )
 
     def __repr__(self):
-        return str("<HttpAddRequest communicator='{0}' '{1}'>").format(
+        return "<HttpAddRequest communicator='{0}' '{1}'>".format(
             self.communicator_type.value, self.request_list
         )
 
@@ -360,7 +360,7 @@ class StartLoopCall:
         self.response_list = response_list
 
     def __repr__(self):
-        return str("<HttpStartLoop '{0}'>").format(self.response_list)
+        return "<HttpStartLoop '{0}'>".format(self.response_list)
 
 
 def _compare_request_data(expected, real):

--- a/pcs_test/tools/command_env/mock_push_cib.py
+++ b/pcs_test/tools/command_env/mock_push_cib.py
@@ -16,7 +16,7 @@ class Call:
         self.exception = exception
 
     def __repr__(self):
-        return str("<CibPush wait_timeout='{0}'>").format(self.wait_timeout)
+        return "<CibPush wait_timeout='{0}'>".format(self.wait_timeout)
 
 
 def get_push_cib(call_queue):

--- a/pcs_test/tools/command_env/mock_push_corosync_conf.py
+++ b/pcs_test/tools/command_env/mock_push_corosync_conf.py
@@ -24,7 +24,7 @@ class Call:
         self.need_stopped_cluster = need_stopped_cluster
 
     def __repr__(self):
-        return str("<CorosyncConfPush skip-offline='{0}'>").format(
+        return "<CorosyncConfPush skip-offline='{0}'>".format(
             self.skip_offline_targets
         )
 

--- a/pcs_test/tools/command_env/mock_runner.py
+++ b/pcs_test/tools/command_env/mock_runner.py
@@ -105,7 +105,7 @@ class Call:
         self.env = env or {}
 
     def __repr__(self):
-        return str("<Runner '{0}' returncode='{1}' env='{2}'>").format(
+        return "<Runner '{0}' returncode='{1}' env='{2}'>".format(
             self.command, self.returncode, self.env
         )
 

--- a/pcs_test/tools/misc.py
+++ b/pcs_test/tools/misc.py
@@ -144,7 +144,7 @@ def is_minimum_pacemaker_version(major, minor, rev):
     )
 
 
-@lru_cache()
+@lru_cache
 def _get_current_pacemaker_version():
     output, dummy_stderr, dummy_retval = runner.run(
         [settings.crm_mon_exec, "--version"]
@@ -158,7 +158,7 @@ def _get_current_pacemaker_version():
     return major, minor, rev
 
 
-@lru_cache()
+@lru_cache
 def _get_current_cib_schema_version():
     regexp = re.compile(r"pacemaker-((\d+)\.(\d+))")
     all_versions = set()
@@ -197,7 +197,7 @@ def _has_pacemaker_features(requested_features):
     return actual >= requested
 
 
-@lru_cache()
+@lru_cache
 def _get_current_pacemaker_features():
     output, dummy_stderr, dummy_retval = runner.run(
         [settings.pacemakerd_exec, "--features"]
@@ -212,7 +212,7 @@ def _get_current_pacemaker_features():
     return (major, minor, rev), features_list
 
 
-@lru_cache()
+@lru_cache
 def is_pacemaker_21_without_20_compatibility():
     return is_minimum_pacemaker_version(
         2, 1, 0
@@ -281,7 +281,7 @@ def skip_unless_root():
     return skipUnless(os.getuid() == 0, "Root user required")
 
 
-@lru_cache()
+@lru_cache
 def _is_booth_resource_agent_installed():
     output, dummy_stderr, dummy_retval = runner.run(
         [settings.crm_resource_exec, "--list-agents", "ocf:pacemaker"]

--- a/pyproject.toml.in
+++ b/pyproject.toml.in
@@ -78,6 +78,7 @@ select = [
   "SLF",
   "SLOT",
   "TC",
+  "UP",
 ]
 # ruff does not respect pylint ignore directives
 # https://github.com/astral-sh/ruff/issues/1203
@@ -86,6 +87,15 @@ ignore = [
   "C408", # https://docs.astral.sh/ruff/rules/unnecessary-collection-call/
   "SIM102", # https://docs.astral.sh/ruff/rules/collapsible-if/
   "TC006", # https://docs.astral.sh/ruff/rules/runtime-cast-value/
+  # deprecated syntax which is used a lot, we want to fix it eventually but not
+  # right now
+  "UP012", # https://docs.astral.sh/ruff/rules/unnecessary-encode-utf8/
+  "UP015", # https://docs.astral.sh/ruff/rules/redundant-open-modes/
+  "UP030", # https://docs.astral.sh/ruff/rules/format-literals/
+  "UP031", # https://docs.astral.sh/ruff/rules/printf-string-formatting/
+  "UP032", # https://docs.astral.sh/ruff/rules/f-string/
+  "UP046", # https://docs.astral.sh/ruff/rules/non-pep695-generic-class/
+  "UP047", # https://docs.astral.sh/ruff/rules/non-pep695-generic-function/
 ]
 
 [tool.ruff.lint.flake8-builtins]


### PR DESCRIPTION
More fixes related to https://github.com/ClusterLabs/pcs/pull/1144

<!-- testing-farm = {"lock":"false","comment-id":"4863623305","data":[{"id":"247f2a68-ce19-4035-88cd-369302267fb5","name":"CentOS-Stream-10","runTime":568.802227,"created":"2026-07-02T08:57:37.079790","updated":"2026-07-02T08:57:37.079798","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/247f2a68-ce19-4035-88cd-369302267fb5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/247f2a68-ce19-4035-88cd-369302267fb5/pipeline.log\">pipeline</a>"]}]} -->