### PR TITLE
Move daemons mgmt urls to python

### DIFF
--- a/pcs/cli/common/lib_wrapper.py
+++ b/pcs/cli/common/lib_wrapper.py
@@ -549,12 +549,7 @@ def load_module(env, middleware_factory, name):  # noqa: PLR0911, PLR0912
             middleware.build(),
             {
                 # Internal use only, see lib.commands.services for details
-                "start_service": services.start_service,
-                "stop_service": services.stop_service,
-                "enable_service": services.enable_service,
-                "disable_service": services.disable_service,
                 "get_services_info": services.get_services_info,
-                # End of internal use only commands
             },
         )
     if name == "scsi":

--- a/pcs/daemon/app/api_v0.py
+++ b/pcs/daemon/app/api_v0.py
@@ -219,6 +219,75 @@ class ManageServicesHandler(_BaseApiV0Handler):
         self.write(json.dumps(response))
 
 
+class _SimpleServiceActionHandler(_BaseApiV0Handler):
+    _cmd_name: str
+    _success_message: str
+    _failure_message: str
+
+    async def _handle_request(self) -> None:
+        result = await self._run_library_command(self._cmd_name, {})
+        if not result.success:
+            raise self._error(self._failure_message)
+        self.write(self._success_message)
+
+
+class _ServiceActionWithSkipHandler(_BaseApiV0Handler):
+    _cmd_name: str
+    _success_message: str
+    _failure_message: str
+    _skip_message: str
+
+    async def _handle_request(self) -> None:
+        result = await self._run_library_command(self._cmd_name, {})
+        if not result.success:
+            raise self._error(self._failure_message)
+        if any(
+            report_item.message.code == reports.codes.SERVICE_ACTION_SKIPPED
+            for report_item in result.reports
+        ):
+            self.write(self._skip_message)
+            return
+        self.write(self._success_message)
+
+
+class QdeviceClientDisableHandler(_SimpleServiceActionHandler):
+    _cmd_name = "services.corosync_qdevice_disable_local"
+    _success_message = "corosync-qdevice disabled"
+    _failure_message = "Disabling corosync-qdevice failed"
+
+
+class QdeviceClientEnableHandler(_ServiceActionWithSkipHandler):
+    _cmd_name = "services.corosync_qdevice_enable_local"
+    _success_message = "corosync-qdevice enabled"
+    _failure_message = "Enabling corosync-qdevice failed"
+    _skip_message = "corosync is not enabled, skipping"
+
+
+class QdeviceClientStartHandler(_ServiceActionWithSkipHandler):
+    _cmd_name = "services.corosync_qdevice_start_local"
+    _success_message = "corosync-qdevice started"
+    _failure_message = "Starting corosync-qdevice failed"
+    _skip_message = "corosync is not running, skipping"
+
+
+class QdeviceClientStopHandler(_SimpleServiceActionHandler):
+    _cmd_name = "services.corosync_qdevice_stop_local"
+    _success_message = "corosync-qdevice stopped"
+    _failure_message = "Stopping corosync-qdevice failed"
+
+
+class SbdEnableHandler(_SimpleServiceActionHandler):
+    _cmd_name = "services.sbd_enable_local"
+    _success_message = "SBD enabled"
+    _failure_message = "Enabling SBD failed"
+
+
+class SbdDisableHandler(_SimpleServiceActionHandler):
+    _cmd_name = "services.sbd_disable_local"
+    _success_message = "SBD disabled"
+    _failure_message = "Disabling SBD failed"
+
+
 class ResourceManageUnmanageHandler(_BaseApiV0Handler):
     async def _handle_request(self) -> None:
         self._check_required_params({"resource_list_json"})
