### PR TITLE
Move add_meta_attr_remote from Ruby to Python

### DIFF
--- a/pcs/daemon/app/api_v0.py
+++ b/pcs/daemon/app/api_v0.py
@@ -249,6 +249,33 @@ class ResourceUnmanageHandler(ResourceManageUnmanageHandler):
         return "resource.unmanage"
 
 
+class AddMetaAttrHandler(_BaseApiV0Handler):
+    async def _handle_request(self) -> None:
+        self._check_required_params({"res_id", "key", "value"})
+        res_id = self.get_argument("res_id")
+        key = self.get_argument("key")
+        value = self.get_argument("value")
+        force_flags: list[str] = []
+        if key in ("remote-node", "remote-addr"):
+            # --force is a workaround for missing guest node management in the
+            # web ui. The reports generated are to prevent adding guest nodes,
+            # removing guest nodes and changing their connection parameters.
+            force_flags.append(reports.codes.FORCE)
+
+        result = await self._run_library_command(
+            "resource.update_meta",
+            dict(
+                resource_id=res_id,
+                meta_attrs={key: value},
+                force_flags=force_flags,
+            ),
+        )
+
+        if not result.success:
+            raise self._error(reports_to_str(result.reports))
+        self.write("Successfully added meta attribute")
+
+
 class QdeviceNetGetCaCertificateHandler(_BaseApiV0Handler):
     async def _handle_request(self) -> None:
         result = await self._run_library_command(
@@ -794,7 +821,6 @@ def get_routes(
     sync_config_lock: Lock,
 ) -> RoutesType:
     def r(url: str) -> str:
-        # pylint: disable=invalid-name
         return f"/remote/{url}"
 
     params = dict(
@@ -806,6 +832,7 @@ def get_routes(
         # resources
         (r("manage_resource"), ResourceManageHandler, params),
         (r("unmanage_resource"), ResourceUnmanageHandler, params),
+        (r("add_meta_attr_remote"), AddMetaAttrHandler, params),
         # qdevice
         (
             r("qdevice_net_client_destroy"),

--- a/pcs_test/tier0/daemon/app/test_api_v0.py
+++ b/pcs_test/tier0/daemon/app/test_api_v0.py
@@ -752,6 +752,64 @@ class ResourceUnmanageHandler(ResourceManageUnmanageMixin, ApiV0HandlerTest):
     command_name = "resource.unmanage"
 
 
+class AddMetaAttrHandler(ApiV0HandlerTest):
+    url = "/remote/add_meta_attr_remote"
+    body_data = {"res_id": "myres", "key": "target-role", "value": "Started"}
+    command_data = {
+        "resource_id": "myres",
+        "meta_attrs": {"target-role": "Started"},
+        "force_flags": [],
+    }
+
+    def assert_success(self, body_data, command_data):
+        self.mock_run_library_command.return_value = self.result_success()
+        response = self.fetch(self.url, body=urlencode(body_data))
+        self.assert_body(response.body, "Successfully added meta attribute")
+        self.assertEqual(response.code, 200)
+        self.mock_run_library_command.assert_called_once_with(
+            "resource.update_meta", command_data
+        )
+
+    def test_success(self):
+        self.assert_success(self.body_data, self.command_data)
+
+    def test_success_with_is_stonith_param(self):
+        self.assert_success(
+            {**self.body_data, "is-stonith": "true"}, self.command_data
+        )
+
+    def test_success_remote_node_forced(self):
+        self.assert_success(
+            {"res_id": "myres", "key": "remote-node", "value": "node1"},
+            {
+                "resource_id": "myres",
+                "meta_attrs": {"remote-node": "node1"},
+                "force_flags": [reports.codes.FORCE],
+            },
+        )
+
+    def test_success_remote_addr_forced(self):
+        self.assert_success(
+            {"res_id": "myres", "key": "remote-addr", "value": "10.0.0.1"},
+            {
+                "resource_id": "myres",
+                "meta_attrs": {"remote-addr": "10.0.0.1"},
+                "force_flags": [reports.codes.FORCE],
+            },
+        )
+
+    def test_missing_params(self):
+        response = self.fetch(self.url)
+        self.assertEqual(response.code, 400)
+        self.mock_run_library_command.assert_not_called()
+
+    def test_failure(self):
+        self.assert_error_with_report(self.url, body=urlencode(self.body_data))
+        self.mock_run_library_command.assert_called_once_with(
+            "resource.update_meta", self.command_data
+        )
+
+
 class QdeviceNetGetCaCertificateHandler(ApiV0HandlerTest):
     url = "/remote/qdevice_net_get_ca_certificate"
 

--- a/pcsd/capabilities.xml.in
+++ b/pcsd/capabilities.xml.in
@@ -1733,8 +1733,7 @@
     </capability>
     <capability id="pcmk.resource.update-meta.stonith" in-pcs="0" in-pcsd="1">
       <description>
-        The add_meta_attr_remote url also supports stonith when called with
-        an explicit is-stonith flag.
+        The add_meta_attr_remote url also supports stonith resources.
 
         daemon urls: add_meta_attr_remote
       </description>

--- a/pcsd/pcs.rb
+++ b/pcsd/pcs.rb
@@ -45,20 +45,6 @@ def add_node_attr(auth_user, node, key, value)
   return retval
 end
 
-def add_meta_attr(auth_user, resource, key, value, is_stonith)
-  resource_or_stonith = if is_stonith then "stonith" else "resource" end
-  cmd = [resource_or_stonith, "meta", resource, key.to_s + "=" + value.to_s]
-  flags = []
-  if ["remote-node", "remote-addr"].include?(key.to_s)
-    # --force is a workaround for missing guest node management in the web ui
-    # The reports generated are to prevent adding guest nodes, removing guest
-    # nodes and changing their connection parameters.
-    flags << "--force"
-  end
-  stdout, stderr, retval = run_cmd(auth_user, PCS, *flags, "--", *cmd)
-  return retval
-end
-
 def add_location_constraint(
   auth_user, resource, node, score, force=false
 )

--- a/pcsd/remote.rb
+++ b/pcsd/remote.rb
@@ -64,7 +64,6 @@ def remote(params, request, auth_user)
       # /api/v1/constraint-ticket-remove/v1
       :remove_constraint_remote => method(:remove_constraint_remote),
       :remove_constraint_rule_remote => method(:remove_constraint_rule_remote),
-      :add_meta_attr_remote => method(:add_meta_attr_remote),
       :update_cluster_settings => method(:update_cluster_settings),
       :add_node_attr_remote => method(:add_node_attr_remote),
       :resource_change_group => method(:resource_change_group),
@@ -719,24 +718,6 @@ def add_node_attr_remote(params, request, auth_user)
     return [200, "Successfully added attribute to node"]
   else
     return [400, "Error adding attribute to node"]
-  end
-end
-
-def add_meta_attr_remote(params, request, auth_user)
-  if not allowed_for_local_cluster(auth_user, Permissions::WRITE)
-    return 403, 'Permission denied'
-  end
-  retval = add_meta_attr(
-    auth_user,
-    params["res_id"],
-    params["key"],
-    params["value"],
-    params["is-stonith"] == "true"
-  )
-  if retval == 0
-    return [200, "Successfully added meta attribute"]
-  else
-    return [400, "Error adding meta attribute"]
   end
 end
 


### PR DESCRIPTION
## What does this MR do?

Migrate Ruby `add_meta_attr_remote` API endpoint to Python APIv0.

Assisted-by: ClaudeCode

<!-- testing-farm = {"lock":"false","comment-id":"4876626857","data":[{"id":"215c467e-2fa4-4872-9ede-1c2d565b4b4a","name":"CentOS-Stream-10","runTime":3976.987979,"created":"2026-07-03T11:55:46.389307","updated":"2026-07-03T11:55:46.389313","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/215c467e-2fa4-4872-9ede-1c2d565b4b4a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/215c467e-2fa4-4872-9ede-1c2d565b4b4a/pipeline.log\">pipeline</a>"]}]} -->