@@ -829,6 +898,12 @@ def get_routes(
     return [
         # services
         (r("manage_services"), ManageServicesHandler, params),
+        (r("qdevice_client_disable"), QdeviceClientDisableHandler, params),
+        (r("qdevice_client_enable"), QdeviceClientEnableHandler, params),
+        (r("qdevice_client_start"), QdeviceClientStartHandler, params),
+        (r("qdevice_client_stop"), QdeviceClientStopHandler, params),
+        (r("sbd_disable"), SbdDisableHandler, params),
+        (r("sbd_enable"), SbdEnableHandler, params),
         # resources
         (r("manage_resource"), ResourceManageHandler, params),
         (r("unmanage_resource"), ResourceUnmanageHandler, params),

--- a/pcs/daemon/async_tasks/worker/command_mapping.py
+++ b/pcs/daemon/async_tasks/worker/command_mapping.py
@@ -492,6 +492,30 @@ COMMAND_MAP: Mapping[str, _Cmd] = {
         cmd=services.pacemaker_remote_off_local,
         required_permission=p.WRITE,
     ),
+    "services.corosync_qdevice_enable_local": _Cmd(
+        cmd=services.corosync_qdevice_enable_local,
+        required_permission=p.WRITE,
+    ),
+    "services.corosync_qdevice_disable_local": _Cmd(
+        cmd=services.corosync_qdevice_disable_local,
+        required_permission=p.WRITE,
+    ),
+    "services.corosync_qdevice_start_local": _Cmd(
+        cmd=services.corosync_qdevice_start_local,
+        required_permission=p.WRITE,
+    ),
+    "services.corosync_qdevice_stop_local": _Cmd(
+        cmd=services.corosync_qdevice_stop_local,
+        required_permission=p.WRITE,
+    ),
+    "services.sbd_enable_local": _Cmd(
+        cmd=services.sbd_enable_local,
+        required_permission=p.WRITE,
+    ),
+    "services.sbd_disable_local": _Cmd(
+        cmd=services.sbd_disable_local,
+        required_permission=p.WRITE,
+    ),
     "sbd.check_sbd": _Cmd(
         cmd=sbd.check_sbd,
         required_permission=p.READ,
@@ -548,11 +572,7 @@ COMMAND_MAP: Mapping[str, _Cmd] = {
         required_permission=p.READ,
     ),
     # CMDs allowed in pcs_internal but not exposed via REST API:
-    # "services.disable_service": Cmd(services.disable_service,
-    # "services.enable_service": Cmd(services.enable_service,
-    # "services.get_services_info": Cmd(services.get_services_info,
-    # "services.start_service": Cmd(services.start_service,
-    # "services.stop_service": Cmd(services.stop_service,
+    # "services.get_services_info": _Cmd(services.get_services_info,
 }
 
 
@@ -584,6 +604,12 @@ LEGACY_API_COMMANDS = (
     # the API.
     "services.pacemaker_remote_on_local",
     "services.pacemaker_remote_off_local",
+    "services.corosync_qdevice_enable_local",
+    "services.corosync_qdevice_disable_local",
+    "services.corosync_qdevice_start_local",
+    "services.corosync_qdevice_stop_local",
+    "services.sbd_enable_local",
+    "services.sbd_disable_local",
     "status.full_cluster_status_plaintext",
     "stonith_agent.describe_agent",
     "stonith_agent.list_agents",

--- a/pcs/lib/commands/services.py
+++ b/pcs/lib/commands/services.py
@@ -10,44 +10,12 @@ from pcs.lib.errors import LibraryError
 from pcs.lib.services import service_exception_to_report
 
 
-# Following commands are meant to be used internally only. They are only used
+# Following command is meant to be used internally only. It is only used
 # from pcsd via pcs_internal script, so that the service_manager functionality
-# is not duplicated in ruby. They don't do any checks and thus allow anyone to
-# manage any service, not limited to cluster services. Therefore, they MUST NOT
+# is not duplicated in ruby. It doesn't do any checks and thus allows anyone to
+# query any service, not limited to cluster services. Therefore, it MUST NOT
 # be exposed in CLI, APIv0, APIv1, neither APIv2. Once related ruby code is
-# moved to python, these commands won't be needed anymore and should be removed.
-def start_service(
-    env: LibraryEnvironment,
-    service: str,
-    instance: str | None,
-) -> None:
-    env.service_manager.start(service, instance)
-
-
-def stop_service(
-    env: LibraryEnvironment,
-    service: str,
-    instance: str | None,
-) -> None:
-    env.service_manager.stop(service, instance)
-
-
-def enable_service(
-    env: LibraryEnvironment,
-    service: str,
-    instance: str | None,
-) -> None:
-    env.service_manager.enable(service, instance)
-
-
-def disable_service(
-    env: LibraryEnvironment,
-    service: str,
-    instance: str | None,
-) -> None:
-    env.service_manager.disable(service, instance)
-
-
+# moved to python, this command won't be needed anymore and should be removed.
 def get_services_info(
     env: LibraryEnvironment,
     services: StringIterable,
@@ -95,9 +63,6 @@ def get_services_info(
             )
         ]
     )
-
-
-# End of commands for internal use only.
 
 
 # This module is a good place for commands managing cluster daemons. Naming

--- a/pcs/lib/commands/services.py
+++ b/pcs/lib/commands/services.py
@@ -186,3 +186,133 @@ def pacemaker_remote_off_local(env: LibraryEnvironment) -> None:
     except ManageServiceError as e:
         env.report_processor.report(service_exception_to_report(e))
         raise LibraryError() from e
+
+
+def corosync_qdevice_enable_local(env: LibraryEnvironment) -> None:
+    _ensure_live_env(env)
+    service_name = "corosync-qdevice"
+    if not env.service_manager.is_enabled("corosync"):
+        env.report_processor.report(
+            reports.ReportItem.info(
+                reports.messages.ServiceActionSkipped(
+                    reports.const.SERVICE_ACTION_ENABLE,
+                    service_name,
+                    "corosync is not enabled",
+                )
+            )
+        )
+        return
+    try:
+        env.service_manager.enable(service_name, instance=None)
+        env.report_processor.report(
+            reports.ReportItem.info(
+                reports.messages.ServiceActionSucceeded(
+                    reports.const.SERVICE_ACTION_ENABLE,
+                    service_name,
+                )
+            )
+        )
+    except ManageServiceError as e:
+        env.report_processor.report(service_exception_to_report(e))
+        raise LibraryError() from e
+
+
+def corosync_qdevice_disable_local(env: LibraryEnvironment) -> None:
+    _ensure_live_env(env)
+    service_name = "corosync-qdevice"
+    try:
+        env.service_manager.disable(service_name, instance=None)
+        env.report_processor.report(
+            reports.ReportItem.info(
+                reports.messages.ServiceActionSucceeded(
+                    reports.const.SERVICE_ACTION_DISABLE,
+                    service_name,
+                )
+            )
+        )
+    except ManageServiceError as e:
+        env.report_processor.report(service_exception_to_report(e))
+        raise LibraryError() from e
+
+
+def corosync_qdevice_start_local(env: LibraryEnvironment) -> None:
+    _ensure_live_env(env)
+    service_name = "corosync-qdevice"
+    if not env.service_manager.is_running("corosync"):
+        env.report_processor.report(
+            reports.ReportItem.info(
+                reports.messages.ServiceActionSkipped(
+                    reports.const.SERVICE_ACTION_START,
+                    service_name,
+                    "corosync is not running",
+                )
+            )
+        )
+        return
+    try:
+        env.service_manager.start(service_name, instance=None)
+        env.report_processor.report(
+            reports.ReportItem.info(
+                reports.messages.ServiceActionSucceeded(
+                    reports.const.SERVICE_ACTION_START,
+                    service_name,
+                )
+            )
+        )
+    except ManageServiceError as e:
+        env.report_processor.report(service_exception_to_report(e))
+        raise LibraryError() from e
+
+
+def corosync_qdevice_stop_local(env: LibraryEnvironment) -> None:
+    _ensure_live_env(env)
+    service_name = "corosync-qdevice"
+    try:
+        env.service_manager.stop(service_name, instance=None)
+        env.report_processor.report(
+            reports.ReportItem.info(
+                reports.messages.ServiceActionSucceeded(
+                    reports.const.SERVICE_ACTION_STOP,
+                    service_name,
+                )
+            )
+        )
+    except ManageServiceError as e:
+        env.report_processor.report(service_exception_to_report(e))
+        raise LibraryError() from e
+
+
+def sbd_enable_local(env: LibraryEnvironment) -> None:
+    _ensure_live_env(env)
+    service_name = "sbd"
+    try:
+        env.service_manager.enable(service_name, instance=None)
+        env.report_processor.report(
+            reports.ReportItem.info(
+                reports.messages.ServiceActionSucceeded(
+                    reports.const.SERVICE_ACTION_ENABLE,
+                    service_name,
+                )
+            )
+        )
+    except ManageServiceError as e:
+        env.report_processor.report(service_exception_to_report(e))
+        raise LibraryError() from e
+
+
+def sbd_disable_local(env: LibraryEnvironment) -> None:
+    _ensure_live_env(env)
+    service_name = "sbd"
+    try:
+        env.service_manager.disable(service_name, instance=None)
+        env.report_processor.report(
+            reports.ReportItem.info(
+                reports.messages.ServiceActionSucceeded(
+                    reports.const.SERVICE_ACTION_DISABLE,
+                    service_name,
+                )
+            )
+        )
+    except ManageServiceError as e:
+        env.report_processor.report(service_exception_to_report(e))
+        raise LibraryError() from e

--- a/pcs/lib/commands/services.py
+++ b/pcs/lib/commands/services.py
@@ -1,3 +1,4 @@
+from pcs import settings
 from pcs.common import file_type_codes, reports
 from pcs.common.services.errors import ManageServiceError
 from pcs.common.services_dto import (
@@ -249,7 +250,7 @@ def corosync_qdevice_stop_local(env: LibraryEnvironment) -> None:
 
 def sbd_enable_local(env: LibraryEnvironment) -> None:
     _ensure_live_env(env)
-    service_name = "sbd"
+    service_name = settings.sbd_service_name
     try:
         env.service_manager.enable(service_name, instance=None)
         env.report_processor.report(
@@ -267,7 +268,7 @@ def sbd_enable_local(env: LibraryEnvironment) -> None:
 
 def sbd_disable_local(env: LibraryEnvironment) -> None:
     _ensure_live_env(env)
-    service_name = "sbd"
+    service_name = settings.sbd_service_name
     try:
         env.service_manager.disable(service_name, instance=None)
         env.report_processor.report(

--- a/pcs/pcs_internal.py
+++ b/pcs/pcs_internal.py
@@ -15,11 +15,7 @@ from pcs.lib.errors import LibraryError
 
 SUPPORTED_COMMANDS = {
     "pcs_cfgsync.save_sync_pcs_settings_internal",
-    "services.disable_service",
-    "services.enable_service",
     "services.get_services_info",
-    "services.start_service",
-    "services.stop_service",
 }
 
 

--- a/pcs_test/tier0/daemon/app/test_api_v0.py
+++ b/pcs_test/tier0/daemon/app/test_api_v0.py
@@ -2228,3 +2228,173 @@ class SetSbdConfigHandler(ApiV0HandlerTest):
         self.mock_run_library_command.assert_called_once_with(
             "sbd.set_node_sbd_config_text", self.command_data
         )
+
+
+class QdeviceClientDisableHandler(ApiV0HandlerTest):
+    url = "/remote/qdevice_client_disable"
+
+    def test_success(self):
+        self.mock_run_library_command.return_value = self.result_success()
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "corosync-qdevice disabled")
+        self.assertEqual(response.code, 200)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.corosync_qdevice_disable_local", {}
+        )
+
+    def test_failure(self):
+        self.mock_run_library_command.return_value = self.result_failure()
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "Disabling corosync-qdevice failed")
+        self.assertEqual(response.code, 400)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.corosync_qdevice_disable_local", {}
+        )
+
+
+class QdeviceClientEnableHandler(ApiV0HandlerTest):
+    url = "/remote/qdevice_client_enable"
+
+    def test_success(self):
+        self.mock_run_library_command.return_value = self.result_success()
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "corosync-qdevice enabled")
+        self.assertEqual(response.code, 200)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.corosync_qdevice_enable_local", {}
+        )
+
+    def test_skip(self):
+        self.mock_run_library_command.return_value = self.result_success(
+            reports=[
+                reports.ReportItem.info(
+                    reports.messages.ServiceActionSkipped(
+                        reports.const.SERVICE_ACTION_ENABLE,
+                        "corosync-qdevice",
+                        "corosync is not enabled",
+                    )
+                ).to_dto()
+            ]
+        )
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "corosync is not enabled, skipping")
+        self.assertEqual(response.code, 200)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.corosync_qdevice_enable_local", {}
+        )
+
+    def test_failure(self):
+        self.mock_run_library_command.return_value = self.result_failure()
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "Enabling corosync-qdevice failed")
+        self.assertEqual(response.code, 400)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.corosync_qdevice_enable_local", {}
+        )
+
+
+class QdeviceClientStartHandler(ApiV0HandlerTest):
+    url = "/remote/qdevice_client_start"
+
+    def test_success(self):
+        self.mock_run_library_command.return_value = self.result_success()
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "corosync-qdevice started")
+        self.assertEqual(response.code, 200)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.corosync_qdevice_start_local", {}
+        )
+
+    def test_skip(self):
+        self.mock_run_library_command.return_value = self.result_success(
+            reports=[
+                reports.ReportItem.info(
+                    reports.messages.ServiceActionSkipped(
+                        reports.const.SERVICE_ACTION_START,
+                        "corosync-qdevice",
+                        "corosync is not running",
+                    )
+                ).to_dto()
+            ]
+        )
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "corosync is not running, skipping")
+        self.assertEqual(response.code, 200)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.corosync_qdevice_start_local", {}
+        )
+
+    def test_failure(self):
+        self.mock_run_library_command.return_value = self.result_failure()
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "Starting corosync-qdevice failed")
+        self.assertEqual(response.code, 400)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.corosync_qdevice_start_local", {}
+        )
+
+
+class QdeviceClientStopHandler(ApiV0HandlerTest):
+    url = "/remote/qdevice_client_stop"
+
+    def test_success(self):
+        self.mock_run_library_command.return_value = self.result_success()
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "corosync-qdevice stopped")
+        self.assertEqual(response.code, 200)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.corosync_qdevice_stop_local", {}
+        )
+
+    def test_failure(self):
+        self.mock_run_library_command.return_value = self.result_failure()
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "Stopping corosync-qdevice failed")
+        self.assertEqual(response.code, 400)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.corosync_qdevice_stop_local", {}
+        )
+
+
+class SbdEnableHandler(ApiV0HandlerTest):
+    url = "/remote/sbd_enable"
+
+    def test_success(self):
+        self.mock_run_library_command.return_value = self.result_success()
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "SBD enabled")
+        self.assertEqual(response.code, 200)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.sbd_enable_local", {}
+        )
+
+    def test_failure(self):
+        self.mock_run_library_command.return_value = self.result_failure()
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "Enabling SBD failed")
+        self.assertEqual(response.code, 400)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.sbd_enable_local", {}
+        )
+
+
+class SbdDisableHandler(ApiV0HandlerTest):
+    url = "/remote/sbd_disable"
+
+    def test_success(self):
+        self.mock_run_library_command.return_value = self.result_success()
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "SBD disabled")
+        self.assertEqual(response.code, 200)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.sbd_disable_local", {}
+        )
+
+    def test_failure(self):
+        self.mock_run_library_command.return_value = self.result_failure()
+        response = self.fetch(self.url)
+        self.assert_body(response.body, "Disabling SBD failed")
+        self.assertEqual(response.code, 400)
+        self.mock_run_library_command.assert_called_once_with(
+            "services.sbd_disable_local", {}
+        )

--- a/pcs_test/tier0/lib/commands/test_services.py
+++ b/pcs_test/tier0/lib/commands/test_services.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from pcs import settings
 from pcs.common import file_type_codes, reports
 from pcs.lib.commands import services as lib
 
@@ -460,7 +461,7 @@ class CorosyncQdeviceStopLocal(EnsureLiveEnvMixin, TestCase):
 
 
 class SbdEnableLocal(EnsureLiveEnvMixin, TestCase):
-    service_name = "sbd"
+    service_name = settings.sbd_service_name
 
     def get_lib_command(self):
         return lib.sbd_enable_local
@@ -506,7 +507,7 @@ class SbdEnableLocal(EnsureLiveEnvMixin, TestCase):
 
 
 class SbdDisableLocal(EnsureLiveEnvMixin, TestCase):
-    service_name = "sbd"
+    service_name = settings.sbd_service_name
 
     def get_lib_command(self):
         return lib.sbd_disable_local

--- a/pcs_test/tier0/lib/commands/test_services.py
+++ b/pcs_test/tier0/lib/commands/test_services.py
@@ -7,10 +7,9 @@ from pcs_test.tools import fixture
 from pcs_test.tools.command_env import get_env_tools
 
 
-class PacemakerRemoteServiceMixin:
+class EnsureLiveEnvMixin:
     def setUp(self):
         self.env_assist, self.config = get_env_tools(test_case=self)
-        self.service_name = "pacemaker_remote"
 
     def get_lib_command(self):
         raise NotImplementedError()
@@ -68,7 +67,9 @@ class PacemakerRemoteServiceMixin:
         )
 
 
-class PacemakerRemoteOnLocal(PacemakerRemoteServiceMixin, TestCase):
+class PacemakerRemoteOnLocal(EnsureLiveEnvMixin, TestCase):
+    service_name = "pacemaker_remote"
+
     def get_lib_command(self):
         return lib.pacemaker_remote_on_local
 
@@ -150,7 +151,9 @@ class PacemakerRemoteOnLocal(PacemakerRemoteServiceMixin, TestCase):
         )
 
 
-class PacemakerRemoteOffLocal(PacemakerRemoteServiceMixin, TestCase):
+class PacemakerRemoteOffLocal(EnsureLiveEnvMixin, TestCase):
+    service_name = "pacemaker_remote"
+
     def get_lib_command(self):
         return lib.pacemaker_remote_off_local
 
@@ -225,6 +228,322 @@ class PacemakerRemoteOffLocal(PacemakerRemoteServiceMixin, TestCase):
                     action=reports.const.SERVICE_ACTION_DISABLE,
                     service=self.service_name,
                     reason="disable failed: service timeout",
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+
+class CorosyncQdeviceEnableLocal(EnsureLiveEnvMixin, TestCase):
+    service_name = "corosync-qdevice"
+
+    def get_lib_command(self):
+        return lib.corosync_qdevice_enable_local
+
+    def test_skip_corosync_not_enabled(self):
+        self.config.services.is_enabled("corosync", return_value=False)
+
+        lib.corosync_qdevice_enable_local(self.env_assist.get_env())
+
+        self.env_assist.assert_reports(
+            [
+                fixture.info(
+                    reports.codes.SERVICE_ACTION_SKIPPED,
+                    action=reports.const.SERVICE_ACTION_ENABLE,
+                    service=self.service_name,
+                    reason="corosync is not enabled",
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+    def test_success(self):
+        self.config.services.is_enabled("corosync", return_value=True)
+        self.config.services.enable(self.service_name)
+
+        lib.corosync_qdevice_enable_local(self.env_assist.get_env())
+
+        self.env_assist.assert_reports(
+            [
+                fixture.info(
+                    reports.codes.SERVICE_ACTION_SUCCEEDED,
+                    action=reports.const.SERVICE_ACTION_ENABLE,
+                    service=self.service_name,
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+    def test_failure(self):
+        self.config.services.is_enabled("corosync", return_value=True)
+        self.config.services.enable(
+            self.service_name, failure_msg="enable failed"
+        )
+
+        self.env_assist.assert_raise_library_error(
+            lambda: lib.corosync_qdevice_enable_local(self.env_assist.get_env())
+        )
+
+        self.env_assist.assert_reports(
+            [
+                fixture.error(
+                    reports.codes.SERVICE_ACTION_FAILED,
+                    action=reports.const.SERVICE_ACTION_ENABLE,
+                    service=self.service_name,
+                    reason="enable failed",
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+
+class CorosyncQdeviceDisableLocal(EnsureLiveEnvMixin, TestCase):
+    service_name = "corosync-qdevice"
+
+    def get_lib_command(self):
+        return lib.corosync_qdevice_disable_local
+
+    def test_success(self):
+        self.config.services.disable(self.service_name)
+
+        lib.corosync_qdevice_disable_local(self.env_assist.get_env())
+
+        self.env_assist.assert_reports(
+            [
+                fixture.info(
+                    reports.codes.SERVICE_ACTION_SUCCEEDED,
+                    action=reports.const.SERVICE_ACTION_DISABLE,
+                    service=self.service_name,
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+    def test_failure(self):
+        self.config.services.disable(
+            self.service_name, failure_msg="disable failed"
+        )
+
+        self.env_assist.assert_raise_library_error(
+            lambda: lib.corosync_qdevice_disable_local(
+                self.env_assist.get_env()
+            )
+        )
+
+        self.env_assist.assert_reports(
+            [
+                fixture.error(
+                    reports.codes.SERVICE_ACTION_FAILED,
+                    action=reports.const.SERVICE_ACTION_DISABLE,
+                    service=self.service_name,
+                    reason="disable failed",
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+
+class CorosyncQdeviceStartLocal(EnsureLiveEnvMixin, TestCase):
+    service_name = "corosync-qdevice"
+
+    def get_lib_command(self):
+        return lib.corosync_qdevice_start_local
+
+    def test_skip_corosync_not_running(self):
+        self.config.services.is_running("corosync", return_value=False)
+
+        lib.corosync_qdevice_start_local(self.env_assist.get_env())
+
+        self.env_assist.assert_reports(
+            [
+                fixture.info(
+                    reports.codes.SERVICE_ACTION_SKIPPED,
+                    action=reports.const.SERVICE_ACTION_START,
+                    service=self.service_name,
+                    reason="corosync is not running",
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+    def test_success(self):
+        self.config.services.is_running("corosync", return_value=True)
+        self.config.services.start(self.service_name)
+
+        lib.corosync_qdevice_start_local(self.env_assist.get_env())
+
+        self.env_assist.assert_reports(
+            [
+                fixture.info(
+                    reports.codes.SERVICE_ACTION_SUCCEEDED,
+                    action=reports.const.SERVICE_ACTION_START,
+                    service=self.service_name,
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+    def test_failure(self):
+        self.config.services.is_running("corosync", return_value=True)
+        self.config.services.start(
+            self.service_name, failure_msg="start failed"
+        )
+
+        self.env_assist.assert_raise_library_error(
+            lambda: lib.corosync_qdevice_start_local(self.env_assist.get_env())
+        )
+
+        self.env_assist.assert_reports(
+            [
+                fixture.error(
+                    reports.codes.SERVICE_ACTION_FAILED,
+                    action=reports.const.SERVICE_ACTION_START,
+                    service=self.service_name,
+                    reason="start failed",
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+
+class CorosyncQdeviceStopLocal(EnsureLiveEnvMixin, TestCase):
+    service_name = "corosync-qdevice"
+
+    def get_lib_command(self):
+        return lib.corosync_qdevice_stop_local
+
+    def test_success(self):
+        self.config.services.stop(self.service_name)
+
+        lib.corosync_qdevice_stop_local(self.env_assist.get_env())
+
+        self.env_assist.assert_reports(
+            [
+                fixture.info(
+                    reports.codes.SERVICE_ACTION_SUCCEEDED,
+                    action=reports.const.SERVICE_ACTION_STOP,
+                    service=self.service_name,
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+    def test_failure(self):
+        self.config.services.stop(self.service_name, failure_msg="stop failed")
+
+        self.env_assist.assert_raise_library_error(
+            lambda: lib.corosync_qdevice_stop_local(self.env_assist.get_env())
+        )
+
+        self.env_assist.assert_reports(
+            [
+                fixture.error(
+                    reports.codes.SERVICE_ACTION_FAILED,
+                    action=reports.const.SERVICE_ACTION_STOP,
+                    service=self.service_name,
+                    reason="stop failed",
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+
+class SbdEnableLocal(EnsureLiveEnvMixin, TestCase):
+    service_name = "sbd"
+
+    def get_lib_command(self):
+        return lib.sbd_enable_local
+
+    def test_success(self):
+        self.config.services.enable(self.service_name)
+
+        lib.sbd_enable_local(self.env_assist.get_env())
+
+        self.env_assist.assert_reports(
+            [
+                fixture.info(
+                    reports.codes.SERVICE_ACTION_SUCCEEDED,
+                    action=reports.const.SERVICE_ACTION_ENABLE,
+                    service=self.service_name,
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+    def test_failure(self):
+        self.config.services.enable(
+            self.service_name, failure_msg="enable failed"
+        )
+
+        self.env_assist.assert_raise_library_error(
+            lambda: lib.sbd_enable_local(self.env_assist.get_env())
+        )
+
+        self.env_assist.assert_reports(
+            [
+                fixture.error(
+                    reports.codes.SERVICE_ACTION_FAILED,
+                    action=reports.const.SERVICE_ACTION_ENABLE,
+                    service=self.service_name,
+                    reason="enable failed",
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+
+class SbdDisableLocal(EnsureLiveEnvMixin, TestCase):
+    service_name = "sbd"
+
+    def get_lib_command(self):
+        return lib.sbd_disable_local
+
+    def test_success(self):
+        self.config.services.disable(self.service_name)
+
+        lib.sbd_disable_local(self.env_assist.get_env())
+
+        self.env_assist.assert_reports(
+            [
+                fixture.info(
+                    reports.codes.SERVICE_ACTION_SUCCEEDED,
+                    action=reports.const.SERVICE_ACTION_DISABLE,
+                    service=self.service_name,
+                    node="",
+                    instance="",
+                ),
+            ]
+        )
+
+    def test_failure(self):
+        self.config.services.disable(
+            self.service_name, failure_msg="disable failed"
+        )
+
+        self.env_assist.assert_raise_library_error(
+            lambda: lib.sbd_disable_local(self.env_assist.get_env())
+        )
+
+        self.env_assist.assert_reports(
+            [
+                fixture.error(
+                    reports.codes.SERVICE_ACTION_FAILED,
+                    action=reports.const.SERVICE_ACTION_DISABLE,
+                    service=self.service_name,
+                    reason="disable failed",
                     node="",
                     instance="",
                 ),

--- a/pcsd/pcs.rb
+++ b/pcsd/pcs.rb
@@ -1201,45 +1201,6 @@ def allowed_for_superuser(auth_user)
   return true
 end
 
-def enable_service(service)
-  result = run_pcs_internal(
-    PCSAuth.getSuperuserAuth(),
-    "services.enable_service",
-    {:service => service, :instance => nil},
-  )
-  return result[:status] == 'success'
-end
-
-def disable_service(service)
-  result = run_pcs_internal(
-    PCSAuth.getSuperuserAuth(),
-    "services.disable_service",
-    {:service => service, :instance => nil},
-  )
-  return result[:status] == 'success'
-end
-
-def start_service(service)
-  result = run_pcs_internal(
-    PCSAuth.getSuperuserAuth(),
-    "services.start_service",
-    {:service => service, :instance => nil},
-  )
-  return result[:status] == 'success'
-end
-
-def stop_service(service)
-  if not ServiceChecker.new([service], installed: true).is_installed?(service)
-    return true
-  end
-  result = run_pcs_internal(
-    PCSAuth.getSuperuserAuth(),
-    "services.stop_service",
-    {:service => service, :instance => nil},
-  )
-  return result[:status] == 'success'
-end
-
 class ServiceChecker
   def initialize(services, flags={})
     result = run_pcs_internal(

--- a/pcsd/remote.rb
+++ b/pcsd/remote.rb
@@ -34,14 +34,8 @@ def remote(params, request, auth_user)
       :cluster_destroy => method(:cluster_destroy),
       :get_cluster_known_hosts => method(:get_cluster_known_hosts),
       :get_cluster_properties_definition => method(:get_cluster_properties_definition),
-      :sbd_disable => method(:sbd_disable),
-      :sbd_enable => method(:sbd_enable),
       :remove_stonith_watchdog_timeout=> method(:remove_stonith_watchdog_timeout),
       :set_stonith_watchdog_timeout_to_zero => method(:set_stonith_watchdog_timeout_to_zero),
-      :qdevice_client_enable => method(:qdevice_client_enable),
-      :qdevice_client_disable => method(:qdevice_client_disable),
-      :qdevice_client_start => method(:qdevice_client_start),
-      :qdevice_client_stop => method(:qdevice_client_stop),
       :booth_set_config => method(:booth_set_config),
       :booth_save_files => method(:booth_save_files),
       :put_file => method(:put_file),
@@ -1057,28 +1051,6 @@ def get_cluster_properties_definition(params, request, auth_user)
   return [400, '{}']
 end
 
-def sbd_disable(param, request, auth_user)
-  unless allowed_for_local_cluster(auth_user, Permissions::WRITE)
-    return 403, 'Permission denied'
-  end
-  if disable_service(SBD_SERVICE_NAME)
-    return pcsd_success('SBD disabled')
-  else
-    return pcsd_error("Disabling SBD failed")
-  end
-end
-
-def sbd_enable(param, request, auth_user)
-  unless allowed_for_local_cluster(auth_user, Permissions::WRITE)
-    return 403, 'Permission denied'
-  end
-  if enable_service(SBD_SERVICE_NAME)
-    return pcsd_success('SBD enabled')
-  else
-    return pcsd_error("Enabling SBD failed")
-  end
-end
-
 # Original name of the cluster property is 'stonith-watchdog-timeout'. In
 # pacemaker feature set 3.20.5 (at the time of writing this comment it hasn't
 # been released in any pacemaker version yet), it was renamed to
@@ -1154,54 +1126,6 @@ def set_stonith_watchdog_timeout_to_zero(param, request, auth_user)
     return [400, 'Failed to set cluster property fencing-watchdog-timeout / stonith-watchdog-timeout to zero']
   else
     return [200, 'OK']
-  end
-end
-
-def qdevice_client_disable(param, request, auth_user)
-  unless allowed_for_local_cluster(auth_user, Permissions::WRITE)
-    return 403, 'Permission denied'
-  end
-  if disable_service('corosync-qdevice')
-    return pcsd_success('corosync-qdevice disabled')
-  else
-    return pcsd_error("Disabling corosync-qdevice failed")
-  end
-end
-
-def qdevice_client_enable(param, request, auth_user)
-  unless allowed_for_local_cluster(auth_user, Permissions::WRITE)
-    return 403, 'Permission denied'
-  end
-  if not ServiceChecker.new(['corosync'], enabled: true).is_enabled?('corosync')
-    return pcsd_success('corosync is not enabled, skipping')
-  elsif enable_service('corosync-qdevice')
-    return pcsd_success('corosync-qdevice enabled')
-  else
-    return pcsd_error("Enabling corosync-qdevice failed")
-  end
-end
-
-def qdevice_client_stop(param, request, auth_user)
-  unless allowed_for_local_cluster(auth_user, Permissions::WRITE)
-    return 403, 'Permission denied'
-  end
-  if stop_service('corosync-qdevice')
-    return pcsd_success('corosync-qdevice stopped')
-  else
-    return pcsd_error("Stopping corosync-qdevice failed")
-  end
-end
-
-def qdevice_client_start(param, request, auth_user)
-  unless allowed_for_local_cluster(auth_user, Permissions::WRITE)
-    return 403, 'Permission denied'
-  end
-  if not ServiceChecker.new(['corosync'], running: true).is_running?('corosync')
-    return pcsd_success('corosync is not running, skipping')
-  elsif start_service('corosync-qdevice')
-    return pcsd_success('corosync-qdevice started')
-  else
-    return pcsd_error("Starting corosync-qdevice failed")
   end
 end
 


### PR DESCRIPTION


<!-- testing-farm = {"lock":"false","comment-id":"4925448377","data":[{"id":"e3093b0e-0c92-46cb-a047-b0ffdc2c6891","name":"CentOS-Stream-10","runTime":572.866502,"created":"2026-07-09T13:09:51.887919","updated":"2026-07-09T13:09:51.887926","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/e3093b0e-0c92-46cb-a047-b0ffdc2c6891\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e3093b0e-0c92-46cb-a047-b0ffdc2c6891/pipeline.log\">pipeline</a>"]}]} -->