### PR TITLE
 Remove pylint disable comments 

### DIFF
--- a/pcs/app.py
+++ b/pcs/app.py
@@ -113,10 +113,6 @@ filename = ""
 
 
 def main(argv=None):  # noqa: PLR0912, PLR0915
-    # pylint: disable=global-statement
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     if completion.has_applicable_environment(os.environ):
         print(
             completion.make_suggestions(

--- a/pcs/cli/common/env_cli.py
+++ b/pcs/cli/common/env_cli.py
@@ -1,5 +1,4 @@
 class Env:
-    # pylint: disable=too-many-instance-attributes
     def __init__(self):
         self.cib_data = None
         self.user = None

--- a/pcs/cli/common/lib_wrapper.py
+++ b/pcs/cli/common/lib_wrapper.py
@@ -105,8 +105,6 @@ def bind_all(env, run_with_middleware, dictionary):
 
 
 def load_module(env, middleware_factory, name):  # noqa: PLR0911, PLR0912
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-return-statements
     if name == "acl":
         return bind_all(
             env,

--- a/pcs/cli/host.py
+++ b/pcs/cli/host.py
@@ -19,7 +19,7 @@ from pcs.common.str_tools import format_list
 
 
 def _parse_host_options(host: str, options: Argv) -> Destination:
-    ADDR_OPT_KEYWORD = "addr"  # pylint: disable=invalid-name
+    ADDR_OPT_KEYWORD = "addr"
     supported_options = {ADDR_OPT_KEYWORD}
     parsed_options = KeyValueParser(options).get_unique()
     unknown_options = set(parsed_options.keys()) - supported_options

--- a/pcs/cli/query/resource.py
+++ b/pcs/cli/query/resource.py
@@ -344,7 +344,6 @@ def is_state(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:
         * -f - CIB file
         * --quiet - do not print anything to output
     """
-    # pylint: disable=too-many-locals
     resource_id, instance_id = _pop_resource_id(argv)
 
     sections = group_by_keywords(

--- a/pcs/cli/reports/messages.py
+++ b/pcs/cli/reports/messages.py
@@ -682,7 +682,6 @@ class ResourceWaitDeprecated(CliReportMessageCustom):
 def _create_report_msg_map() -> dict[str, type]:
     result: dict[str, type] = {}
     for report_msg_cls in get_all_subclasses(CliReportMessageCustom):
-        # pylint: disable=protected-access
         code = (
             get_type_hints(report_msg_cls)  # noqa: SLF001
             .get("_obj", item.ReportItemMessage)

--- a/pcs/cli/reports/preprocessor.py
+++ b/pcs/cli/reports/preprocessor.py
@@ -34,7 +34,6 @@ def get_duplicate_constraint_exists_preprocessor(
         matching IDs from the message.
         """
 
-        # pylint: disable=too-many-branches
         nonlocal constraints_dto
 
         def my_print(lines: StringIterable) -> None:

--- a/pcs/cli/resource/output.py
+++ b/pcs/cli/resource/output.py
@@ -114,7 +114,6 @@ def _resource_operation_to_str(
 def resource_agent_parameter_metadata_to_text(  # noqa: PLR0912
     parameter: resource_agent.dto.ResourceAgentParameterDto,
 ) -> list[str]:
-    # pylint: disable=too-many-branches
     # title line
     param_title = [parameter.name]
     if parameter.deprecated_by:
@@ -230,7 +229,6 @@ def resource_agent_metadata_to_text(
 
 
 class ResourcesConfigurationFacade:
-    # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         primitives: Sequence[CibResourcePrimitiveDto],
@@ -1067,7 +1065,6 @@ def _warn_stonith_unsupported(
 def resources_to_cmd(
     resources_facade: ResourcesConfigurationFacade,
 ) -> list[list[str]]:
-    # pylint: disable=too-many-branches
     output: list[list[str]] = []
     primitives_created_with_bundle = set()
     for bundle_dto in resources_facade.bundles:

--- a/pcs/cli/resource/parse_args.py
+++ b/pcs/cli/resource/parse_args.py
@@ -123,8 +123,6 @@ def parse_clone(arg_list: Argv, promotable: bool = False) -> CloneOptions:
 
 
 def parse_create_new(arg_list: Argv) -> ComplexResourceOptions:  # noqa: PLR0912
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
     top_groups = group_by_keywords(
         arg_list,
         {"clone", "promotable", "bundle", "group"},
@@ -253,9 +251,6 @@ def parse_create_new(arg_list: Argv) -> ComplexResourceOptions:  # noqa: PLR0912
 def parse_create_old(  # noqa: PLR0912
     arg_list: Argv, modifiers: InputModifiers
 ) -> ComplexResourceOptions:
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     top_groups = group_by_keywords(
         arg_list,
         {"clone", "promotable", "bundle"},

--- a/pcs/cluster.py
+++ b/pcs/cluster.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import contextlib
 import datetime
 import json
@@ -467,7 +466,6 @@ def stop_cluster_nodes(nodes: StringCollection) -> None:  # noqa: PLR0912
       * --force - no error when possible quorum loss
       * --request-timeout - timeout for HTTP requests
     """
-    # pylint: disable=too-many-branches
     all_nodes, report_list = get_existing_nodes_names(
         utils.get_corosync_conf_facade()
     )
@@ -776,9 +774,6 @@ def cluster_push(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:  # no
       * --config - push only configuration section of CIB
       * -f - CIB file
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
 
     def get_details_from_crm_verify():
         # get a new runner to run crm_verify command and pass the CIB filename
@@ -948,7 +943,6 @@ def cluster_edit(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:  # no
       * -f - CIB file
       * --wait
     """
-    # pylint: disable=too-many-branches
     modifiers.ensure_only_supported("--config", "--wait", "-f")
     if "EDITOR" in os.environ:
         if len(argv) > 1:
@@ -1005,7 +999,6 @@ def get_cib(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:  # noqa: P
       * --config show configuration section of CIB
       * -f - CIB file
     """
-    # pylint: disable=too-many-branches
     del lib
     modifiers.ensure_only_supported("--config", "-f")
     if len(argv) > 2:
@@ -1199,8 +1192,6 @@ def cluster_uidgid(  # noqa: PLR0912
     """
     Options: no options
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
     del lib
     modifiers.ensure_only_supported()
     if not argv:
@@ -1269,8 +1260,6 @@ def cluster_destroy(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:  #
       * --request-timeout - timeout of HTTP requests, effective only with --all
       * --yes - required for destroying the cluster
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-statements
     del lib
     modifiers.ensure_only_supported(
         "--all", "--force", "--request-timeout", "--yes"
@@ -1416,7 +1405,6 @@ def cluster_report(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:  # 
         want to use --overwrite and not --force.
     """
 
-    # pylint: disable=too-many-branches
     del lib
     modifiers.ensure_only_supported("--force", "--from", "--overwrite", "--to")
     if len(argv) != 1:
@@ -1499,8 +1487,6 @@ def cluster_auth_cmd(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:  
       * -u - username
       * -p - password
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
     modifiers.ensure_only_supported(
         "--corosync_conf", "--request-timeout", "-u", "-p"
     )
@@ -1611,7 +1597,7 @@ def _parse_node_options(
     """
     Commandline options: no options
     """
-    ADDR_OPT_KEYWORD = "addr"  # pylint: disable=invalid-name
+    ADDR_OPT_KEYWORD = "addr"
     supported_options = {ADDR_OPT_KEYWORD} | set(additional_options)
     repeatable_options = {ADDR_OPT_KEYWORD} | set(additional_repeatable_options)
     parser = KeyValueParser(options, repeatable_options)
@@ -1683,7 +1669,6 @@ def cluster_setup(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:
       * --corosync_conf - corosync.conf file path, do not talk to cluster nodes
       * --overwrite - allow overwriting existing files
     """
-    # pylint: disable=too-many-locals
     is_local = modifiers.is_specified("--corosync_conf")
 
     allowed_options_common = ["--force", "--no-cluster-uuid"]
@@ -2014,8 +1999,8 @@ def _config_get_cmd(corosync_conf: CorosyncConfDto) -> list[str]:
 
 
 def _parse_add_node(argv: Argv) -> dict[str, str | list[str]]:
-    DEVICE_KEYWORD = "device"  # pylint: disable=invalid-name
-    WATCHDOG_KEYWORD = "watchdog"  # pylint: disable=invalid-name
+    DEVICE_KEYWORD = "device"
+    WATCHDOG_KEYWORD = "watchdog"
     hostname, *argv = argv
     node_dict = _parse_node_options(
         hostname,

--- a/pcs/common/corosync_conf.py
+++ b/pcs/common/corosync_conf.py
@@ -32,7 +32,6 @@ class CorosyncQuorumDeviceSettingsDto(DataTransferObject):
 
 @dataclass(frozen=True)
 class CorosyncConfDto(DataTransferObject):
-    # pylint: disable=too-many-instance-attributes
     cluster_name: str
     cluster_uuid: str | None
     transport: CorosyncTransportType

--- a/pcs/common/interface/dto.py
+++ b/pcs/common/interface/dto.py
@@ -11,7 +11,7 @@ from pcs.common import types
 from pcs.common.str_tools import format_list
 
 if TYPE_CHECKING:
-    from _typeshed import DataclassInstance  # pylint: disable=import-error
+    from _typeshed import DataclassInstance
 else:
 
     class DataclassInstance:

--- a/pcs/common/node_communicator.py
+++ b/pcs/common/node_communicator.py
@@ -538,7 +538,6 @@ def _create_request_handle(
     # it is not possible to take this callback out of this function, because of
     # curl API
     def __debug_callback(data_type: int, debug_data: bytes) -> None:
-        # pylint: disable=no-member
         prefixes = {
             # Dynamically added attributes in pcs/common/pcs_pycurl.py
             pycurl.DEBUG_TEXT: b"* ",  # type: ignore[attr-defined]

--- a/pcs/common/pacemaker/constraint/all.py
+++ b/pcs/common/pacemaker/constraint/all.py
@@ -23,7 +23,6 @@ from .ticket import (
 
 @dataclass(frozen=True)
 class CibConstraintsDto(DataTransferObject):
-    # pylint: disable=too-many-instance-attributes
     location: Sequence[CibConstraintLocationDto] = tuple()
     location_set: Sequence[CibConstraintLocationSetDto] = tuple()
     colocation: Sequence[CibConstraintColocationDto] = tuple()

--- a/pcs/common/pacemaker/constraint/colocation.py
+++ b/pcs/common/pacemaker/constraint/colocation.py
@@ -18,7 +18,6 @@ class CibConstraintColocationAttributesDto(DataTransferObject):
 
 @dataclass(frozen=True)
 class CibConstraintColocationDto(DataTransferObject):
-    # pylint: disable=too-many-instance-attributes
     resource_id: str
     with_resource_id: str
     node_attribute: str | None

--- a/pcs/common/pacemaker/constraint/set.py
+++ b/pcs/common/pacemaker/constraint/set.py
@@ -10,7 +10,6 @@ from pcs.common.pacemaker.types import (
 
 @dataclass(frozen=True)
 class CibResourceSetDto(DataTransferObject):
-    # pylint: disable=too-many-instance-attributes
     set_id: str
     sequential: bool | None
     require_all: bool | None

--- a/pcs/common/pacemaker/nvset.py
+++ b/pcs/common/pacemaker/nvset.py
@@ -7,14 +7,14 @@ from pcs.common.pacemaker.rule import CibRuleExpressionDto
 
 @dataclass(frozen=True)
 class CibNvpairDto(DataTransferObject):
-    id: str  # pylint: disable=invalid-name
+    id: str
     name: str
     value: str
 
 
 @dataclass(frozen=True)
 class CibNvsetDto(DataTransferObject):
-    id: str  # pylint: disable=invalid-name
+    id: str
     options: Mapping[str, str]
     rule: CibRuleExpressionDto | None
     nvpairs: Sequence[CibNvpairDto]

--- a/pcs/common/pacemaker/resource/bundle.py
+++ b/pcs/common/pacemaker/resource/bundle.py
@@ -24,7 +24,7 @@ class CibResourceBundleContainerRuntimeOptionsDto(DataTransferObject):
 
 @dataclass(frozen=True)
 class CibResourceBundlePortMappingDto(DataTransferObject):
-    id: str  # pylint: disable=invalid-name
+    id: str
     port: int | None
     internal_port: int | None
     range: str | None
@@ -41,7 +41,7 @@ class CibResourceBundleNetworkOptionsDto(DataTransferObject):
 
 @dataclass(frozen=True)
 class CibResourceBundleStorageMappingDto(DataTransferObject):
-    id: str  # pylint: disable=invalid-name
+    id: str
     source_dir: str | None
     source_dir_root: str | None
     target_dir: str
@@ -50,8 +50,7 @@ class CibResourceBundleStorageMappingDto(DataTransferObject):
 
 @dataclass(frozen=True)
 class CibResourceBundleDto(DataTransferObject):
-    # pylint: disable=too-many-instance-attributes
-    id: str  # pylint: disable=invalid-name
+    id: str
     description: str | None
     member_id: str | None
     container_type: ContainerType | None

--- a/pcs/common/pacemaker/resource/clone.py
+++ b/pcs/common/pacemaker/resource/clone.py
@@ -7,7 +7,7 @@ from pcs.common.pacemaker.nvset import CibNvsetDto
 
 @dataclass(frozen=True)
 class CibResourceCloneDto(DataTransferObject):
-    id: str  # pylint: disable=invalid-name
+    id: str
     description: str | None
     member_id: str
     meta_attributes: Sequence[CibNvsetDto]

--- a/pcs/common/pacemaker/resource/group.py
+++ b/pcs/common/pacemaker/resource/group.py
@@ -7,7 +7,7 @@ from pcs.common.pacemaker.nvset import CibNvsetDto
 
 @dataclass(frozen=True)
 class CibResourceGroupDto(DataTransferObject):
-    id: str  # pylint: disable=invalid-name
+    id: str
     description: str | None
     member_ids: list[str]
     meta_attributes: Sequence[CibNvsetDto]

--- a/pcs/common/pacemaker/resource/operations.py
+++ b/pcs/common/pacemaker/resource/operations.py
@@ -13,8 +13,7 @@ OCF_CHECK_LEVEL_INSTANCE_ATTRIBUTE_NAME = "OCF_CHECK_LEVEL"
 
 @dataclass(frozen=True)
 class CibResourceOperationDto(DataTransferObject):
-    # pylint: disable=too-many-instance-attributes
-    id: str  # pylint: disable=invalid-name
+    id: str
     name: str
     interval: str
     description: str | None

--- a/pcs/common/pacemaker/resource/primitive.py
+++ b/pcs/common/pacemaker/resource/primitive.py
@@ -10,7 +10,7 @@ from .operations import CibResourceOperationDto
 
 @dataclass(frozen=True)
 class CibResourcePrimitiveDto(DataTransferObject):
-    id: str  # pylint: disable=invalid-name
+    id: str
     agent_name: ResourceAgentNameDto
     description: str | None
     operations: Sequence[CibResourceOperationDto]

--- a/pcs/common/pacemaker/resource/relations.py
+++ b/pcs/common/pacemaker/resource/relations.py
@@ -8,7 +8,7 @@ from pcs.common.types import ResourceRelationType
 
 @dataclass(frozen=True)
 class RelationEntityDto(DataTransferObject):
-    id: str  # pylint: disable=invalid-name
+    id: str
     type: ResourceRelationType
     members: list[str]
     metadata: Mapping[str, Any]

--- a/pcs/common/pacemaker/rule.py
+++ b/pcs/common/pacemaker/rule.py
@@ -10,14 +10,13 @@ from pcs.common.types import (
 
 @dataclass(frozen=True)
 class CibRuleDateCommonDto(DataTransferObject):
-    id: str  # pylint: disable=invalid-name
+    id: str
     options: Mapping[str, str]
 
 
 @dataclass(frozen=True)
 class CibRuleExpressionDto(DataTransferObject):
-    # pylint: disable=too-many-instance-attributes
-    id: str  # pylint: disable=invalid-name
+    id: str
     type: CibRuleExpressionType
     in_effect: CibRuleInEffectStatus  # only valid for type==rule
     options: Mapping[str, str]

--- a/pcs/common/pcs_pycurl.py
+++ b/pcs/common/pcs_pycurl.py
@@ -1,7 +1,5 @@
 import sys
 
-# pylint: disable=unused-wildcard-import
-# pylint: disable=wildcard-import
 from pycurl import *  # noqa: F403
 
 # This package defines constants which are not present in some older versions

--- a/pcs/common/reports/codes.py
+++ b/pcs/common/reports/codes.py
@@ -1,5 +1,3 @@
-# pylint: disable=unused-wildcard-import
-# pylint: disable=wildcard-import
 # Wildcard import of deprecated report codes will prevent creation of a new
 # report with the code of deprecated report
 from .deprecated_codes import *  # noqa: F403

--- a/pcs/common/reports/conversions.py
+++ b/pcs/common/reports/conversions.py
@@ -34,7 +34,7 @@ def report_dto_to_item(
 def _create_report_msg_map() -> dict[str, type]:
     result: dict[str, type] = {}
     for report_msg_cls in get_all_subclasses(messages.ReportItemMessage):
-        code = report_msg_cls._code  # pylint: disable=protected-access # noqa: SLF001
+        code = report_msg_cls._code  # noqa: SLF001
         if code:
             if code in result:
                 raise AssertionError()

--- a/pcs/common/reports/messages.py
+++ b/pcs/common/reports/messages.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -840,7 +839,7 @@ class InvalidIdBadChar(ReportItemMessage):
     is_first_char -- is it the first character which is forbidden?
     """
 
-    id: str  # pylint: disable=invalid-name
+    id: str
     id_description: str
     invalid_character: str
     is_first_char: bool
@@ -2736,7 +2735,7 @@ class IdAlreadyExists(ReportItemMessage):
     id -- existing id
     """
 
-    id: str  # pylint: disable=invalid-name
+    id: str
     _code = codes.ID_ALREADY_EXISTS
 
     @property
@@ -2752,7 +2751,7 @@ class IdBelongsToUnexpectedType(ReportItemMessage):
     But id does not belong to group.
     """
 
-    id: str  # pylint: disable=invalid-name
+    id: str
     expected_types: list[str]
     current_type: str
     _code = codes.ID_BELONGS_TO_UNEXPECTED_TYPE
@@ -2829,7 +2828,7 @@ class IdNotFound(ReportItemMessage):
     context_id -- id of the subsection
     """
 
-    id: str  # pylint: disable=invalid-name
+    id: str
     expected_types: list[str]
     context_type: str = ""
     context_id: str = ""

--- a/pcs/common/resource_agent/dto.py
+++ b/pcs/common/resource_agent/dto.py
@@ -25,8 +25,6 @@ class ListResourceAgentNameDto(DataTransferObject):
 
 @dataclass(frozen=True)
 class ResourceAgentActionDto(DataTransferObject):
-    # pylint: disable=too-many-instance-attributes
-
     # (start, stop, promote...), mandatory by both OCF 1.0 and 1.1
     name: str
     # mandatory by both OCF 1.0 and 1.1, sometimes not defined by agents
@@ -48,8 +46,6 @@ class ResourceAgentActionDto(DataTransferObject):
 
 @dataclass(frozen=True)
 class ResourceAgentParameterDto(DataTransferObject):
-    # pylint: disable=too-many-instance-attributes
-
     # name of the parameter
     name: str
     # short description

--- a/pcs/common/status_dto.py
+++ b/pcs/common/status_dto.py
@@ -10,7 +10,6 @@ from pcs.common.interface.dto import DataTransferObject
 
 @dataclass(frozen=True)
 class PrimitiveStatusDto(DataTransferObject):
-    # pylint: disable=too-many-instance-attributes
     resource_id: str
     instance_id: str | None
     resource_agent: str
@@ -42,7 +41,6 @@ class GroupStatusDto(DataTransferObject):
 
 @dataclass(frozen=True)
 class CloneStatusDto(DataTransferObject):
-    # pylint: disable=too-many-instance-attributes
     resource_id: str
     multi_state: bool
     unique: bool
@@ -67,7 +65,6 @@ class BundleReplicaStatusDto(DataTransferObject):
 
 @dataclass(frozen=True)
 class BundleStatusDto(DataTransferObject):
-    # pylint: disable=too-many-instance-attributes
     resource_id: str
     type: str
     image: str

--- a/pcs/config.py
+++ b/pcs/config.py
@@ -114,9 +114,6 @@ def _config_show_cib_lines(lib, properties_facade=None):  # noqa: PLR0912, PLR09
     Commandline options:
       * -f - CIB file
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
 
     # update of pcs_options will change output of constraint show and
     # displaying resources and operations defaults
@@ -341,8 +338,6 @@ def config_restore_remote(infile_name, infile_obj):  # noqa: PLR0912
     Commandline options:
       * --request-timeout - timeout for HTTP requests
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
     extracted = {
         "version.txt": "",
         "corosync.conf": "",
@@ -429,9 +424,6 @@ def config_restore_local(infile_name, infile_obj):  # noqa: PLR0912, PLR0915
     """
     Commandline options: no options
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     service_manager = utils.get_service_manager()
     if (
         service_manager.is_running("corosync")
@@ -846,7 +838,6 @@ def config_checkpoint_restore(lib, argv, modifiers):
     cib_path = os.path.join(settings.cib_dir, "cib-%s.raw" % argv[0])
     try:
         snapshot_dom = parse(cib_path)
-    # pylint: disable=broad-except
     except Exception as e:
         utils.err("unable to read the checkpoint: %s" % e)
     utils.replace_cib_configuration(snapshot_dom)

--- a/pcs/constraint.py
+++ b/pcs/constraint.py
@@ -65,12 +65,6 @@ from pcs.lib.pacemaker.values import (
     sanitize_id,
 )
 
-# pylint: disable=invalid-name
-# pylint: disable=too-many-branches
-# pylint: disable=too-many-lines
-# pylint: disable=too-many-locals
-# pylint: disable=too-many-statements
-
 DEFAULT_ACTION = const.PCMK_ACTION_START
 DEFAULT_ROLE = const.PCMK_ROLE_STARTED
 
@@ -1018,7 +1012,6 @@ def location_add(  # noqa: PLR0912, PLR0915
     elementsToRemove = [
         rsc_loc
         for rsc_loc in constraintsElement.getElementsByTagName("rsc_location")
-        # pylint: disable=too-many-boolean-expressions
         if rsc_loc.getAttribute("id") == constraint_id
         or (
             rsc_loc.getAttribute("node") == node

--- a/pcs/daemon/app/common.py
+++ b/pcs/daemon/app/common.py
@@ -191,8 +191,6 @@ class LegacyApiHandler(LegacyApiBaseHandler):
 
 
 class RedirectHandler(EnhanceHeadersMixin, TornadoRedirectHandler):
-    # abstract method `data_received` is not used in redirect:
-    # pylint: disable=abstract-method
     """
     RedirectHandler with modified HTTP headers.
     """

--- a/pcs/daemon/app/ui_common.py
+++ b/pcs/daemon/app/ui_common.py
@@ -14,10 +14,6 @@ class AjaxMixin:
 
 
 class StaticFile(EnhanceHeadersMixin, StaticFileHandler):
-    # abstract method `data_received` does need to be overridden. This
-    # method should be implemented to handle streamed request data.
-    # BUT static files are not streamed SO:
-    # pylint: disable=abstract-method
     def initialize(
         self, path: str, default_filename: str | None = None
     ) -> None:

--- a/pcs/daemon/async_tasks/scheduler.py
+++ b/pcs/daemon/async_tasks/scheduler.py
@@ -49,7 +49,6 @@ class SchedulerConfig:
 
 
 class Scheduler:
-    # pylint: disable=too-many-instance-attributes
     """
     Task management core with an interface for the REST API
     """
@@ -67,7 +66,6 @@ class Scheduler:
         self._logging_q = self._proc_pool_manager.Queue()
         self._worker_log_listener = self._init_worker_logging()
         self._single_use_process_pool: list[mp.Process] = []
-        # pylint: disable=consider-using-with
         self._proc_pool = mp.Pool(
             processes=self._config.worker_count,
             maxtasksperchild=self._config.worker_reset_limit,
@@ -200,7 +198,6 @@ class Scheduler:
             del self._task_register[task.task_ident]
 
     def _spawn_new_single_use_worker(self) -> None:
-        # pylint: disable=protected-access
         additional_process = mp.Process(
             group=None,
             target=mp_worker_init,

--- a/pcs/daemon/async_tasks/task.py
+++ b/pcs/daemon/async_tasks/task.py
@@ -56,7 +56,6 @@ class Task(ImplementsToDto):
     Task's representation in the scheduler
     """
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         task_ident: str,

--- a/pcs/daemon/async_tasks/worker/executor.py
+++ b/pcs/daemon/async_tasks/worker/executor.py
@@ -42,7 +42,6 @@ def worker_init(message_q: mp.Queue, logging_q: mp.Queue) -> None:
     :param message_q: Queue instance for sending messages to the scheduler
     :param logging_q: Queue instance for sending log records to the scheduler
     """
-    # pylint: disable=global-statement
     # Create and configure new logger
     logger = setup_worker_logger(logging_q)
     logger.info("Worker initialized.")
@@ -52,7 +51,6 @@ def worker_init(message_q: mp.Queue, logging_q: mp.Queue) -> None:
     worker_com = WorkerCommunicator(message_q)
 
     def ignore_signals(sig_num, frame):  # type: ignore
-        # pylint: disable=unused-argument
         pass
 
     signal.signal(signal.SIGINT, ignore_signals)
@@ -188,7 +186,7 @@ def task_executor(task: WorkerCommand) -> None:
         logger.error("Task %s raised a LibraryError: %s.", task.task_ident, e)
         _pause_worker()
         return
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as e:
         # For unhandled exceptions during execution
         worker_com.put(
             Message(
@@ -221,7 +219,6 @@ def _param_to_field_tuple(
         return (
             param.name,
             field_type,
-            # pylint: disable=invalid-field-call
             # this is actually used within make_dataclass function
             dataclasses.field(default=param.default),
         )

--- a/pcs/daemon/async_tasks/worker/logging.py
+++ b/pcs/daemon/async_tasks/worker/logging.py
@@ -20,8 +20,6 @@ class Logger(logging.Logger):
         extra=None,
         sinfo=None,
     ) -> logging.LogRecord:
-        # pylint: disable=too-many-arguments
-        # pylint: disable=too-many-positional-arguments
         pid = os.getpid()
         return super().makeRecord(
             name,

--- a/pcs/daemon/env.py
+++ b/pcs/daemon/env.py
@@ -123,7 +123,6 @@ def str_to_ssl_options(ssl_options_string, reports):
 
 
 class EnvLoader:
-    # pylint: disable=too-many-public-methods
     def __init__(self, environ):
         self.environ = environ
         self.errors = []

--- a/pcs/daemon/http_server.py
+++ b/pcs/daemon/http_server.py
@@ -16,7 +16,6 @@ class HttpsServerManageException(Exception):
 
 
 class HttpsServerManage:
-    # pylint: disable=too-many-instance-attributes
     """
     Instance of HttpsServerManage encapsulates the construction of an HTTPServer
     """

--- a/pcs/daemon/log.py
+++ b/pcs/daemon/log.py
@@ -9,7 +9,6 @@ LOGGER_NAMES = [
     "tornado.general",
 ]
 
-# pylint:disable=invalid-name
 pcsd = logging.getLogger("pcs.daemon")
 
 

--- a/pcs/daemon/run.py
+++ b/pcs/daemon/run.py
@@ -120,7 +120,6 @@ def configure_app(  # noqa: PLR0913
     *,
     debug: bool = False,
 ):
-    # pylint: disable=too-many-arguments
     def make_app(https_server_manage: HttpsServerManage):
         """
         https_server_manage -- allows to control the server (specifically

--- a/pcs/daemon/systemd.py
+++ b/pcs/daemon/systemd.py
@@ -19,7 +19,6 @@ async def notify(socket_name):
         await stream.connect(socket_name)
         await stream.write(b"READY=1")
         stream.close()
-        # pylint: disable=broad-except
     except Exception as e:
         log.pcsd.error("Unable to notify systemd on '%s': %s", socket_name, e)
 

--- a/pcs/entry_points/cli.py
+++ b/pcs/entry_points/cli.py
@@ -1,6 +1,3 @@
-# pylint: disable=unused-import
-# pylint: disable=wrong-import-position
-
 from .common import add_bundled_packages_to_path
 
 add_bundled_packages_to_path()

--- a/pcs/entry_points/daemon.py
+++ b/pcs/entry_points/daemon.py
@@ -1,6 +1,3 @@
-# pylint: disable=unused-import
-# pylint: disable=wrong-import-position
-
 from .common import add_bundled_packages_to_path
 
 add_bundled_packages_to_path()

--- a/pcs/entry_points/internal.py
+++ b/pcs/entry_points/internal.py
@@ -1,6 +1,3 @@
-# pylint: disable=unused-import
-# pylint: disable=wrong-import-position
-
 from .common import add_bundled_packages_to_path
 
 add_bundled_packages_to_path()

--- a/pcs/entry_points/snmp_agent.py
+++ b/pcs/entry_points/snmp_agent.py
@@ -1,6 +1,3 @@
-# pylint: disable=unused-import
-# pylint: disable=wrong-import-position
-
 from .common import add_bundled_packages_to_path
 
 add_bundled_packages_to_path()

--- a/pcs/lib/auth/pam.py
+++ b/pcs/lib/auth/pam.py
@@ -19,15 +19,15 @@ PAM_PROMPT_ECHO_OFF = 1
 PCSD_SERVICE = "pcsd"
 
 
-class pam_message(Structure):  # pylint: disable=invalid-name
+class pam_message(Structure):
     _fields_ = [("msg_style", c_int), ("msg", POINTER(c_char))]
 
 
-class pam_response(Structure):  # pylint: disable=invalid-name
+class pam_response(Structure):
     _fields_ = [("resp", POINTER(c_char)), ("resp_retcode", c_int)]
 
 
-class pam_handle(Structure):  # pylint: disable=invalid-name
+class pam_handle(Structure):
     _fields_ = [("handle", c_void_p)]
 
 
@@ -40,11 +40,11 @@ pam_conversation = CFUNCTYPE(
 )
 
 
-class pam_conv(Structure):  # pylint: disable=invalid-name
+class pam_conv(Structure):
     _fields_ = [("conv", pam_conversation), ("appdata_ptr", c_void_p)]
 
 
-def _prep_fn(fn, restype, argtypes):  # pylint: disable=invalid-name
+def _prep_fn(fn, restype, argtypes):
     fn.restype = restype
     fn.argtypes = argtypes
     return fn

--- a/pcs/lib/cib/constraint/ticket.py
+++ b/pcs/lib/cib/constraint/ticket.py
@@ -282,7 +282,6 @@ def remove_with_resource_set(
             continue
         set_element.remove(ref_element)
         # set_element is lxml element, therefore we have to use len() here
-        # pylint: disable=len-as-condition
         if not len(set_element):
             ticket_element = set_element.getparent()
             if ticket_element is None:

--- a/pcs/lib/cib/fencing_topology.py
+++ b/pcs/lib/cib/fencing_topology.py
@@ -100,8 +100,6 @@ def add_level(  # noqa: PLR0913
     force_device -- continue even if a stonith device does not exist
     force_node -- continue even if a node (target) does not exist
     """
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-positional-arguments
     id_provider = IdProvider(cib)
     validate_id_reports: ReportItemList = []
     if level_id is not None:

--- a/pcs/lib/cib/nvpair_multi.py
+++ b/pcs/lib/cib/nvpair_multi.py
@@ -149,8 +149,6 @@ class ValidateNvsetAppendNew:
     Validator for creating new nvset and appending it to CIB
     """
 
-    # pylint: disable=too-many-instance-attributes
-
     def __init__(
         self,
         id_provider: IdProvider,

--- a/pcs/lib/cib/remove_elements.py
+++ b/pcs/lib/cib/remove_elements.py
@@ -487,7 +487,6 @@ def _is_last_element(parent_element: _Element, child_tag: str) -> bool:
 def _is_empty_after_inner_el_removal(  # noqa: PLR0911
     parent_el: _Element,
 ) -> bool:
-    # pylint: disable=too-many-return-statements
     if is_any_clone(parent_el):
         return True
     if is_group(parent_el):

--- a/pcs/lib/cib/resource/bundle.py
+++ b/pcs/lib/cib/resource/bundle.py
@@ -246,8 +246,6 @@ def append_new(  # noqa: PLR0913
     storage_map: Iterable[Mapping[str, str]],
     meta_attributes: Mapping[str, str],
 ) -> _Element:
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-positional-arguments
     """
     Create new bundle and add it to the CIB
 
@@ -378,8 +376,6 @@ def validate_update(  # noqa: PLR0913
     meta_attributes: Mapping[str, str],
     force_options: bool = False,
 ) -> reports.ReportItemList:
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-positional-arguments
     """
     Validate modifying an existing bundle, return list of report items
 
@@ -425,8 +421,6 @@ def update(  # noqa: PLR0913
     storage_map_remove: StringIterable,
     meta_attributes: Mapping[str, str],
 ) -> None:
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-positional-arguments
     """
     Modify an existing bundle (does not touch encapsulated resources)
 

--- a/pcs/lib/cib/resource/primitive.py
+++ b/pcs/lib/cib/resource/primitive.py
@@ -150,9 +150,6 @@ def create(  # noqa: PLR0913
     do_not_report_instance_attribute_server_exists: bool = False,
     enable_agent_self_validation: bool = False,
 ) -> _Element:
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-positional-arguments
     """
     Prepare all parts of primitive resource and append it into cib.
 
@@ -223,7 +220,6 @@ def create(  # noqa: PLR0913
                 report_msg = cast(
                     reports.messages.InvalidOptions, report_item.message
                 )
-                # pylint: disable=no-member
                 report_item.message = reports.messages.InvalidOptions(
                     report_msg.option_names,
                     sorted(
@@ -310,8 +306,6 @@ def append_new(  # noqa: PLR0913
     meta_attributes: Mapping[str, str],
     operation_list: Iterable[ResourceOperationFilteredIn],
 ) -> _Element:
-    # pylint:disable=too-many-arguments
-    # pylint: disable=too-many-positional-arguments
     """
     Append a new primitive element to the resources_section.
 
@@ -533,7 +527,6 @@ def validate_resource_instance_attributes_update(
     # will be fixed to accept the updated resource as an element instead of a
     # string.
 
-    # pylint: disable=too-many-locals
     report_items: reports.ReportItemList = []
     current_instance_attrs = get_nvset_as_dict(
         INSTANCE_ATTRIBUTES_TAG,

--- a/pcs/lib/cib/resource/relations.py
+++ b/pcs/lib/cib/resource/relations.py
@@ -58,7 +58,6 @@ class ResourceRelationNode:
         self._is_leaf = True
 
     def add_member(self, member: "ResourceRelationNode") -> None:
-        # pylint: disable=protected-access
         if member._parent is not None:  # noqa: SLF001
             raise AssertionError(
                 "object {} already has a parent set: {}".format(
@@ -81,7 +80,6 @@ class ResourceRelationNode:
             self._members.append(member)
 
     def _get_all_parents(self) -> list[str]:
-        # pylint: disable=protected-access
         if self._parent is None:
             return []
         return self._parent._get_all_parents() + [self._parent.obj.id]  # noqa: SLF001

--- a/pcs/lib/cib/resource/remote_node.py
+++ b/pcs/lib/cib/resource/remote_node.py
@@ -214,8 +214,6 @@ def create(  # noqa: PLR0913
     allow_invalid_instance_attributes: bool = False,
     use_default_operations: bool = True,
 ) -> _Element:
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-positional-arguments
     """
     Prepare all parts of remote resource and append it into the cib.
 

--- a/pcs/lib/cib/resource/stonith.py
+++ b/pcs/lib/cib/resource/stonith.py
@@ -433,7 +433,6 @@ def update_scsi_devices_without_restart(
     id_provider -- elements' ids generator
     device_list -- list of updated scsi devices
     """
-    # pylint: disable=too-many-locals
     cib = get_root(resource_el)
     resource_id = resource_el.get("id", "")
     roles_with_nodes = get_resource_state(cluster_state, resource_id)

--- a/pcs/lib/cib/resource/validations.py
+++ b/pcs/lib/cib/resource/validations.py
@@ -279,7 +279,6 @@ def validate_unmove_unban(
 
 @dataclass(frozen=True)
 class _MoveBanClearAnalysis:
-    # pylint: disable=too-many-instance-attributes
     is_bundle: bool
     is_in_bundle: bool
     is_clone: bool

--- a/pcs/lib/cib/rule/cib_to_str.py
+++ b/pcs/lib/cib/rule/cib_to_str.py
@@ -71,8 +71,6 @@ class RuleToStr:
         return f" {boolean_op} ".join(string_parts)
 
     def _simple_expr_to_str(self, expr_el: _Element) -> str:
-        # pylint - all *_to_str methods must have the same interface
-        # pylint: disable=no-self-use
         string_parts = []
         if "value" in expr_el.attrib:
             # "attribute" and "operation" are defined as mandatory in CIB schema
@@ -130,8 +128,6 @@ class RuleToStr:
         return " ".join(string_parts)
 
     def _op_expr_to_str(self, expr_el: _Element) -> str:
-        # pylint - all *_to_str methods must have the same interface
-        # pylint: disable=no-self-use
         string_parts = ["op", str(expr_el.get("name", ""))]
         if "interval" in expr_el.attrib:
             string_parts.append(
@@ -140,8 +136,6 @@ class RuleToStr:
         return " ".join(string_parts)
 
     def _rsc_expr_to_str(self, expr_el: _Element) -> str:
-        # pylint - all *_to_str methods must have the same interface
-        # pylint: disable=no-self-use
         return "resource " + ":".join(
             [
                 str(expr_el.get(attr, ""))

--- a/pcs/lib/cib/rule/parsed_to_cib.py
+++ b/pcs/lib/cib/rule/parsed_to_cib.py
@@ -83,7 +83,6 @@ class _Exporter:
         id_: str | None = None,
     ) -> _Element:
         func = self.part_export_map[type(expr_tree)]
-        # pylint: disable=comparison-with-callable
         if func == self._export_bool:
             # mypy doesn't handle this dynamic call
             return func(parent_el, expr_tree, id_)  # type: ignore

--- a/pcs/lib/cib/rule/validator.py
+++ b/pcs/lib/cib/rule/validator.py
@@ -56,7 +56,6 @@ class Validator:
         return report_list
 
     def _call_validate(self, expr: RuleExprPart) -> reports.ReportItemList:  # noqa: PLR0911
-        # pylint: disable=too-many-return-statements
         if isinstance(expr, BoolExpr):
             return self._validate_bool_expr(expr)
         if isinstance(expr, DateInRangeExpr):

--- a/pcs/lib/cib/status.py
+++ b/pcs/lib/cib/status.py
@@ -1,5 +1,4 @@
 def get_resources_failcounts(cib_status):
-    # pylint: disable=too-many-locals
     """
     List all resources failcounts
     Return a dict {

--- a/pcs/lib/cib/tag.py
+++ b/pcs/lib/cib/tag.py
@@ -139,10 +139,6 @@ def validate_create_tag(
     resources_section -- element resources
     tag_id -- identifier of new tag
     idref_list -- reference ids which we want to tag
-
-    NOTE: Sequence vs. Collection issue:
-            Value 'Collection' is unsubscriptable
-            https://github.com/PyCQA/pylint/issues/2377
     """
     return (
         _validate_tag_id(tag_id, id_provider)
@@ -195,7 +191,6 @@ def validate_remove_tag(
 
 
 class ValidateTagUpdateByIds:
-    # pylint:disable=too-many-instance-attributes
     """
     Validate update of a tag element by using ids.
 

--- a/pcs/lib/cluster_property.py
+++ b/pcs/lib/cluster_property.py
@@ -104,8 +104,6 @@ def validate_set_cluster_properties(  # noqa: PLR0912
     service_manager -- manager for system daemon services
     force -- if True, produce warnings instead of errors
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
     possible_properties_dict = {
         parameter.name: parameter
         for parameter in cluster_properties_facade.metadata.parameters

--- a/pcs/lib/commands/booth.py
+++ b/pcs/lib/commands/booth.py
@@ -144,7 +144,6 @@ def config_destroy(  # noqa: PLR0912
     instance_name: str | None = None,
     ignore_config_load_problems: bool = False,
 ) -> None:
-    # pylint: disable=too-many-branches
     """
     remove booth configuration files
 

--- a/pcs/lib/commands/cluster/node.py
+++ b/pcs/lib/commands/cluster/node.py
@@ -73,9 +73,6 @@ def remove_nodes(  # noqa: PLR0912, PLR0915
     node_list,
     force_flags: reports.types.ForceFlags = (),
 ) -> None:
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     """
     Remove nodes from a cluster.
 

--- a/pcs/lib/commands/cluster/setup_cluster.py
+++ b/pcs/lib/commands/cluster/setup_cluster.py
@@ -50,10 +50,6 @@ def setup(  # noqa:  PLR0913, PLR0915
     no_cluster_uuid: bool = False,
     force_flags: reports.types.ForceFlags = (),
 ) -> None:
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-positional-arguments
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     """
     Set up cluster on specified nodes.
     Validation of the inputs is done here. Possible existing clusters are
@@ -340,9 +336,6 @@ def setup_local(  # noqa: PLR0913
         {"name": "node3", "addrs": []},
     ]
     """
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-positional-arguments
     force = reports.codes.FORCE in force_flags
 
     transport_type = transport_type or "knet"
@@ -430,9 +423,6 @@ def _validate_create_corosync_conf(  # noqa: PLR0913
     quorum_options: Mapping[str, str],
     force: bool,
 ) -> reports.ReportItemList:
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-positional-arguments
-
     # Get IP version for node addresses validation. Defaults taken from man
     # corosync.conf
     ip_version = (
@@ -491,8 +481,6 @@ def _create_corosync_conf(  # noqa: PLR0913
     quorum_options: Mapping[str, str],
     no_cluster_uuid: bool,
 ) -> config_facade.ConfigFacade:
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-positional-arguments
     corosync_conf = config_facade.ConfigFacade.create(
         cluster_name, nodes, transport_type
     )

--- a/pcs/lib/commands/cluster/setup_node.py
+++ b/pcs/lib/commands/cluster/setup_node.py
@@ -57,9 +57,6 @@ def add_nodes(  # noqa: PLR0912, PLR0915
     no_watchdog_validation=False,
     force_flags: reports.types.ForceFlags = (),
 ):
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     """
     Add specified nodes to the local cluster
     Raise LibraryError on any error.

--- a/pcs/lib/commands/cluster/setup_utils.py
+++ b/pcs/lib/commands/cluster/setup_utils.py
@@ -92,7 +92,6 @@ def _wait_for_pacemaker_to_start(
 def host_check_cluster_setup(
     host_info_dict, force, check_services_versions=True
 ):
-    # pylint: disable=too-many-locals
     report_list = []
     # We only care about services which matter for creating a cluster. It does
     # not make sense to check e.g. booth when a) it will never be used b) it

--- a/pcs/lib/commands/constraint/location.py
+++ b/pcs/lib/commands/constraint/location.py
@@ -37,7 +37,6 @@ def create_plain_with_rule(
     constraint_options -- additional options for the constraint
     force_flags -- list of flags codes
     """
-    # pylint: disable=too-many-locals
     # Pacemaker 3 changed CIB schema for rules. We no longer support the
     # old schema, so we require CIB to be upgraded to the new one.
     cib = env.get_cib(minimal_version=const.PCMK_RULES_PCMK3_SYNTAX_CIB_VERSION)

--- a/pcs/lib/commands/dr.py
+++ b/pcs/lib/commands/dr.py
@@ -77,7 +77,6 @@ def set_recovery_site(env: LibraryEnvironment, node_name: str) -> None:
     env
     node_name -- a known host from the recovery site
     """
-    # pylint: disable=too-many-locals
     if env.ghost_file_codes:
         raise LibraryError(
             ReportItem.error(

--- a/pcs/lib/commands/quorum.py
+++ b/pcs/lib/commands/quorum.py
@@ -150,7 +150,6 @@ def add_device(
     force_options=False,
     skip_offline_nodes=False,
 ):
-    # pylint: disable=too-many-locals
     """
     Add a quorum device to a cluster, distribute and reload configs if live
 

--- a/pcs/lib/commands/remote_node.py
+++ b/pcs/lib/commands/remote_node.py
@@ -246,10 +246,6 @@ def node_add_remote(  # noqa: PLR0912, PLR0913, PLR0915
     use_default_operations: bool = True,
     wait: WaitType = False,
 ):
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     """
     create an ocf:pacemaker:remote resource and use it as a remote node
 
@@ -451,9 +447,6 @@ def node_add_guest(  # noqa: PLR0912, PLR0915
     allow_pacemaker_remote_service_fail=False,
     wait: WaitType = False,
 ):
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     """
     Make a guest node from the specified resource
 

--- a/pcs/lib/commands/resource.py
+++ b/pcs/lib/commands/resource.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import re
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -499,8 +498,6 @@ def create(  # noqa: PLR0913
     allow_not_suitable_command: bool = False,
     enable_agent_self_validation: bool = False,
 ):
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-locals
     """
     Create a primitive resource in a cib.
 
@@ -618,8 +615,6 @@ def create_as_clone(  # noqa: PLR0913
     allow_incompatible_clone_meta_attributes: bool = False,
     enable_agent_self_validation: bool = False,
 ):
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-locals
     """
     Create a primitive resource in a clone
 
@@ -785,8 +780,6 @@ def create_in_group(  # noqa: PLR0913
     allow_not_suitable_command: bool = False,
     enable_agent_self_validation: bool = False,
 ):
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-locals
     """
     Create a resource in a cib and put it into a defined group
 
@@ -940,8 +933,6 @@ def create_into_bundle(  # noqa: PLR0913
     allow_not_accessible_resource: bool = False,
     enable_agent_self_validation: bool = False,
 ):
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-locals
     """
     Create a new resource in a cib and put it into an existing bundle
 
@@ -1064,7 +1055,6 @@ def bundle_create(  # noqa: PLR0913
     ensure_disabled=False,
     wait=False,
 ):
-    # pylint: disable=too-many-arguments
     """
     Create a new bundle containing no resources
 
@@ -1150,7 +1140,6 @@ def bundle_reset(  # noqa: PLR0913
     ensure_disabled=False,
     wait=False,
 ):
-    # pylint: disable=too-many-arguments
     """
     Remove configuration of bundle bundle_id and create new one into it.
 
@@ -1243,7 +1232,6 @@ def bundle_update(  # noqa: PLR0913
     force_options=False,
     wait=False,
 ):
-    # pylint: disable=too-many-arguments
     """
     Modify an existing bundle (does not touch encapsulated resources)
 
@@ -1795,8 +1783,6 @@ def group_add(  # noqa: PLR0912
     bool put_after_adjacent -- put resources after or before the adjacent one
     mixed wait -- flag for controlling waiting for pacemaker idle mechanism
     """
-    # pylint: disable = too-many-locals
-    # pylint: disable = too-many-branches
 
     if wait is not False:
         # deprecated in the first version of 0.12
@@ -1918,7 +1904,6 @@ def group_add(  # noqa: PLR0912
 def get_failcounts(
     env, resource=None, node=None, operation=None, interval=None
 ):
-    # pylint: disable=redefined-outer-name
     """
     List resources failcounts, optionally filtered by a resource, node or op
 
@@ -2029,9 +2014,6 @@ def move_autoclean(  # noqa: PLR0912, PLR0915
     strict -- if True affecting other resources than the specified resource
         will cause failure. If False affecting other resources is allowed.
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     wait_timeout = max(wait_timeout, 0)
     if not env.is_cib_live:
         raise LibraryError(
@@ -2439,7 +2421,6 @@ class _MoveBanTemplate:
         lifetime=None,
         wait: WaitType = False,
     ):
-        # pylint: disable=too-many-locals
         # validate
 
         if wait is not False:

--- a/pcs/lib/commands/sbd.py
+++ b/pcs/lib/commands/sbd.py
@@ -221,8 +221,6 @@ def enable_sbd(  # noqa: PLR0913
     no_watchdog_validation: bool = False,
     allow_invalid_option_values: bool = False,
 ) -> None:
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-locals
     """
     Enable SBD on all nodes in cluster.
 

--- a/pcs/lib/commands/status.py
+++ b/pcs/lib/commands/status.py
@@ -106,9 +106,6 @@ def full_cluster_status_plaintext(  # noqa: PLR0912, PLR0915
     hide_inactive_resources -- if True, do not display non-running resources
     verbose -- if True, display more info
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
 
     # validation
     if not env.is_cib_live and env.is_corosync_conf_live:

--- a/pcs/lib/commands/stonith.py
+++ b/pcs/lib/commands/stonith.py
@@ -106,8 +106,6 @@ def create(  # noqa: PLR0913
     wait: WaitType = False,
     enable_agent_self_validation: bool = False,
 ):
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-locals
     """
     Create stonith as resource in a cib.
 

--- a/pcs/lib/communication/nodes.py
+++ b/pcs/lib/communication/nodes.py
@@ -391,7 +391,6 @@ class PcmkRemoteServiceOff(_PcmkRemoteServiceAction):
 
 
 class FileActionBase(RunActionBase):
-    # pylint: disable=abstract-method
     def _init_properties(self):
         self._response_key = "files"
         self._force_code = report_codes.FORCE

--- a/pcs/lib/communication/qdevice.py
+++ b/pcs/lib/communication/qdevice.py
@@ -13,7 +13,6 @@ from pcs.lib.communication.tools import (
 class QdeviceBase(
     SkipOfflineMixin, AllSameDataMixin, AllAtOnceStrategyMixin, RunRemotelyBase
 ):
-    # pylint: disable=abstract-method
     def __init__(self, report_processor, skip_offline_targets=False):
         super().__init__(report_processor)
         self._set_skip_offline(skip_offline_targets)

--- a/pcs/lib/communication/tools.py
+++ b/pcs/lib/communication/tools.py
@@ -181,7 +181,6 @@ class OneByOneStrategyMixin(StrategyBase):
     list. Other requests are then available by calling method _get_next_list.
     """
 
-    # pylint: disable=abstract-method
     __iter = None
 
     def get_initial_request_list(self):
@@ -209,7 +208,6 @@ class AllAtOnceStrategyMixin(StrategyBase):
     parallel.
     """
 
-    # pylint: disable=abstract-method
     def get_initial_request_list(self):
         return self._prepare_initial_requests()
 

--- a/pcs/lib/corosync/config_facade.py
+++ b/pcs/lib/corosync/config_facade.py
@@ -18,7 +18,6 @@ T = TypeVar("T")
 
 
 class ConfigFacade(FacadeInterface):
-    # pylint: disable=too-many-public-methods
     """
     Provides high level access to a corosync config file
     """
@@ -64,7 +63,6 @@ class ConfigFacade(FacadeInterface):
             )
 
         self = cls(root)
-        # pylint: disable=protected-access
         self.__update_two_node()
 
         return self
@@ -767,7 +765,6 @@ class ConfigFacade(FacadeInterface):
         generic_options: Mapping[str, str],
         heuristics_options: Mapping[str, str],
     ) -> None:
-        # pylint: disable=too-many-locals
         """
         Add quorum device configuration
 

--- a/pcs/lib/corosync/config_parser.py
+++ b/pcs/lib/corosync/config_parser.py
@@ -122,7 +122,6 @@ class Section:
         if section.parent:
             section.parent.del_section(section)
         # here we are editing obj's _parent attribute of the same class
-        # pylint: disable=protected-access
         section._parent = self  # noqa: SLF001
         self._section_list.append(section)
         return self
@@ -132,7 +131,6 @@ class Section:
         # don't set parent to None if the section was not found in the list
         # thanks to remove raising a ValueError in that case
         # here we are editing obj's _parent attribute of the same class
-        # pylint: disable=protected-access
         section._parent = None  # noqa: SLF001
         return self
 
@@ -276,7 +274,6 @@ def _is_valid_name(name: str) -> bool:
 
 
 def _is_valid_value(value: str) -> bool:
-    # pylint: disable=superfluous-parens
     return not (set(value) & set("{}\n\r"))
 
 

--- a/pcs/lib/corosync/config_validators.py
+++ b/pcs/lib/corosync/config_validators.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from collections import (
     Counter,
     defaultdict,
@@ -100,9 +99,6 @@ def create(  # noqa: PLR0912, PLR0915
     force_unresolvable: bool = False,
     force_cluster_name: bool = False,
 ) -> ReportItemList:
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     """
     Validate creating a new minimalistic corosync.conf
 
@@ -418,9 +414,6 @@ def add_nodes(  # noqa: PLR0912, PLR0915
     pcmk_existing_nodes: Iterable[PacemakerNode],
     force_unresolvable: bool = False,
 ) -> ReportItemList:
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     """
     Validate adding nodes to a config with a nonempty nodelist
 
@@ -940,7 +933,6 @@ def add_link(
     ip_version: str,
     force_unresolvable: bool = False,
 ) -> ReportItemList:
-    # pylint: disable=too-many-locals
     """
     Validate adding a link
 
@@ -1165,10 +1157,6 @@ def update_link(  # noqa: PLR0912, PLR0913
     ip_version: str,
     force_unresolvable: bool = False,
 ) -> ReportItemList:
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-positional-arguments
     """
     Validate changing an existing link
 

--- a/pcs/lib/corosync/live.py
+++ b/pcs/lib/corosync/live.py
@@ -176,7 +176,6 @@ class QuorumStatusFacade:
 
 
 def _parse_quorum_status(quorum_status: str) -> QuorumStatus:  # noqa: PLR0912
-    # pylint: disable=too-many-branches
     node_list: list[QuorumStatusNode] = []
     qdevice_list: list[QuorumStatusNode] = []
     quorate: bool | None = None

--- a/pcs/lib/corosync/qdevice_net.py
+++ b/pcs/lib/corosync/qdevice_net.py
@@ -60,7 +60,6 @@ def set_up_client_certificates(
     skip_offline_nodes -- continue even if not all nodes are accessible
     allow_skip_offline -- enables forcing errors by skip_offline_nodes
     """
-    # pylint: disable=too-many-locals
     reporter.report(
         reports.ReportItem.info(
             reports.messages.QdeviceCertificateDistributionStarted()

--- a/pcs/lib/env.py
+++ b/pcs/lib/env.py
@@ -71,9 +71,6 @@ def _wait_type_to_int(wait: WaitType) -> int:
 
 
 class LibraryEnvironment:
-    # pylint: disable=too-many-instance-attributes
-    # pylint: disable=too-many-public-methods
-
     def __init__(  # noqa: PLR0913
         self,
         logger: Logger,
@@ -88,8 +85,6 @@ class LibraryEnvironment:
         ) = None,
         request_timeout: int | None = None,
     ):
-        # pylint: disable=too-many-arguments
-        # pylint: disable=too-many-positional-arguments
         self._logger = logger
         self._report_processor = report_processor
         self._user_login = user_login

--- a/pcs/lib/external.py
+++ b/pcs/lib/external.py
@@ -90,7 +90,6 @@ class CommandRunner:
         )
 
         try:
-            # pylint: disable=subprocess-popen-preexec-fn, consider-using-with
             # this is OK as pcs is only single-threaded application
             process = subprocess.Popen(
                 args,

--- a/pcs/lib/file/instance.py
+++ b/pcs/lib/file/instance.py
@@ -20,7 +20,6 @@ from pcs.lib.interface.config import (
 
 
 class FileInstance:
-    # pylint: disable=too-many-public-methods
     """
     Provides a high-level easy access to config files
     """

--- a/pcs/lib/file/metadata.py
+++ b/pcs/lib/file/metadata.py
@@ -125,7 +125,6 @@ def _for_pcs_settings_conf() -> FileMetadata:
 def for_file_type(  # noqa: PLR0911
     file_type_code: code.FileTypeCode, filename: str | None = None
 ) -> FileMetadata:
-    # pylint: disable=too-many-return-statements
     if file_type_code == code.BOOTH_CONFIG:
         if not filename:
             raise AssertionError("filename must be set")

--- a/pcs/lib/file/raw_file.py
+++ b/pcs/lib/file/raw_file.py
@@ -7,7 +7,6 @@ from io import BytesIO
 # the import makes it look like RealFile is implemented here so we don't
 # have to import RawFile from common and Ghost file from here in other
 # places
-# pylint: disable=unused-import
 from pcs.common import reports
 from pcs.common.file import (
     FileMetadata,

--- a/pcs/lib/pacemaker/live.py
+++ b/pcs/lib/pacemaker/live.py
@@ -969,7 +969,6 @@ def get_resource_digests(
     resource_options -- resource options with updated values
     crm_meta_attributes -- parameters of a monitor operation
     """
-    # pylint: disable=too-many-locals
     if crm_meta_attributes is None:
         crm_meta_attributes = {}
     command = [

--- a/pcs/lib/resource_agent/types.py
+++ b/pcs/lib/resource_agent/types.py
@@ -56,9 +56,7 @@ class ResourceAgentName:
 
 
 @dataclass(frozen=True)
-class ResourceAgentActionOcf1_0:  # pylint: disable=invalid-name
-    # pylint: disable=too-many-instance-attributes
-
+class ResourceAgentActionOcf1_0:
     # (start, stop, promote...), mandatory by both OCF 1.0 and 1.1
     name: str
     # mandatory by both OCF 1.0 and 1.1, sometimes not defined by agents
@@ -79,9 +77,7 @@ class ResourceAgentActionOcf1_0:  # pylint: disable=invalid-name
 
 
 @dataclass(frozen=True)
-class ResourceAgentActionOcf1_1:  # pylint: disable=invalid-name
-    # pylint: disable=too-many-instance-attributes
-
+class ResourceAgentActionOcf1_1:
     # (start, stop, promote...), mandatory by both OCF 1.0 and 1.1
     name: str
     # mandatory by both OCF 1.0 and 1.1, sometimes not defined by agents
@@ -103,9 +99,7 @@ class ResourceAgentActionOcf1_1:  # pylint: disable=invalid-name
 
 
 @dataclass(frozen=True)
-class ResourceAgentParameterOcf1_0:  # pylint: disable=invalid-name
-    # pylint: disable=too-many-instance-attributes
-
+class ResourceAgentParameterOcf1_0:
     # name of the parameter
     name: str
     # short description
@@ -129,9 +123,7 @@ class ResourceAgentParameterOcf1_0:  # pylint: disable=invalid-name
 
 
 @dataclass(frozen=True)
-class ResourceAgentParameterOcf1_1:  # pylint: disable=invalid-name
-    # pylint: disable=too-many-instance-attributes
-
+class ResourceAgentParameterOcf1_1:
     # name of the parameter
     name: str
     # short description
@@ -162,7 +154,7 @@ class ResourceAgentParameterOcf1_1:  # pylint: disable=invalid-name
 
 
 @dataclass(frozen=True)
-class ResourceAgentMetadataOcf1_0:  # pylint: disable=invalid-name
+class ResourceAgentMetadataOcf1_0:
     name: ResourceAgentName
     shortdesc: str | None
     longdesc: str | None
@@ -171,7 +163,7 @@ class ResourceAgentMetadataOcf1_0:  # pylint: disable=invalid-name
 
 
 @dataclass(frozen=True)
-class ResourceAgentMetadataOcf1_1:  # pylint: disable=invalid-name
+class ResourceAgentMetadataOcf1_1:
     name: ResourceAgentName
     shortdesc: str | None
     longdesc: str | None
@@ -181,8 +173,6 @@ class ResourceAgentMetadataOcf1_1:  # pylint: disable=invalid-name
 
 @dataclass(frozen=True)
 class ResourceAgentAction:
-    # pylint: disable=too-many-instance-attributes
-
     # (start, stop, promote...), mandatory by both OCF 1.0 and 1.1
     name: str
     # mandatory by both OCF 1.0 and 1.1, sometimes not defined by agents
@@ -216,8 +206,6 @@ class ResourceAgentAction:
 
 @dataclass(frozen=True)
 class ResourceAgentParameter:
-    # pylint: disable=too-many-instance-attributes
-
     # name of the parameter
     name: str
     # short description

--- a/pcs/lib/tools.py
+++ b/pcs/lib/tools.py
@@ -130,7 +130,6 @@ def create_tmp_cib(
     report_processor: reports.ReportProcessor, data: str | None
 ) -> IO[str]:
     try:
-        # pylint: disable=consider-using-with
         tmp_file = tempfile.NamedTemporaryFile(mode="w+", suffix=".pcs")  # noqa: SIM115
         if data is not None:
             tmp_file.write(data)

--- a/pcs/pcs.in
+++ b/pcs/pcs.in
@@ -15,7 +15,6 @@ if __name__ == "__main__":
     sys.path.insert(0, BUNDLED_PACKAGES_DIR)
     sys.path.insert(0, PACKAGE_DIR)
 
-    # pylint: disable=wrong-import-position
     # we need settings to be imported from a path defined above
     from pcs import settings
 

--- a/pcs/pcs_internal.py
+++ b/pcs/pcs_internal.py
@@ -64,7 +64,6 @@ class LibraryReportProcessor(ReportProcessor):
 
 
 def main() -> None:
-    # pylint: disable=broad-except
     argv = sys.argv[1:]
     if argv:
         _exit(

--- a/pcs/resource.py
+++ b/pcs/resource.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import json
 import re
 import sys
@@ -602,7 +601,6 @@ def resource_create(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:  #
       * -f - CIB file
       * --future - enable future cli parser behavior
     """
-    # pylint: disable=too-many-branches
     modifiers_deprecated = ["--before", "--after", "--group"]
     modifiers.ensure_only_supported(
         *(
@@ -945,9 +943,6 @@ def resource_update(args: Argv, modifiers: InputModifiers) -> None:  # noqa: PLR
       * --force - allow invalid options, do not fail if not possible to get
         agent metadata, allow not suitable command
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     modifiers.ensure_only_supported(
         "-f", "--wait", "--force", "--agent-validation"
     )
@@ -1234,9 +1229,6 @@ def resource_operation_add(  # noqa: PLR0912, PLR0915
     Commandline options:
       * --force
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     if not argv:
         raise CmdLineInputError()
 
@@ -1373,7 +1365,6 @@ def resource_operation_remove(res_id: str, argv: Argv) -> None:  # noqa: PLR0912
     Commandline options:
       * -f - CIB file
     """
-    # pylint: disable=too-many-branches
     # if no args, then we're removing an operation id
 
     # Do not ever remove an operations element, even if it is empty. There may
@@ -1609,7 +1600,6 @@ def resource_clone_create(  # noqa: PLR0912
     Commandline options:
       * --force - allow to clone stonith resource
     """
-    # pylint: disable=too-many-branches
     name = argv.pop(0)
 
     resources_el = cib_dom.getElementsByTagName("resources")[0]
@@ -1783,7 +1773,6 @@ def resource_clone_master_remove(
       * -f - CIB file
       * --wait
     """
-    # pylint: disable=too-many-locals
     del lib
     modifiers.ensure_only_supported("-f", "--wait")
     if len(argv) != 1:
@@ -2013,9 +2002,6 @@ def resource_status(  # noqa: PLR0912, PLR0915
       * -f - CIB file
       * --hide-inactive - print only active resources
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     del lib
     modifiers.ensure_only_supported("-f", "--hide-inactive")
     if len(argv) > 2:
@@ -2288,7 +2274,6 @@ def resource_force_action(  # noqa: PLR0912
       * --force
       * --full - more verbose output
     """
-    # pylint: disable=too-many-branches
     modifiers.ensure_only_supported("--force", "--full")
     action_command = {
         "debug-start": "--force-start",
@@ -2403,7 +2388,6 @@ def resource_failcount_show(
       * --full
       * -f - CIB file
     """
-    # pylint: disable=too-many-locals
     modifiers.ensure_only_supported("-f", "--full")
 
     resource = argv.pop(0) if argv and "=" not in argv[0] else None
@@ -2782,7 +2766,6 @@ def resource_relocate_run(cib_dom, resources=None, dry=True):  # noqa: PLR0912
       * --force - allow constraint on any resource, may not have any effective
         as an invalid copnstraint is ignored anyway
     """
-    # pylint: disable=too-many-branches
     resources = [] if resources is None else resources
     was_error = False
     anything_changed = False

--- a/pcs/snmp/agentx/types.py
+++ b/pcs/snmp/agentx/types.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 
-# pylint: disable=import-error
 import pyagentx
 
 BaseType = namedtuple("BaseType", ["data_type", "value"])

--- a/pcs/snmp/agentx/updater.py
+++ b/pcs/snmp/agentx/updater.py
@@ -1,4 +1,3 @@
-# pylint: disable=import-error
 from pyagentx import Updater
 
 from pcs.snmp.agentx.types import Oid

--- a/pcs/snmp/pcs_snmp_agent.py
+++ b/pcs/snmp/pcs_snmp_agent.py
@@ -3,7 +3,6 @@ import logging.handlers
 import os
 import sys
 
-# pylint: disable=import-error
 import pyagentx
 
 import pcs.utils
@@ -81,7 +80,6 @@ def main():
     try:
         agent = PcsAgent()
         agent.start()
-    # pylint: disable=broad-except
     except Exception as e:
         print("Unhandled exception: {0}".format(str(e)))
         agent.stop()

--- a/pcs/snmp/updaters/v1.py
+++ b/pcs/snmp/updaters/v1.py
@@ -45,7 +45,6 @@ class ClusterPcsV1Updater(AgentxUpdaterBase):
     _oid_tree = Oid(0, "pcs_v1", member_list=[_cluster_v1_oid_tree])
 
     def update(self):
-        # pylint: disable=too-many-locals
         output, ret_val = run_pcsdcli("node_status")
         if ret_val != 0 or output["status"] != "ok":
             logger.error(

--- a/pcs/status.py
+++ b/pcs/status.py
@@ -47,9 +47,6 @@ def nodes_status(lib, argv, modifiers):  # noqa: PLR0912, PLR0915
 
     NOTE: modifiers check is in subcommand
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     del lib
     if len(argv) == 1 and (argv[0] == "config"):
         modifiers.ensure_only_supported("-f", "--corosync_conf")

--- a/pcs/usage.py
+++ b/pcs/usage.py
@@ -11,8 +11,6 @@ from pcs.cli.reports.output import print_to_stderr
 from pcs.common.str_tools import format_optional, indent, outdent
 from pcs.common.types import StringIterable
 
-# pylint: disable=too-many-lines
-
 examples = ""
 
 _WIDTH = 80
@@ -101,8 +99,6 @@ def full_usage() -> None:
 
 
 def strip_extras(text: str) -> str:  # noqa: PLR0912
-    # pylint: disable=global-statement
-    # pylint: disable=too-many-branches
     global examples  # noqa: PLW0603
     ret = ""
     group_name = text.split(" ")[2]
@@ -2438,7 +2434,6 @@ Commands:
 
 def property_usage(args: Argv) -> str:
     # 'property' is a built-in
-    # pylint: disable=redefined-builtin
     output = """
 Usage: pcs property [commands]...
 Configure pacemaker properties

--- a/pcs/utils.py
+++ b/pcs/utils.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import base64
 import getpass
 import json
@@ -66,8 +65,6 @@ from pcs.lib.services import service_exception_to_report
 if TYPE_CHECKING:
     from pcs.common.reports.item import ReportItemList
 
-# pylint: disable=invalid-name
-# pylint: disable=too-many-branches
 
 # usefile & filename variables are set in pcs module
 usefile = False
@@ -515,8 +512,6 @@ def sendHTTPRequest(  # noqa: PLR0912, PLR0915
       * --request-timeout - timeout for HTTP requests
       * --debug
     """
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-statements
     port = None
     addr = host
     token = None
@@ -538,7 +533,6 @@ def sendHTTPRequest(  # noqa: PLR0912, PLR0915
 
     def __debug_callback(data_type, debug_data):
         prefixes = {
-            # pylint: disable=no-member
             pycurl.DEBUG_TEXT: b"* ",
             pycurl.DEBUG_HEADER_IN: b"< ",
             pycurl.DEBUG_HEADER_OUT: b"> ",
@@ -632,7 +626,6 @@ def sendHTTPRequest(  # noqa: PLR0912, PLR0915
             reports_output.warn(
                 "Proxy is set in environment variables, try disabling it"
             )
-        # pylint: disable=unbalanced-tuple-unpacking
         dummy_errno, reason = e.args
         if "--debug" in pcs_options:
             print_to_stderr(f"Response Reason: {reason}")
@@ -854,7 +847,6 @@ def run(
         else:
             stdin_pipe = subprocess.DEVNULL
 
-        # pylint: disable=subprocess-popen-preexec-fn, consider-using-with
         p = subprocess.Popen(
             args,
             stdin=stdin_pipe,
@@ -959,7 +951,6 @@ def call_local_pcsd(argv, options, std_in=None):  # noqa: PLR0911
     Commandline options:
       * --request-timeout - timeout of call to local pcsd
     """
-    # pylint: disable=too-many-return-statements
     # some commands cannot be run under a non-root account
     # so we pass those commands to locally running pcsd to execute them
     # returns [list_of_errors, exit_code, stdout, stderr]
@@ -1281,7 +1272,6 @@ def validate_constraint_resource(dom, resource_id):  # noqa: PLR0911
     Commandline options:
       * --force - allow constraint on any resource
     """
-    # pylint: disable=too-many-return-statements
     resource_el = (
         dom_get_clone(dom, resource_id)
         or dom_get_master(dom, resource_id)
@@ -1413,7 +1403,6 @@ def get_resource_for_running_check(cluster_state, resource_id, stopped=False):
     def _isnum(value):
         return all(char in list("0123456789") for char in value)
 
-    # pylint: disable=too-many-nested-blocks
     for clone in cluster_state.getElementsByTagName("clone"):
         if clone.getAttribute("id") == resource_id:
             for child in clone.childNodes:
@@ -1448,7 +1437,6 @@ def resource_running_on(resource, passed_state=None, stopped=False):
     Commandline options:
       * -f - has effect but doesn't make sense to check state of resource
     """
-    # pylint: disable=too-many-locals
     nodes_started = []
     nodes_promoted = []
     nodes_unpromoted = []
@@ -2031,7 +2019,6 @@ def tar_add_file_data(  # noqa: PLR0913
     gname=None,
     mtime=None,
 ):
-    # pylint: disable=too-many-arguments
     """
     Commandline options: no options
     """

--- a/pcs_test/api_v2_client.py
+++ b/pcs_test/api_v2_client.py
@@ -48,7 +48,6 @@ def get_token_for_localhost() -> str:
 
 def get_signal_handler(token: str):
     def signal_handler(sig, frame):
-        # pylint: disable=global-statement
         del frame
         if sig == signal.SIGINT:
             global kill_requested  # noqa: PLW0603
@@ -142,7 +141,6 @@ def error(text: str) -> None:
 def fetch_task_result(
     task_ident_dto: TaskIdentDto, auth_token: str, sleep_interval: float = 0.3
 ) -> TaskResultDto:
-    # pylint: disable=global-statement
     # Using global report list to recall reports in signal handler
     global report_list  # noqa: PLW0603
     task_state = TaskState.CREATED
@@ -169,7 +167,6 @@ def fetch_task_result(
 
 
 def perform_command(command_dto: CommandDto, auth_token: str) -> TaskResultDto:
-    # pylint: disable=global-statement
     global task_ident  # noqa: PLW0603
     response = make_api_request_post(
         "task/create", json.dumps(to_dict(command_dto)), auth_token

--- a/pcs_test/curl_test.py
+++ b/pcs_test/curl_test.py
@@ -1,9 +1,6 @@
 # This module is intended to test just the new Communicator/MultiringCommunicator
 # classes which are using curllib
 
-# pylint: disable=no-member
-# pylint: disable=protected-access
-# pylint: disable=wrong-import-position
 
 import logging
 import os.path

--- a/pcs_test/pcs_for_tests.in
+++ b/pcs_test/pcs_for_tests.in
@@ -21,7 +21,6 @@ if not TEST_INSTALLED:
 if "BUNDLED_LIB_LOCATION" in os.environ:
     sys.path.insert(0, os.environ["BUNDLED_LIB_LOCATION"])
 
-# pylint: disable=wrong-import-position
 from pcs import settings
 
 if TEST_INSTALLED:

--- a/pcs_test/tier0/cli/cluster/test_command.py
+++ b/pcs_test/tier0/cli/cluster/test_command.py
@@ -28,7 +28,6 @@ INFO_REPORT = reports.ReportItem.info(
 
 
 class ParseNodeAddRemote(TestCase):
-    # pylint: disable=protected-access
     def test_deal_with_explicit_address(self):
         self.assertEqual(
             command._node_add_remote_separate_name_and_addr(

--- a/pcs_test/tier0/cli/cluster_property/test_output.py
+++ b/pcs_test/tier0/cli/cluster_property/test_output.py
@@ -58,7 +58,6 @@ def fixture_property_metadata(
     enum_values=None,
     advanced=False,
 ):
-    # pylint: disable=redefined-builtin
     return ResourceAgentParameterDto(
         name=name,
         shortdesc=shortdesc,

--- a/pcs_test/tier0/cli/common/test_lib_wrapper.py
+++ b/pcs_test/tier0/cli/common/test_lib_wrapper.py
@@ -15,7 +15,6 @@ class LibraryWrapperTest(TestCase):
     @mock.patch("pcs.cli.common.lib_wrapper.constraint_order.create_with_set")
     @mock.patch("pcs.cli.common.lib_wrapper.cli_env_to_lib_env")
     def test_bind_to_library(self, mock_cli_env_to_lib_env, mock_order_set):
-        # pylint: disable=no-self-use
         lib_env = mock.MagicMock()
         lib_env.is_cib_live = True
         lib_env.is_corosync_conf_live = True

--- a/pcs_test/tier0/cli/common/test_parse_args.py
+++ b/pcs_test/tier0/cli/common/test_parse_args.py
@@ -249,7 +249,6 @@ class ArgsByKeywordsTest(TestCase):
 
 
 class GroupByKeywords(TestCase):
-    # pylint: disable=protected-access
     def test_split_with_implicit_first_keyword(self):
         self.assertEqual(
             group_by_keywords(
@@ -620,7 +619,6 @@ class IsOptionExpectingValue(TestCase):
 
 
 class InputModifiersTest(TestCase):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.supported = ["a", "b", "c"]
         # --debug is implicitly supported in all commands, tested separately
@@ -629,11 +627,9 @@ class InputModifiersTest(TestCase):
         self.val_opts = sorted(MODIFIER_OPTIONS_VAL)
 
     def _get_specified(self, *keys):
-        # pylint: disable=no-self-use
         return {key: i for i, key in enumerate(keys)}
 
     def ensure(self, *specified):
-        # pylint: disable=no-self-use
         InputModifiers(self._get_specified(*specified)).ensure_only_supported(
             *self.supported
         )
@@ -678,7 +674,6 @@ class InputModifiersTest(TestCase):
         self.assertEqual(2, InputModifiers({"a": 1}).get("b", default=2))
 
     def test_debug_implicit(self):
-        # pylint: disable=no-self-use
         InputModifiers({"--debug": ""}).ensure_only_supported()
 
     def test_bool_options(self):
@@ -755,13 +750,11 @@ class InputModifiersTest(TestCase):
         )
 
     def test_mutually_exclusive_not_specified(self):
-        # pylint: disable=no-self-use
         InputModifiers({"a": 1, "b": 2, "c": 3}).ensure_not_mutually_exclusive(
             "x", "y"
         )
 
     def test_mutually_exclusive_one_specified(self):
-        # pylint: disable=no-self-use
         InputModifiers({"a": 1, "b": 2}).ensure_not_mutually_exclusive("a", "c")
 
     def test_mutually_exclusive_more_specified(self):
@@ -772,13 +765,11 @@ class InputModifiersTest(TestCase):
         self.assertEqual(str(cm.exception), "Only one of 'a', 'c' can be used")
 
     def test_incompatible_checked_not_defined(self):
-        # pylint: disable=no-self-use
         InputModifiers({"a": 1, "b": 2, "c": 3}).ensure_not_incompatible(
             "x", ["a", "c"]
         )
 
     def test_incompatible_incompatible_not_defined(self):
-        # pylint: disable=no-self-use
         InputModifiers({"a": 1, "b": 2, "c": 3}).ensure_not_incompatible(
             "a", ["z", "y"]
         )
@@ -798,13 +789,11 @@ class InputModifiersTest(TestCase):
         self.assertEqual(str(cm.exception), "'a' cannot be used with 'b', 'd'")
 
     def test_dependencies_main_defined(self):
-        # pylint: disable=no-self-use
         InputModifiers({"a": 1, "b": 2, "c": 3}).ensure_dependency_satisfied(
             "a", ["x", "y"]
         )
 
     def test_dependencies_main_defined_with_deps(self):
-        # pylint: disable=no-self-use
         InputModifiers(
             {"a": 1, "b": 2, "c": 3, "d": 4}
         ).ensure_dependency_satisfied("a", ["b", "c"])

--- a/pcs_test/tier0/cli/constraint_ticket/test_command.py
+++ b/pcs_test/tier0/cli/constraint_ticket/test_command.py
@@ -95,7 +95,6 @@ class RemoveTest(TestCase):
         )
 
     def test_call_library_remove_with_correct_attrs(self):
-        # pylint: disable=no-self-use
         lib = mock.MagicMock(
             constraint_ticket=mock.MagicMock(remove=mock.Mock())
         )

--- a/pcs_test/tier0/cli/resource/test_parse_args.py
+++ b/pcs_test/tier0/cli/resource/test_parse_args.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from unittest import (
     TestCase,
     mock,
@@ -365,10 +364,9 @@ class ParseCreateArgsCommonMixin:
 
 
 class ParseCreateArgsOld(ParseCreateArgsCommonMixin, TestCase):
-    # pylint: disable=too-many-public-methods
-    # to keep the order of tests, so that the order can be kept once dropping
-    # the old parsing function and merging the test classes back together
-    # pylint: disable=useless-parent-delegation
+    # super().* is just used to keep the order of tests, so that the order can
+    # be kept once dropping the old parsing function and merging the test
+    # classes back together
     msg_clone_without_meta = (
         "Deprecation Warning: Configuring clone meta attributes without "
         "specifying the 'meta' keyword after the 'clone' keyword is deprecated "
@@ -845,10 +843,9 @@ class ParseCreateArgsOld(ParseCreateArgsCommonMixin, TestCase):
 
 
 class ParseCreateArgsNew(ParseCreateArgsCommonMixin, TestCase):
-    # pylint: disable=too-many-public-methods
-    # to keep the order of tests, so that the order can be kept once dropping
-    # the old parsing function and merging the test classes back together
-    # pylint: disable=useless-parent-delegation
+    # super().* is just used to keep the order of tests, so that the order can
+    # be kept once dropping the old parsing function and merging the test
+    # classes back together
     msg_clone_without_meta_err = (
         "Specifying instance attributes for a clone is not supported. Use "
         "'meta' after 'clone' if you want to specify meta attributes."
@@ -1294,7 +1291,6 @@ class ParsePrimitive(TestCase):
 
 
 class ParseBundleCreateAndResetMixin:
-    # pylint: disable=too-many-public-methods
     def assert_produce(self, arg_list, result):
         self.assertEqual(result, self.parse_fn(arg_list))
 
@@ -1703,7 +1699,6 @@ class ParseBundleReset(ParseBundleCreateAndResetMixin, TestCase):
 
 
 class ParseBundleUpdateOptions(TestCase):
-    # pylint: disable=too-many-public-methods
     def assert_produce(self, arg_list, result):
         self.assertEqual(
             result, parse_args.parse_bundle_update_options(arg_list)

--- a/pcs_test/tier0/cli/stonith/levels/test_output.py
+++ b/pcs_test/tier0/cli/stonith/levels/test_output.py
@@ -91,7 +91,6 @@ class LevelsToText(TestCase, LevelsToOutputMixin):
     ]
 
     def _call_command(self, dto):
-        # pylint: disable=no-self-use
         return output.stonith_level_config_to_text(dto)
 
 
@@ -116,5 +115,4 @@ class LevelsToCmd(TestCase, LevelsToOutputMixin):
     ]
 
     def _call_command(self, dto):
-        # pylint: disable=no-self-use
         return output.stonith_level_config_to_cmd(dto)

--- a/pcs_test/tier0/cli/test_cluster.py
+++ b/pcs_test/tier0/cli/test_cluster.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import json
 from textwrap import dedent
 from unittest import TestCase, mock
@@ -27,7 +26,6 @@ DEFAULT_TRANSPORT_TYPE = "knet"
 
 
 class ClusterSetup(TestCase):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.lib = mock.Mock(spec_set=["cluster"])
         self.cluster = mock.Mock(spec_set=["setup", "setup_local"])
@@ -551,7 +549,6 @@ class ClusterSetup(TestCase):
 
 
 class NodeAdd(TestCase):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.lib = mock.Mock(spec_set=["cluster"])
         self.cluster = mock.Mock(spec_set=["add_nodes"])
@@ -742,7 +739,6 @@ class NodeAdd(TestCase):
 
 
 class AddLink(TestCase):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.lib = mock.Mock(spec_set=["cluster"])
         self.cluster = mock.Mock(spec_set=["add_link"])
@@ -1005,7 +1001,6 @@ class RemoveLink(TestCase):
 
 
 class UpdateLink(TestCase):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.lib = mock.Mock(spec_set=["cluster"])
         self.cluster = mock.Mock(spec_set=["update_link"])

--- a/pcs_test/tier0/cli/test_stonith.py
+++ b/pcs_test/tier0/cli/test_stonith.py
@@ -354,7 +354,6 @@ class SbdDeviceSetup(TestCase):
 
 
 class StonithUpdateScsiDevices(TestCase):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.lib = mock.Mock(spec_set=["stonith"])
         self.stonith = mock.Mock(

--- a/pcs_test/tier0/common/reports/test_messages.py
+++ b/pcs_test/tier0/common/reports/test_messages.py
@@ -15,8 +15,6 @@ from pcs.common.resource_agent.dto import ResourceAgentNameDto
 from pcs.common.resource_status import ResourceState
 from pcs.common.types import CibRuleExpressionType
 
-# pylint: disable=too-many-lines
-
 
 class AllClassesTested(TestCase):
     def test_success(self):

--- a/pcs_test/tier0/common/services/drivers/test_openrc.py
+++ b/pcs_test/tier0/common/services/drivers/test_openrc.py
@@ -101,14 +101,12 @@ class DisableTest(Base, BaseTestMixin):
 
     def setUp(self):
         super().setUp()
-        # pylint: disable=protected-access
         self.driver._available_services = [self.service]
         self.driver_callback = self.driver.disable
         self.executable = self.rc_update_bin
         self.cmd = ["delete", self.service, "default"]
 
     def test_not_installed(self):
-        # pylint: disable=protected-access
         self.driver._available_services = [f"not_{self.service}"]
         self.driver_callback(self.service)
         self.mock_executor.run.assert_not_called()

--- a/pcs_test/tier0/common/services/drivers/test_systemd.py
+++ b/pcs_test/tier0/common/services/drivers/test_systemd.py
@@ -111,12 +111,10 @@ class DisableTest(Base, BaseTestMixin):
 
     def setUp(self):
         super().setUp()
-        # pylint: disable=protected-access
         self.driver._available_services = [self.service]
         self.driver_callback = self.driver.disable
 
     def test_not_installed(self):
-        # pylint: disable=protected-access
         self.driver._available_services = [f"not_{self.service}"]
         self.driver_callback(self.service)
         self.mock_executor.run.assert_not_called()

--- a/pcs_test/tier0/common/services/drivers/test_sysvinit_rhel.py
+++ b/pcs_test/tier0/common/services/drivers/test_sysvinit_rhel.py
@@ -104,13 +104,11 @@ class DisableTest(Base, BaseTestMixin):
 
     def setUp(self):
         super().setUp()
-        # pylint: disable=protected-access
         self.driver._available_services = [self.service]
         self.driver_callback = self.driver.disable
         self.executable = self.chkconfig_bin
 
     def test_not_installed(self):
-        # pylint: disable=protected-access
         self.driver._available_services = [f"not_{self.service}"]
         self.driver_callback(self.service)
         self.mock_executor.run.assert_not_called()

--- a/pcs_test/tier0/common/test_file.py
+++ b/pcs_test/tier0/common/test_file.py
@@ -482,7 +482,6 @@ class RawFileUpdate(TestCase):
         with tmp_dir:
             with raw_file.update() as io_buffer:
                 try:
-                    # pylint: disable=consider-using-with
                     file_obj = open(file_path)  # noqa: SIM115
                 except OSError:
                     self.fail("Unable to open file")
@@ -553,7 +552,6 @@ class RawFileUpdate(TestCase):
 
 @patch_file("os.remove")
 class RawFileRemove(TestCase):
-    # pylint: disable=no-self-use
     def test_success(self, mock_remove):
         RawFile(fixture_metadata()).remove()
         mock_remove.assert_called_once_with(FILE_PATH)

--- a/pcs_test/tier0/common/test_node_communicator.py
+++ b/pcs_test/tier0/common/test_node_communicator.py
@@ -268,7 +268,6 @@ class ResponseTest(TestCase):
 
 @mock.patch("pcs.common.node_communicator.pycurl.Curl")
 class CreateRequestHandleTest(TestCase):
-    # pylint: disable=no-member
     _common_opts = {
         pycurl.PROTOCOLS: pycurl.PROTO_HTTPS,
         pycurl.VERBOSE: 1,
@@ -298,7 +297,6 @@ class CreateRequestHandleTest(TestCase):
             "name1": "val1",
             "name2": "val2",
         }
-        # pylint: disable=protected-access
         handle = lib._create_request_handle(request, cookies, 1)
         expected_opts = {
             pycurl.TIMEOUT: 1,
@@ -328,7 +326,6 @@ class CreateRequestHandleTest(TestCase):
         request = lib.Request(
             lib.RequestTarget("label"), lib.RequestData("action")
         )
-        # pylint: disable=protected-access
         handle = lib._create_request_handle(request, {}, 10)
         expected_opts = {
             pycurl.TIMEOUT: 10,
@@ -398,7 +395,6 @@ class CommunicatorSimpleTest(CommunicatorBaseTest):
         self.mock_com_log.log_response.assert_called_once_with(response)
         self.assertEqual(0, self.mock_com_log.log_retry.call_count)
         self.assertEqual(0, self.mock_com_log.log_no_more_addresses.call_count)
-        # pylint: disable=protected-access
         com._multi_handle.assert_no_handle_left()
 
     def test_simple(self, mock_create_handle, _):
@@ -484,7 +480,6 @@ class CommunicatorMultiTest(CommunicatorBaseTest):
             ]
         )
         self.assertEqual(logger_calls, self.mock_com_log.mock_calls)
-        # pylint: disable=no-member, protected-access
         com._multi_handle.assert_no_handle_left()
 
 
@@ -573,7 +568,6 @@ class MultiaddressCommunicatorTest(CommunicatorBaseTest):
             ]
         )
         self.assertEqual(logger_calls, self.mock_com_log.mock_calls)
-        # pylint: disable=no-member, protected-access
         com._multi_handle.assert_no_handle_left()
 
     def test_failure(
@@ -634,5 +628,4 @@ class MultiaddressCommunicatorTest(CommunicatorBaseTest):
             ]
         )
         self.assertEqual(logger_calls, self.mock_com_log.mock_calls)
-        # pylint: disable=no-member, protected-access
         com._multi_handle.assert_no_handle_left()

--- a/pcs_test/tier0/common/test_resource_status.py
+++ b/pcs_test/tier0/common/test_resource_status.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from collections.abc import Sequence
 from unittest import TestCase
 
@@ -51,7 +50,6 @@ def fixture_primitive_dto(  # noqa: PLR0913
     pending: str | None = None,
     locked_to: str | None = None,
 ) -> PrimitiveStatusDto:
-    # pylint: disable=too-many-arguments
     return PrimitiveStatusDto(
         resource_id,
         instance_id,
@@ -103,7 +101,6 @@ def fixture_clone_dto(  # noqa: PLR0913
     failure_ignored: bool = False,
     instances: Sequence[PrimitiveStatusDto] | Sequence[GroupStatusDto] = (),
 ) -> CloneStatusDto:
-    # pylint: disable=too-many-arguments
     return CloneStatusDto(
         resource_id,
         multi_state,
@@ -120,7 +117,6 @@ def fixture_clone_dto(  # noqa: PLR0913
 
 
 class TestFilterCloneOrphans(TestCase):
-    # pylint: disable=protected-access
     def test_primitives(self):
         resource_list = [
             fixture_primitive_dto("primitive", None, node_names=["node1"]),
@@ -178,7 +174,6 @@ class TestFilterCloneOrphans(TestCase):
 
 
 class TestFacadeFromDto(TestCase):
-    # pylint: disable=protected-access
     def test_primitive(self):
         primitive = fixture_primitive_dto("primitive", None)
         dto = ResourcesStatusDto([primitive])
@@ -1119,7 +1114,6 @@ class TestFacadeCanHaveMultipleInstances(TestCase):
 
 
 class TestFacadeIsState(TestCase):
-    # pylint: disable=too-many-public-methods
     def test_nonexistent(self):
         facade = ResourcesStatusFacade([])
 

--- a/pcs_test/tier0/common/test_str_tools.py
+++ b/pcs_test/tier0/common/test_str_tools.py
@@ -48,7 +48,6 @@ class FormatOptionalTest(TestCase):
 
 
 class IsMultipleTest(TestCase):
-    # pylint: disable=protected-access
     def test_unsupported(self):
         def empty_func():
             pass
@@ -102,7 +101,6 @@ class IsMultipleTest(TestCase):
 
 
 class AddSTest(TestCase):
-    # pylint: disable=protected-access
     def test_add_s(self):
         self.assertEqual(tools._add_s("fedora"), "fedoras")
 

--- a/pcs_test/tier0/common/test_tools.py
+++ b/pcs_test/tier0/common/test_tools.py
@@ -4,7 +4,6 @@ from pcs.common import tools
 
 
 class VersionTest(TestCase):
-    # pylint: disable=invalid-name
     def assert_asterisk(self, expected, major, minor=None, revision=None):
         self.assertEqual(expected, (major, minor, revision))
 

--- a/pcs_test/tier0/common/test_tools_xml_fromstring.py
+++ b/pcs_test/tier0/common/test_tools_xml_fromstring.py
@@ -5,7 +5,6 @@ from pcs.common.tools import xml_fromstring
 
 class XmlFromstring(TestCase):
     def test_large_xml(self):
-        # pylint: disable=no-self-use
         # it raises on a huge xml without the flag huge_tree=True
         # see https://bugzilla.redhat.com/show_bug.cgi?id=1506864
         xml_fromstring(large_xml)

--- a/pcs_test/tier0/daemon/app/fixtures_app.py
+++ b/pcs_test/tier0/daemon/app/fixtures_app.py
@@ -14,7 +14,6 @@ PASSWORD = "password"
 
 class RubyPcsdWrapper(ruby_pcsd.Wrapper):
     def __init__(self, request_type):
-        # pylint: disable=super-init-not-called
         self.request_type = request_type
         self.status_code = 200
         self.headers = {"Some": "value"}
@@ -59,7 +58,6 @@ class AppTest(AsyncHTTPTestCase):
         return Application(self.get_routes())
 
     def get_routes(self):
-        # pylint: disable=no-self-use
         return []
 
     def fetch(self, path, raise_error=False, **kwargs):

--- a/pcs_test/tier0/daemon/app/test_api_v0.py
+++ b/pcs_test/tier0/daemon/app/test_api_v0.py
@@ -136,13 +136,9 @@ class BaseApiV0Handler(ApiV0Test):
     command_executed = True
 
     class HandlerForTest(api_v0._BaseApiV0Handler):
-        # pylint: disable=protected-access
-
         def initialize(
             self, api_auth_provider_factory, scheduler, cmd_name, cmd_params
         ):
-            # pylint: disable=arguments-differ
-            # pylint: disable=attribute-defined-outside-init
             super().initialize(api_auth_provider_factory, scheduler)
             self.cmd_name = cmd_name
             self.cmd_params = cmd_params
@@ -359,7 +355,6 @@ class ApiV0HandlerTest(ApiV0Test):
         super().setUp()
         self.mock_run_library_command = mock.AsyncMock()
         run_library_command_patcher = mock.patch.object(
-            # pylint: disable=protected-access
             api_v0._BaseApiV0Handler,
             "_run_library_command",
             self.mock_run_library_command,

--- a/pcs_test/tier0/daemon/app/ui_manage/test_base.py
+++ b/pcs_test/tier0/daemon/app/ui_manage/test_base.py
@@ -67,8 +67,6 @@ class BaseAjaxProtectedManageHandlerTest(UiManageTest):
         def initialize(
             self, scheduler, api_auth_provider_factory, cmd_name, cmd_params
         ):
-            # pylint: disable=arguments-differ
-            # pylint: disable=attribute-defined-outside-init
             super().initialize(scheduler, api_auth_provider_factory)
             self.cmd_name = cmd_name
             self.cmd_params = cmd_params

--- a/pcs_test/tier0/daemon/async_tasks/dummy_commands.py
+++ b/pcs_test/tier0/daemon/async_tasks/dummy_commands.py
@@ -18,7 +18,6 @@ def dummy_workload_with_result(_) -> str:
 
 
 def dummy_workload_unhandled_exception(_) -> None:
-    # pylint: disable=broad-exception-raised
     raise Exception("Whoa, something happened to this task!")
 
 

--- a/pcs_test/tier0/daemon/async_tasks/helpers.py
+++ b/pcs_test/tier0/daemon/async_tasks/helpers.py
@@ -124,7 +124,6 @@ class AssertTaskStatesMixin:
     def assert_task_state_counts_equal(
         self, created, queued, executed, finished
     ):
-        # pylint: disable=protected-access
         # Cannot use public method get_task because it deletes finished tasks
         state_counts = Counter(
             [task.state for task in self.scheduler._task_register.values()]

--- a/pcs_test/tier0/daemon/async_tasks/test_integration.py
+++ b/pcs_test/tier0/daemon/async_tasks/test_integration.py
@@ -46,7 +46,6 @@ executor.worker_com = Queue()  # patched at runtime
 
 class IntegrationBaseTestCase(SchedulerBaseAsyncTestCase):
     async def perform_actions(self, message_count):
-        # pylint: disable=protected-access
         """
         USE THIS FUNCTION IN TIER0 TESTS instead of the scheduler function with
         the same name to guarantee consistency between test runs. This function
@@ -162,7 +161,6 @@ class GarbageCollectionTimeoutTests(
         self.finish_tasks(["id0"])
         await self.perform_actions(1)
         self.scheduler.get_task("id0", AUTH_USER)
-        # pylint: disable=protected-access
         self.assertIsNotNone(
             self.scheduler._task_register["id0"]._to_delete_timestamp
         )
@@ -356,8 +354,6 @@ class TaskResultsTests(MockOsKillMixin, IntegrationBaseTestCase):
     behavior. All possible task outcomes are tested.
     """
 
-    # pylint: disable=protected-access
-
     def setUp(self):
         super().setUp()
         self.addCleanup(mock.patch.stopall)
@@ -487,8 +483,6 @@ class TaskResultsTests(MockOsKillMixin, IntegrationBaseTestCase):
 class DeadlockTests(
     MockOsKillMixin, AssertTaskStatesMixin, IntegrationBaseTestCase
 ):
-    # pylint: disable=protected-access
-
     def setUp(self):
         super().setUp()
         self.addCleanup(mock.patch.stopall)

--- a/pcs_test/tier0/daemon/async_tasks/test_scheduler.py
+++ b/pcs_test/tier0/daemon/async_tasks/test_scheduler.py
@@ -1,4 +1,3 @@
-# pylint: disable=protected-access
 import dataclasses
 from queue import Empty
 from unittest import mock

--- a/pcs_test/tier0/daemon/async_tasks/test_task.py
+++ b/pcs_test/tier0/daemon/async_tasks/test_task.py
@@ -1,4 +1,3 @@
-# pylint: disable=protected-access
 from datetime import timedelta
 from unittest import (
     IsolatedAsyncioTestCase,

--- a/pcs_test/tier0/daemon/test_env.py
+++ b/pcs_test/tier0/daemon/test_env.py
@@ -31,7 +31,6 @@ class Logger:
 
 
 class Prepare(TestCase, create_setup_patch_mixin(env)):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.path_exists = self.setup_patch("os.path.exists", return_value=True)
         self.logger = Logger()

--- a/pcs_test/tier0/daemon/test_http_server.py
+++ b/pcs_test/tier0/daemon/test_http_server.py
@@ -65,7 +65,6 @@ class ManageTest(TestCase, create_setup_patch_mixin(http_server)):
         self.assertFalse(self.https_server_manage.server_is_running)
 
     def HTTPServer(self, app, ssl_options=None):
-        # pylint: disable=invalid-name
         self.assertEqual(self.app, app)
         if ssl_options is not None:
             self.assertEqual(

--- a/pcs_test/tier0/daemon/test_ruby_pcsd.py
+++ b/pcs_test/tier0/daemon/test_ruby_pcsd.py
@@ -112,7 +112,6 @@ class ProcessResponseLog(TestCase):
     @patch_ruby_pcsd("log.from_external_source")
     @patch_ruby_pcsd("next", mock.Mock(return_value=1))
     def test_put_correct_values_to_log(self, from_external_source):
-        # pylint: disable=no-self-use
         ruby_pcsd.process_response_logs(
             [
                 {

--- a/pcs_test/tier0/daemon/test_session.py
+++ b/pcs_test/tier0/daemon/test_session.py
@@ -41,7 +41,6 @@ class SessionTest(TestCase, PatchSessionMixin):
         self.assertFalse(self.session.was_unused_last(2))
 
     def test_session_is_refreshable(self):
-        # pylint: disable=pointless-statement
         with self.refresh_test() as session1:
             session1.refresh()
         with self.refresh_test() as session1:

--- a/pcs_test/tier0/lib/auth/test_provider.py
+++ b/pcs_test/tier0/lib/auth/test_provider.py
@@ -43,7 +43,6 @@ _FACADE = Facade(
 
 
 class AuthProviderGetFacadeTest(TestCase):
-    # pylint: disable=protected-access
     def setUp(self):
         self.file_instance_mock = mock.Mock(spec_set=FileInstance)
         self.file_instance_mock.raw_file.metadata = _FILE_METADATA
@@ -99,7 +98,6 @@ class AuthProviderGetFacadeTest(TestCase):
 
 
 class AuthProviderUpdateFacadeTest(TestCase):
-    # pylint: disable=protected-access
     def setUp(self):
         self.file_instance_mock = mock.Mock(spec_set=FileInstance)
         self.raw_file_mock = mock.MagicMock(spec_set=RawFile)

--- a/pcs_test/tier0/lib/booth/test_config_parser.py
+++ b/pcs_test/tier0/lib/booth/test_config_parser.py
@@ -47,7 +47,6 @@ class OrganizeLinesTest(TestCase):
                 ConfigItem("ticket", "TA"),
             ],
             # testing a function which should not be used outside of the module
-            # pylint: disable=protected-access
             config_parser._organize_lines(
                 [
                     ("site", "1.1.1.1"),
@@ -85,7 +84,6 @@ class OrganizeLinesTest(TestCase):
                 ),
             ],
             # testing a function which should not be used outside of the module
-            # pylint: disable=protected-access
             config_parser._organize_lines(
                 [
                     ("site", "1.1.1.1"),
@@ -118,7 +116,6 @@ class ParseRawLinesTest(TestCase):
                 ("line-with", "hash#literal"),
             ],
             # testing a function which should not be used outside of the module
-            # pylint: disable=protected-access
             config_parser._parse_to_raw_lines(
                 "\n".join(
                     [
@@ -137,7 +134,6 @@ class ParseRawLinesTest(TestCase):
         self.assertEqual(
             [("site", "1.1.1.1")],
             # testing a function which should not be used outside of the module
-            # pylint: disable=protected-access
             config_parser._parse_to_raw_lines(
                 "\n".join(
                     [
@@ -152,7 +148,6 @@ class ParseRawLinesTest(TestCase):
         self.assertEqual(
             [("site", "1.1.1.1")],
             # testing a function which should not be used outside of the module
-            # pylint: disable=protected-access
             config_parser._parse_to_raw_lines(
                 "\n".join(
                     [
@@ -172,7 +167,6 @@ class ParseRawLinesTest(TestCase):
         line_list = ["site = 1.1.1.1"] + invalid_line_list
         with self.assertRaises(config_parser.InvalidLines) as context_manager:
             # testing a function which should not be used outside of the module
-            # pylint: disable=protected-access
             config_parser._parse_to_raw_lines("\n".join(line_list))
         self.assertEqual(context_manager.exception.args[0], invalid_line_list)
 
@@ -180,7 +174,6 @@ class ParseRawLinesTest(TestCase):
         self.assertEqual(
             [("site", "1.1.1.1")],
             # testing a function which should not be used outside of the module
-            # pylint: disable=protected-access
             config_parser._parse_to_raw_lines(
                 "\n".join(
                     [

--- a/pcs_test/tier0/lib/booth/test_config_validators.py
+++ b/pcs_test/tier0/lib/booth/test_config_validators.py
@@ -10,7 +10,6 @@ from pcs_test.tools.assertions import assert_report_item_list_equal
 
 
 class CheckInstanceName(TestCase):
-    # pylint: disable=no-self-use
     def test_success(self):
         assert_report_item_list_equal(
             config_validators.check_instance_name("valid_instance"), []
@@ -31,7 +30,6 @@ class CheckInstanceName(TestCase):
 
 
 class Create(TestCase):
-    # pylint: disable=no-self-use
     def test_no_reports_on_correct_args(self):
         assert_report_item_list_equal(
             config_validators.create(["1.1.1.1", "2.2.2.2"], ["3.3.3.3"]), []

--- a/pcs_test/tier0/lib/booth/test_env.py
+++ b/pcs_test/tier0/lib/booth/test_env.py
@@ -13,7 +13,6 @@ from pcs_test.tools.assertions import assert_raise_library_error
 
 class BoothEnv(TestCase):
     def test_ghost_conf_real_key(self):
-        # pylint: disable=no-self-use
         assert_raise_library_error(
             lambda: env.BoothEnv(
                 "my_booth", {"config_data": "some config data".encode("utf-8")}
@@ -26,7 +25,6 @@ class BoothEnv(TestCase):
         )
 
     def test_real_conf_ghost_key(self):
-        # pylint: disable=no-self-use
         assert_raise_library_error(
             lambda: env.BoothEnv(
                 "my_booth", {"key_data": "some key data".encode("utf-8")}
@@ -101,7 +99,6 @@ class BoothEnv(TestCase):
         self.assertEqual(arbitrator_list, facade.get_arbitrators())
 
     def test_invalid_instance(self):
-        # pylint: disable=no-self-use
         assert_raise_library_error(
             lambda: env.BoothEnv("/tmp/booth/booth", {}),
             fixture.error(
@@ -112,7 +109,6 @@ class BoothEnv(TestCase):
         )
 
     def test_invalid_instance_ghost(self):
-        # pylint: disable=no-self-use
         assert_raise_library_error(
             lambda: env.BoothEnv(
                 "../../booth/booth",

--- a/pcs_test/tier0/lib/cib/resource/test_hierarchy.py
+++ b/pcs_test/tier0/lib/cib/resource/test_hierarchy.py
@@ -141,7 +141,6 @@ class MoveResourcesToGroup(TestCase):
         assert_xml_equal(cib_after, etree_to_str(cib))
 
     def test_move_from_another_group(self):
-        # pylint: disable=no-self-use
         cib_before = """
             <resources>
                 <group id="G">
@@ -178,7 +177,6 @@ class MoveResourcesToGroup(TestCase):
         assert_xml_equal(cib_after, etree_to_str(cib))
 
     def test_move_last_from_group(self):
-        # pylint: disable=no-self-use
         cib_before = """
             <resources>
                 <group id="G">
@@ -211,7 +209,6 @@ class MoveResourcesToGroup(TestCase):
         assert_xml_equal(cib_after, etree_to_str(cib))
 
     def _assert_move_last_from_cloned_group(self, clone_type):
-        # pylint: disable=no-self-use
         cib_before = f"""
             <resources>
                 <group id="G">

--- a/pcs_test/tier0/lib/cib/resource/test_primitive_validate.py
+++ b/pcs_test/tier0/lib/cib/resource/test_primitive_validate.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from unittest import TestCase, mock
 
 from lxml import etree
@@ -1618,7 +1617,6 @@ class ValidateResourceInstanceAttributesUpdateSelfValidation(TestCase):
 
 
 class ValidateUniqueInstanceAttributes(TestCase):
-    # pylint: disable=protected-access
     cib = etree.fromstring(
         """
         <resources>

--- a/pcs_test/tier0/lib/cib/resource/test_validations.py
+++ b/pcs_test/tier0/lib/cib/resource/test_validations.py
@@ -333,7 +333,6 @@ class ValidateMoveResourcesToGroup(TestCase):
 
 
 class ValidateMoveBanClearMixin:
-    # pylint: disable=too-many-public-methods
     @staticmethod
     def _fixture_bundle():
         return etree.fromstring(

--- a/pcs_test/tier0/lib/cib/rule/test_cib_to_str.py
+++ b/pcs_test/tier0/lib/cib/rule/test_cib_to_str.py
@@ -15,7 +15,6 @@ from pcs.lib.cib.rule.cib_to_str import RuleToStr
 
 
 class IsoToStr(TestCase):
-    # pylint: disable=protected-access
     def test_no_change(self):
         self.assertEqual(RuleToStr._date_to_str("2023-06"), "2023-06")
         self.assertEqual(RuleToStr._date_to_str("202306"), "202306")

--- a/pcs_test/tier0/lib/cib/rule/test_validator.py
+++ b/pcs_test/tier0/lib/cib/rule/test_validator.py
@@ -34,7 +34,6 @@ from pcs_test.tools.assertions import assert_report_item_list_equal
 
 class ComplexExpressions(TestCase):
     def test_propagate_errors_from_subexpressions(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             Validator(
                 BoolExpr(
@@ -221,7 +220,6 @@ class DisallowedNodeAttrExpressions(TestCase):
 
 class DateUnaryExpression(TestCase):
     def test_date_ok(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             Validator(
                 BoolExpr(BOOL_AND, [DateUnaryExpr(DATE_OP_GT, "2020-02-03")])
@@ -230,7 +228,6 @@ class DateUnaryExpression(TestCase):
         )
 
     def test_date_bad(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             Validator(
                 BoolExpr(BOOL_AND, [DateUnaryExpr(DATE_OP_GT, "a date")])
@@ -260,7 +257,6 @@ class DateInrangeExpression(TestCase):
     }
 
     def test_date_date_ok(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             Validator(
                 BoolExpr(
@@ -272,7 +268,6 @@ class DateInrangeExpression(TestCase):
         )
 
     def test_date_ok(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             Validator(
                 BoolExpr(BOOL_AND, [DateInRangeExpr(None, "2020-02-01", None)]),
@@ -298,7 +293,6 @@ class DateInrangeExpression(TestCase):
         )
 
     def test_until_greater_than_since(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             Validator(
                 BoolExpr(
@@ -316,7 +310,6 @@ class DateInrangeExpression(TestCase):
         )
 
     def test_dates_bad(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             Validator(
                 BoolExpr(BOOL_AND, [DateInRangeExpr("date1", "date2", None)]),
@@ -573,7 +566,6 @@ class DatespecExpression(TestCase):
         )
 
     def test_duplicate_names(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             Validator(
                 BoolExpr(

--- a/pcs_test/tier0/lib/cib/test_acl.py
+++ b/pcs_test/tier0/lib/cib/test_acl.py
@@ -372,7 +372,6 @@ class AssignRoleTest(LibraryAclTest):
 @mock.patch("pcs.lib.cib.acl._assign_role")
 class AssignAllRoles(TestCase):
     def test_success(self, assign_role):
-        # pylint: disable=no-self-use
         assign_role.return_value = []
         lib.assign_all_roles("acl_section", ["1", "2", "3"], "element")
         assign_role.assert_has_calls(
@@ -904,7 +903,6 @@ class GetPermissionListTest(LibraryAclTest):
                 "attribute": "attr",
             },
         ]
-        # pylint: disable=protected-access
         self.assertEqual(expected, lib._get_permission_list(role_el))
 
 
@@ -984,7 +982,6 @@ class GetRoleListOfTargetTest(LibraryAclTest):
         etree.SubElement(target_el, "role")
         etree.SubElement(target_el, "role", {"id": "role3"})
         self.assertEqual(
-            # pylint: disable=protected-access
             ["role1", "role2", "role3"],
             lib._get_role_list_of_target(target_el),
         )
@@ -1024,7 +1021,6 @@ class Find(TestCase):
         common_finder.return_value = "element"
         self.assertEqual(
             "element",
-            # pylint: disable=protected-access
             lib._find(
                 lib.TAG_GROUP,
                 "acl_section",
@@ -1044,7 +1040,6 @@ class Find(TestCase):
     @mock.patch("pcs.lib.cib.acl.find_element_by_tag_and_id")
     def test_map_well_to_common_finder_with_automatic_desc(self, common_finder):
         common_finder.return_value = "element"
-        # pylint: disable=protected-access
         self.assertEqual(
             "element",
             lib._find(

--- a/pcs_test/tier0/lib/cib/test_alert.py
+++ b/pcs_test/tier0/lib/cib/test_alert.py
@@ -23,7 +23,6 @@ from pcs_test.tools.assertions import (
 
 
 class UpdateOptionalAttributeTest(TestCase):
-    # pylint: disable=protected-access
     def test_add(self):
         element = etree.Element("element")
         alert._update_optional_attribute(element, "attr", "value1")
@@ -41,7 +40,6 @@ class UpdateOptionalAttributeTest(TestCase):
 
 
 class ValidateRecipientValueIsUniqueTest(TestCase):
-    # pylint: disable=protected-access
     def setUp(self):
         self.alert = etree.Element("alert", id="alert-1")
         self.recipient = etree.SubElement(
@@ -176,7 +174,6 @@ class CreateAlert(TestCase):
         self.id_provider = IdProvider(self.tree)
 
     def test_no_alerts(self):
-        # pylint: disable=no-self-use
         tree = etree.XML(
             """
             <cib>

--- a/pcs_test/tier0/lib/cib/test_constraint.py
+++ b/pcs_test/tier0/lib/cib/test_constraint.py
@@ -19,7 +19,6 @@ from pcs_test.tools.custom_mock import MockLibraryReportProcessor
 
 class PrepareOptionsTest(TestCase):
     def test_refuse_unknown_option(self):
-        # pylint: disable=no-self-use
         assert_raise_library_error(
             lambda: constraint.prepare_options(
                 ("a",), {"b": "c"}, mock.MagicMock(), mock.MagicMock()
@@ -94,7 +93,6 @@ def fixture_constraint_section(return_value):
 
 class CheckIsWithoutDuplicationTest(TestCase):
     def test_raises_when_duplicate_element_found(self):
-        # pylint: disable=no-self-use
         element = mock.MagicMock()
         element.tag = "constraint_type"
 
@@ -124,7 +122,6 @@ class CheckIsWithoutDuplicationTest(TestCase):
         )
 
     def test_success_when_no_duplication_found(self):
-        # pylint: disable=no-self-use
         element = mock.MagicMock()
         element.tag = "constraint_type"
         # no exception raised
@@ -137,7 +134,6 @@ class CheckIsWithoutDuplicationTest(TestCase):
         )
 
     def test_report_when_duplication_allowed(self):
-        # pylint: disable=no-self-use
         element = mock.MagicMock()
         element.tag = "constraint_type"
 
@@ -167,7 +163,6 @@ class CheckIsWithoutDuplicationTest(TestCase):
 
 class CreateWithSetTest(TestCase):
     def test_put_new_constraint_to_constraint_section(self):
-        # pylint: disable=no-self-use
         constraint_section = etree.Element("constraints")
         constraint.create_with_set(
             constraint_section,
@@ -190,7 +185,6 @@ class CreateWithSetTest(TestCase):
         )
 
     def test_refuse_empty_resource_set_list(self):
-        # pylint: disable=no-self-use
         constraint_section = etree.Element("constraints")
         assert_raise_library_error(
             lambda: constraint.create_with_set(

--- a/pcs_test/tier0/lib/cib/test_fencing_topology.py
+++ b/pcs_test/tier0/lib/cib/test_fencing_topology.py
@@ -40,7 +40,6 @@ from pcs_test.tools.xml import etree_to_str
 
 patch_lib = create_patcher("pcs.lib.cib.fencing_topology")
 
-# pylint: disable=protected-access
 
 FIXTURE_NON_UNIQUE_DEVICES = """
     <fencing-topology>
@@ -103,7 +102,6 @@ class CibMixin:
 
 class StatusNodesMixin:
     def get_status(self):
-        # pylint: disable=no-self-use
         with open(rc("crm_mon.minimal.xml")) as crm_mon_file:
             crm_mon_xml = crm_mon_file.read()
         return ClusterState(
@@ -127,7 +125,6 @@ class StatusNodesMixin:
 @patch_lib("_validate_target", return_value=[])
 @patch_lib("_validate_level", return_value=[])
 class AddLevel(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.reporter = MockLibraryReportProcessor()
         self.cib = "cib"
@@ -185,7 +182,6 @@ class AddLevel(TestCase):
         dupl_called=True,
         report_list=None,
     ):
-        # pylint: disable=too-many-arguments
         report_list = report_list or []
         with self.assertRaises(LibraryError):
             lib.add_level(
@@ -643,7 +639,6 @@ class FindLevelsWithDevice(TestCase, CibMixin):
 
 
 class RemoveDeviceFromLevel(TestCase):
-    # pylint: disable=no-self-use
     def test_remove_single(self):
         element = etree.fromstring(
             """
@@ -813,7 +808,6 @@ class Verify(TestCase, CibMixin, StatusNodesMixin):
         self.tree = self.cib.find("configuration/fencing-topology")
 
     def fixture_resource(self, tree, name):
-        # pylint: disable=no-self-use
         el = etree.SubElement(tree, "primitive", id=name, type="fence_dummy")
         el.set("class", "stonith")
 
@@ -915,7 +909,6 @@ class ValidateLevel(TestCase):
 @patch_lib("_validate_target_typewise")
 class ValidateTarget(TestCase):
     def test_delegate(self, validate_type, validate_value):
-        # pylint: disable=no-self-use
         lib._validate_target("status", "type", "value", "force")
         validate_type.assert_called_once_with("type")
         validate_value.assert_called_once_with(
@@ -925,7 +918,6 @@ class ValidateTarget(TestCase):
 
 class ValidateTargetTypewise(TestCase):
     def test_success(self):
-        # pylint: disable=no-self-use
         report_list = []
         report_list.extend(lib._validate_target_typewise(TARGET_TYPE_NODE))
         report_list.extend(lib._validate_target_typewise(TARGET_TYPE_ATTRIBUTE))
@@ -933,7 +925,6 @@ class ValidateTargetTypewise(TestCase):
         assert_report_item_list_equal(report_list, [])
 
     def test_empty(self):
-        # pylint: disable=no-self-use
         report_list = lib._validate_target_typewise("")
         report = [
             (
@@ -953,7 +944,6 @@ class ValidateTargetTypewise(TestCase):
         assert_report_item_list_equal(report_list, report)
 
     def test_invalid(self):
-        # pylint: disable=no-self-use
         report_list = lib._validate_target_typewise("bad_target")
         report = [
             (
@@ -1148,7 +1138,6 @@ class ValidateDevices(TestCase):
 @patch_lib("_find_level_elements")
 class ValidateLevelTargetDevicesDoesNotExist(TestCase):
     def test_success(self, mock_find):
-        # pylint: disable=no-self-use
         mock_find.return_value = []
 
         report_list = lib._validate_level_target_devices_does_not_exist(
@@ -1161,7 +1150,6 @@ class ValidateLevelTargetDevicesDoesNotExist(TestCase):
         assert_report_item_list_equal(report_list, [])
 
     def test_error(self, mock_find):
-        # pylint: disable=no-self-use
         mock_find.return_value = ["element"]
 
         report_list = lib._validate_level_target_devices_does_not_exist(
@@ -1258,7 +1246,6 @@ class FindLevelElements(TestCase, CibMixin):
         self.tree = self.cib.find("configuration/fencing-topology")
 
     def get_ids(self, elements):
-        # pylint: disable=no-self-use
         return [el.get("id") for el in elements]
 
     def test_no_filter(self):

--- a/pcs_test/tier0/lib/cib/test_node.py
+++ b/pcs_test/tier0/lib/cib/test_node.py
@@ -199,7 +199,6 @@ class UpdateNodeInstanceAttrs(TestCase):
 
 
 class EnsureNodeExists(TestCase):
-    # pylint: disable=protected-access
     def setUp(self):
         self.node1 = etree.fromstring(
             """
@@ -282,7 +281,6 @@ class EnsureNodeExists(TestCase):
 
 
 class GetNodeByUname(TestCase):
-    # pylint: disable=protected-access
     def setUp(self):
         self.node1 = etree.fromstring(
             """
@@ -309,7 +307,6 @@ class GetNodeByUname(TestCase):
 
 
 class CreateNode(TestCase):
-    # pylint: disable=protected-access
     def setUp(self):
         self.nodes = etree.Element("nodes")
 

--- a/pcs_test/tier0/lib/cib/test_nvpair.py
+++ b/pcs_test/tier0/lib/cib/test_nvpair.py
@@ -11,10 +11,8 @@ from pcs_test.tools.xml import etree_to_str
 
 class AppendNewNvpair(TestCase):
     def test_append_new_nvpair_to_given_element(self):
-        # pylint: disable=no-self-use
         nvset_element = etree.fromstring('<nvset id="a"/>')
         id_provider = IdProvider(nvset_element)
-        # pylint: disable=protected-access
         nvpair._append_new_nvpair(nvset_element, "b", "c", id_provider)
         assert_xml_equal(
             etree_to_str(nvset_element),
@@ -26,11 +24,9 @@ class AppendNewNvpair(TestCase):
         )
 
     def test_with_id_provider(self):
-        # pylint: disable=no-self-use
         nvset_element = etree.fromstring('<nvset id="a"/>')
         provider = IdProvider(nvset_element)
         provider.book_ids("a-b")
-        # pylint: disable=protected-access
         nvpair._append_new_nvpair(nvset_element, "b", "c", provider)
         assert_xml_equal(
             etree_to_str(nvset_element),
@@ -44,7 +40,6 @@ class AppendNewNvpair(TestCase):
 
 class UpdateNvsetTest(TestCase):
     def test_updates_nvset(self):
-        # pylint: disable=no-self-use
         nvset_element = etree.fromstring(
             """
             <instance_attributes id="iattrs">
@@ -76,7 +71,6 @@ class UpdateNvsetTest(TestCase):
         )
 
     def test_empty_value_has_no_effect(self):
-        # pylint: disable=no-self-use
         xml = """
             <instance_attributes id="iattrs">
                 <nvpair id="iattrs-b" name="a" value="b"/>
@@ -90,7 +84,6 @@ class UpdateNvsetTest(TestCase):
         assert_xml_equal(xml, etree_to_str(nvset_element))
 
     def test_keep_empty_nvset(self):
-        # pylint: disable=no-self-use
         xml_pre = """
             <resource>
                 <instance_attributes id="iattrs">
@@ -179,7 +172,6 @@ class SetNvpairInNvsetTest(TestCase):
 
 class AppendNewNvsetTest(TestCase):
     def test_append_new_nvset_to_given_element(self):
-        # pylint: disable=no-self-use
         context_element = etree.fromstring('<context id="a"/>')
         id_provider = IdProvider(context_element)
         nvpair.append_new_nvset(
@@ -208,7 +200,6 @@ class AppendNewNvsetTest(TestCase):
         )
 
     def test_with_id_provider_booked_ids(self):
-        # pylint: disable=no-self-use
         context_element = etree.fromstring('<context id="a"/>')
         provider = IdProvider(context_element)
         provider.book_ids("a-instance_attributes", "a-instance_attributes-1-a")

--- a/pcs_test/tier0/lib/cib/test_nvpair_multi.py
+++ b/pcs_test/tier0/lib/cib/test_nvpair_multi.py
@@ -633,7 +633,6 @@ class ValidateNvsetAppendNew(TestCase):
 
 
 class NvsetAppendNew(TestCase):
-    # pylint: disable=no-self-use
     def test_minimal(self):
         context_element = etree.fromstring("""<context id="a" />""")
         id_provider = IdProvider(context_element)
@@ -836,7 +835,6 @@ class NvsetAppendNew(TestCase):
 
 
 class NvsetRemove(TestCase):
-    # pylint: disable=no-self-use
     def test_success(self):
         xml = etree.fromstring(
             """
@@ -863,7 +861,6 @@ class NvsetRemove(TestCase):
 
 
 class NvsetUpdate(TestCase):
-    # pylint: disable=no-self-use
     def test_success_nvpair_all_cases(self):
         nvset_element = etree.fromstring(
             """

--- a/pcs_test/tier0/lib/cib/test_remove_elements.py
+++ b/pcs_test/tier0/lib/cib/test_remove_elements.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from unittest import (
     TestCase,
     mock,
@@ -104,7 +103,6 @@ class GetCibMixin:
 
 
 class ElementsToRemoveFindElements(TestCase, GetCibMixin):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.cib = read_test_resource("cib-empty.xml")
 
@@ -1352,7 +1350,6 @@ class EnsureResourcesStopped(TestCase):
 
 
 class DependantElementsToReports(TestCase):
-    # pylint: disable=no-self-use
     def test_no_reports(self):
         elements = lib.DependantElements({})
         assert_report_item_list_equal(elements.to_reports(), [])
@@ -1376,7 +1373,6 @@ class DependantElementsToReports(TestCase):
 
 
 class ElementReferencesToReports(TestCase):
-    # pylint: disable=no-self-use
     def test_no_reports(self):
         elements = lib.ElementReferences({}, {})
         assert_report_item_list_equal(elements.to_reports(), [])
@@ -1407,7 +1403,6 @@ class ElementReferencesToReports(TestCase):
 
 
 class GetInnerReferences(TestCase):
-    # pylint: disable=protected-access
     def test_no_inner_references(self):
         self.assertEqual(
             [], lib._get_inner_references(etree.fromstring("<A/>"))
@@ -1458,7 +1453,6 @@ class GetInnerReferences(TestCase):
 
 
 class IsLastElement(TestCase):
-    # pylint: disable=protected-access
     def test_last_element_true(self):
         for element, tag in (
             (etree.fromstring("<A><a/></A>"), "a"),
@@ -1478,7 +1472,6 @@ class IsLastElement(TestCase):
 
 
 class IsEmptyAfterInnerElRemoval(TestCase):
-    # pylint: disable=protected-access
     def test_last_element_true(self):
         for parent in (
             etree.fromstring("<clone/>"),

--- a/pcs_test/tier0/lib/cib/test_resource_guest_node.py
+++ b/pcs_test/tier0/lib/cib/test_resource_guest_node.py
@@ -614,7 +614,6 @@ class ValidateIsNotGuest(TestCase):
         )
 
     def test_report_when_is_guest(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             guest_node.validate_is_not_guest(
                 etree.fromstring(
@@ -642,7 +641,6 @@ class ValidateIsNotGuest(TestCase):
 
 class SetAsGuest(TestCase):
     def test_set_guest_meta_correctly(self):
-        # pylint: disable=no-self-use
         resource_element = etree.fromstring('<primitive id="A"/>')
         guest_node.set_as_guest(
             resource_element,
@@ -669,7 +667,6 @@ class SetAsGuest(TestCase):
 
 class UnsetGuest(TestCase):
     def test_unset_all_guest_attributes(self):
-        # pylint: disable=no-self-use
         resource_element = etree.fromstring(
             """
             <primitive id="A">
@@ -696,7 +693,6 @@ class UnsetGuest(TestCase):
         )
 
     def test_unset_all_guest_attributes_and_empty_meta_tag(self):
-        # pylint: disable=no-self-use
         resource_element = etree.fromstring(
             """
             <primitive id="A">

--- a/pcs_test/tier0/lib/cib/test_resource_operations.py
+++ b/pcs_test/tier0/lib/cib/test_resource_operations.py
@@ -51,7 +51,6 @@ class Prepare(TestCase):
         complete_operations_options,
         get_remaining_defaults,
     ):
-        # pylint: disable=no-self-use
         new_role_names_supported = False
         validate_operation_list.return_value = ["options_report"]
         validate_different_intervals.return_value = [
@@ -124,14 +123,12 @@ class Prepare(TestCase):
 
 class ValidateDifferentIntervals(TestCase):
     def test_return_empty_reports_on_empty_list(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             operations.validate_different_intervals([]),
             [],
         )
 
     def test_return_empty_reports_on_operations_without_duplication(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             operations.validate_different_intervals(
                 [
@@ -144,7 +141,6 @@ class ValidateDifferentIntervals(TestCase):
         )
 
     def test_return_report_on_duplicated_intervals(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             operations.validate_different_intervals(
                 [
@@ -262,7 +258,6 @@ class Normalize(TestCase):
         self.assertEqual(
             operation,
             {
-                # pylint: disable=protected-access
                 key: operations._normalize(key, value)
                 for key, value in operation.items()
             },
@@ -279,7 +274,6 @@ class Normalize(TestCase):
                 "enabled": "1",
             },
             {
-                # pylint: disable=protected-access
                 key: operations._normalize(key, value)
                 for key, value in {
                     "name": "monitor",
@@ -303,7 +297,6 @@ class ValidateOperation(TestCase):
         allowed_operation_name_list=_DEFAULT,
         allow_invalid=False,
     ):
-        # pylint: disable=no-self-use
         if allowed_operation_name_list is self._DEFAULT:
             allowed_operation_name_list = ["monitor"]
         assert_report_item_list_equal(
@@ -571,7 +564,6 @@ class ValidateOperation(TestCase):
 
 class GetRemainingDefaults(TestCase):
     def test_success(self):
-        # pylint: disable=protected-access
         self.assertEqual(
             operations._get_remaining_defaults(
                 operation_list=[{"name": "monitor"}],

--- a/pcs_test/tier0/lib/cib/test_resource_primitive.py
+++ b/pcs_test/tier0/lib/cib/test_resource_primitive.py
@@ -58,7 +58,6 @@ class FindPrimitivesByAgent(TestCase):
         )
 
     def test_stonith(self):
-        # pylint: disable=protected-access
         results = primitive.find_primitives_by_agent(
             self.resources_section,
             ResourceAgentName(
@@ -76,7 +75,6 @@ class FindPrimitivesByAgent(TestCase):
             assert_xml_equal(expected_results[i], etree.tostring(res).decode())
 
     def test_with_provider(self):
-        # pylint: disable=protected-access
         results = primitive.find_primitives_by_agent(
             self.resources_section,
             ResourceAgentName(

--- a/pcs_test/tier0/lib/cib/test_resource_set.py
+++ b/pcs_test/tier0/lib/cib/test_resource_set.py
@@ -165,7 +165,6 @@ class CreateTest(TestCase):
 
 class CreateOldTest(TestCase):
     def test_resource_set_to_parent(self):
-        # pylint: disable=no-self-use
         constraint_element = etree.Element("constraint")
         resource_set.create_old(
             constraint_element,

--- a/pcs_test/tier0/lib/cib/test_status.py
+++ b/pcs_test/tier0/lib/cib/test_status.py
@@ -136,7 +136,6 @@ class GetResourcesFailcounts(TestCase):
 
 
 class ParseFailureName(TestCase):
-    # pylint: disable=protected-access
     def test_without_clone_id(self):
         self.assertEqual(
             status._parse_failure_name("resource#monitor_1000"),
@@ -151,7 +150,6 @@ class ParseFailureName(TestCase):
 
 
 class FilterResourceFailcounts(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.fail_01 = {
             "node": "nodeA",

--- a/pcs_test/tier0/lib/cib/test_tag.py
+++ b/pcs_test/tier0/lib/cib/test_tag.py
@@ -271,7 +271,6 @@ class ValidateCreateTag(ValidateCommonTestData):
 
 
 class ValidateTagIdTest(ValidateCommonTestData):
-    # pylint: disable=protected-access
     def test_tag_id_is_valid(self):
         assert_report_item_list_equal(
             lib._validate_tag_id("new-tag-id", self.id_provider),
@@ -326,7 +325,6 @@ class ValidateTagIdTest(ValidateCommonTestData):
 
 
 class ValidateTagIdNotInIdrefList(TestCase):
-    # pylint: disable=protected-access
     def setUp(self):
         self.idref_list = ["id1", "id2", "id3"]
 
@@ -350,7 +348,6 @@ class ValidateTagIdNotInIdrefList(TestCase):
 
 
 class ValidateDuplicateReferenceIds(ValidateCommonTestData):
-    # pylint: disable=protected-access
     duplicated_ids_input_output = (
         (
             ["id1", "id1"],
@@ -367,14 +364,12 @@ class ValidateDuplicateReferenceIds(ValidateCommonTestData):
     )
 
     def test_no_duplicates(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             lib._validate_add_remove_duplicate_reference_ids(["id1", "id2"]),
             [],
         )
 
     def test_duplicates(self):
-        # pylint: disable=no-self-use
         for input_ids, output_ids in self.duplicated_ids_input_output:
             assert_report_item_list_equal(
                 lib._validate_add_remove_duplicate_reference_ids(input_ids),
@@ -389,9 +384,7 @@ class ValidateDuplicateReferenceIds(ValidateCommonTestData):
 
 
 class ValidateTagCreateIdrefListNotEmpty(TestCase):
-    # pylint: disable=protected-access
     def test_empty_list(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             lib._validate_tag_create_idref_list_not_empty([]),
             [
@@ -402,7 +395,6 @@ class ValidateTagCreateIdrefListNotEmpty(TestCase):
         )
 
     def test_not_empty_list(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             lib._validate_tag_create_idref_list_not_empty(["id"]),
             [],
@@ -410,7 +402,6 @@ class ValidateTagCreateIdrefListNotEmpty(TestCase):
 
 
 class ValidateReferenceIdsAreResources(ValidateCommonTestData):
-    # pylint: disable=protected-access
     def test_ids_exist(self):
         assert_report_item_list_equal(
             lib._validate_reference_ids_are_resources(
@@ -649,7 +640,6 @@ class ValidateCommonConstraintsTestData(TestCase):
 
 class ValidateRemoveTag(ValidateCommonConstraintsTestData):
     def test_success_non_empty_list_for_remove(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             lib.validate_remove_tag(
                 get_constraints(self.tree_each_tag_has_one_constraint),
@@ -659,7 +649,6 @@ class ValidateRemoveTag(ValidateCommonConstraintsTestData):
         )
 
     def test_fail_empty_list_for_remove(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             lib.validate_remove_tag(
                 get_constraints(self.tree_each_tag_has_one_constraint),
@@ -673,7 +662,6 @@ class ValidateRemoveTag(ValidateCommonConstraintsTestData):
         )
 
     def test_fail_tag_referenced_in_constraint(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             lib.validate_remove_tag(
                 get_constraints(self.tree_each_tag_has_one_constraint),
@@ -689,7 +677,6 @@ class ValidateRemoveTag(ValidateCommonConstraintsTestData):
         )
 
     def test_fail_tag_referenced_in_multiple_constraint(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             lib.validate_remove_tag(
                 get_constraints(self.tree_tag_has_multiple_constraints),
@@ -771,7 +758,6 @@ class FindConstraintsReferencingTag(ValidateCommonConstraintsTestData):
 
 
 class ValidateAddRemoveDuplicateReferenceIds(ValidateCommonTestData):
-    # pylint: disable=protected-access
     duplicated_ids_input_output = (
         (
             ["id1", "id1"],
@@ -788,14 +774,12 @@ class ValidateAddRemoveDuplicateReferenceIds(ValidateCommonTestData):
     )
 
     def test_add_no_duplicates(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             lib._validate_add_remove_duplicate_reference_ids(["id1", "id2"]),
             [],
         )
 
     def test_remove_no_duplicates(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             lib._validate_add_remove_duplicate_reference_ids(
                 ["id1", "id2"],

--- a/pcs_test/tier0/lib/cib/test_tools.py
+++ b/pcs_test/tier0/lib/cib/test_tools.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from functools import partial
 from unittest import (
     TestCase,
@@ -534,13 +533,11 @@ class GetTagsTest(CibToolsTest):
 @mock.patch("pcs.lib.cib.tools.does_id_exist")
 class ValidateIdDoesNotExistsTest(TestCase):
     def test_success_when_id_does_not_exists(self, does_id_exists):
-        # pylint: disable=no-self-use
         does_id_exists.return_value = False
         lib.validate_id_does_not_exist("tree", "some-id")
         does_id_exists.assert_called_once_with("tree", "some-id")
 
     def test_raises_when_id_exists(self, does_id_exists):
-        # pylint: disable=no-self-use
         does_id_exists.return_value = True
         assert_raise_library_error(
             lambda: lib.validate_id_does_not_exist("tree", "some-id"),
@@ -555,7 +552,6 @@ class ValidateIdDoesNotExistsTest(TestCase):
 
 class GetPacemakerVersionByWhichCibWasValidatedTest(TestCase):
     def test_missing_attribute(self):
-        # pylint: disable=no-self-use
         assert_raise_library_error(
             lambda: lib.get_pacemaker_version_by_which_cib_was_validated(
                 etree.XML("<cib/>")
@@ -571,7 +567,6 @@ class GetPacemakerVersionByWhichCibWasValidatedTest(TestCase):
         )
 
     def test_invalid_version(self):
-        # pylint: disable=no-self-use
         assert_raise_library_error(
             lambda: lib.get_pacemaker_version_by_which_cib_was_validated(
                 etree.XML('<cib validate-with="something-1.2.3"/>')
@@ -587,7 +582,6 @@ class GetPacemakerVersionByWhichCibWasValidatedTest(TestCase):
         )
 
     def test_invalid_version_at_end(self):
-        # pylint: disable=no-self-use
         assert_raise_library_error(
             lambda: lib.get_pacemaker_version_by_which_cib_was_validated(
                 etree.XML('<cib validate-with="pacemaker-1.2.3x"/>')
@@ -637,7 +631,6 @@ class GetCibCrmFeatureSet(TestCase):
         )
 
     def test_missing_attribute(self):
-        # pylint: disable=no-self-use
         assert_raise_library_error(
             lambda: lib.get_cib_crm_feature_set(etree.XML("<cib />")),
             fixture.error(
@@ -650,7 +643,6 @@ class GetCibCrmFeatureSet(TestCase):
         )
 
     def test_invalid_version(self):
-        # pylint: disable=no-self-use
         assert_raise_library_error(
             lambda: lib.get_cib_crm_feature_set(
                 etree.XML('<cib crm_feature_set="3" />')
@@ -665,7 +657,6 @@ class GetCibCrmFeatureSet(TestCase):
         )
 
     def test_invalid_version_at_end(self):
-        # pylint: disable=no-self-use
         assert_raise_library_error(
             lambda: lib.get_cib_crm_feature_set(
                 etree.XML('<cib crm_feature_set="3.0.9x" />')
@@ -710,7 +701,6 @@ class FindTagWithId(TestCase):
         self.assertEqual("a", element.attrib["id"])
 
     def test_raises_when_is_under_another_tag(self):
-        # pylint: disable=no-self-use
         tree = etree.fromstring(
             '<cib><resources><primitive id="a"/></resources></cib>'
         )
@@ -729,7 +719,6 @@ class FindTagWithId(TestCase):
         )
 
     def test_raises_when_is_under_another_context(self):
-        # pylint: disable=no-self-use
         tree = etree.fromstring(
             """
             <cib>
@@ -757,7 +746,6 @@ class FindTagWithId(TestCase):
         )
 
     def test_raises_when_id_does_not_exists(self):
-        # pylint: disable=no-self-use
         tree = etree.fromstring("<cib><resources/></cib>")
         assert_raise_library_error(
             lambda: find_group(tree.find(".//resources"), "a"),
@@ -1159,7 +1147,6 @@ class FindElementsReferencingId(TestCase):
 
 
 class RemoveElementById(TestCase):
-    # pylint: disable=no-self-use
     def test_element_not_found(self):
         expected_cib = """<cib><configuration/></cib>"""
         cib = etree.fromstring(expected_cib)
@@ -1253,7 +1240,6 @@ class MultivalueAttrContainsValue(TestCase):
 
 
 class MultivalueAttrDeleteValue(TestCase):
-    # pylint: disable=no-self-use
     def test_remove_one(self):
         element = etree.fromstring('<element attr1="A" attr2="A"/>')
         lib.multivalue_attr_delete_value(element, "attr1", "A")

--- a/pcs_test/tier0/lib/commands/cluster/test_add_nodes.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_add_nodes.py
@@ -1,5 +1,3 @@
-# pylint: disable=too-many-lines
-# pylint: disable=no-member
 import base64
 import fcntl
 import json
@@ -635,7 +633,6 @@ class CheckLive(TestCase):
 
 
 class AddNodesSuccessMinimal(TestCase):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.existing_nodes = ()
@@ -1943,7 +1940,6 @@ class FailureCorosyncConfDistribution(TestCase):
 
 
 class FailurePcsdSslCertSync(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.existing_nodes, self.new_nodes = generate_nodes(4, 2)
@@ -2079,7 +2075,6 @@ class FailurePcsdSslCertSync(TestCase):
 
 
 class FailureFilesDistribution(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.existing_nodes, self.new_nodes = generate_nodes(4, 2)
@@ -2614,7 +2609,6 @@ class FailureFilesDistribution(TestCase):
 
 
 class FailureBoothConfigsDistribution(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.existing_nodes, self.new_nodes = generate_nodes(4, 2)
@@ -3277,7 +3271,6 @@ class FailureBoothConfigsDistribution(TestCase):
 
 
 class FailureDisableSbd(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.existing_nodes, self.new_nodes = generate_nodes(4, 2)
@@ -3411,7 +3404,6 @@ class FailureDisableSbd(TestCase):
 
 
 class FailureEnableSbd(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         # have 5 nodes in total so we do not need to enable atb
@@ -3626,7 +3618,6 @@ class FailureEnableSbd(TestCase):
 
 
 class FailureQdevice(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.existing_nodes, self.new_nodes = generate_nodes(2, 2)
@@ -4026,7 +4017,6 @@ class FailureQdevice(TestCase):
 
 
 class FailureKnownHostsUpdate(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.existing_nodes, self.new_nodes = generate_nodes(2, 2)

--- a/pcs_test/tier0/lib/commands/cluster/test_add_nodes_validation.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_add_nodes_validation.py
@@ -1,5 +1,3 @@
-# pylint: disable=too-many-lines
-# pylint: disable=no-member
 import json
 import re
 from functools import partial

--- a/pcs_test/tier0/lib/commands/cluster/test_remove_nodes.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_remove_nodes.py
@@ -1,5 +1,3 @@
-# pylint: disable=too-many-lines
-# pylint: disable=no-member
 import fcntl
 import json
 import re
@@ -331,7 +329,6 @@ class SuccessMinimal(TestCase):
 
 
 class NodeNamesMissing(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.expected_reports = []
@@ -772,7 +769,6 @@ class FailureAtbRequired(TestCase):
 
 
 class QuorumCheck(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.expected_reports = []
@@ -990,7 +986,6 @@ class QuorumCheck(TestCase):
 
 
 class FailureQuorumLoss(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.expected_reports = []
@@ -1468,7 +1463,6 @@ class FailureRemoveFromCib(TestCase):
 
 
 class FailureCorosyncReload(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.expected_reports = []
@@ -2037,7 +2031,6 @@ class FailureValidationCorosync(TestCase):
 
 
 class OfflineNodes(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.removing_num = 2

--- a/pcs_test/tier0/lib/commands/cluster/test_setup.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_setup.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import json
 from copy import deepcopy
 from unittest import TestCase, mock
@@ -122,8 +121,6 @@ def corosync_conf_fixture(  # noqa: PLR0913
     cluster_name=None,
     cluster_uuid=CLUSTER_UUID,
 ):
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-locals
     if cluster_uuid:
         cluster_uuid = f"\n    cluster_uuid: {cluster_uuid}"
 
@@ -830,8 +827,6 @@ class Setup2NodeSuccessMinimal(TestCase):
     lambda ssl_key, server_name: PCSD_SSL_CERT,
 )
 class Validation(TestCase):
-    # pylint: disable=too-many-instance-attributes
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.config.env.set_known_nodes(["node1", "node2", "node3", "node4"])

--- a/pcs_test/tier0/lib/commands/constraint/test_location.py
+++ b/pcs_test/tier0/lib/commands/constraint/test_location.py
@@ -13,7 +13,6 @@ from pcs_test.tools.command_env import get_env_tools
 
 
 class CreatePlainWithRule(TestCase):
-    # pylint: disable=too-many-public-methods
     resources_xml = """
         <resources>
           <primitive id="R1" class="ocf" provider="pacemaker" type="Dummy">

--- a/pcs_test/tier0/lib/commands/dr/test_set_recovery_site.py
+++ b/pcs_test/tier0/lib/commands/dr/test_set_recovery_site.py
@@ -464,7 +464,6 @@ class FailureRemoteCorocyncConf(TestCase):
 
 
 class FailureRemoteDrCfgDistribution(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.local_nodes = generate_nodes(4)
@@ -606,7 +605,6 @@ class FailureRemoteDrCfgDistribution(TestCase):
 
 
 class FailureLocalDrCfgDistribution(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         local_nodes = generate_nodes(4)

--- a/pcs_test/tier0/lib/commands/remote_node/test_node_add_guest.py
+++ b/pcs_test/tier0/lib/commands/remote_node/test_node_add_guest.py
@@ -99,8 +99,6 @@ class AddGuest(TestCase):
         self.config.env.set_known_hosts_dests(KNOWN_HOSTS_DESTS)
 
     def _config_success_base(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cib()
         self.config.corosync_conf.load(node_name_list=[NODE_1, NODE_2])
         self.config.http.host.check_auth(
@@ -122,8 +120,6 @@ class AddGuest(TestCase):
 
     @mock.patch("pcs.lib.commands.remote_node.generate_binary_key")
     def test_success_generated_authkey(self, generate_binary_key):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         generate_binary_key.return_value = b"password"
         self.config.local.load_cib()
         self.config.corosync_conf.load(node_name_list=[NODE_1, NODE_2])
@@ -163,8 +159,6 @@ class AddGuest(TestCase):
         self.env_assist.assert_reports(my_reports)
 
     def test_new_offline(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cib()
         self.config.corosync_conf.load(node_name_list=[NODE_1, NODE_2])
         self.config.http.host.check_auth(
@@ -192,8 +186,6 @@ class AddGuest(TestCase):
         )
 
     def test_can_skip_new_offline(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         pcmk_authkey_content = b"password"
         self.config.local.load_cib()
         self.config.corosync_conf.load(node_name_list=[NODE_1, NODE_2])
@@ -217,8 +209,6 @@ class AddGuest(TestCase):
 
     @mock.patch("pcs.lib.commands.remote_node.generate_binary_key")
     def test_can_skip_all_offline(self, generate_binary_key):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         generate_binary_key.return_value = b"password"
         self.config.local.load_cib()
         self.config.corosync_conf.load(node_name_list=[NODE_1, NODE_2])
@@ -274,8 +264,6 @@ class AddGuest(TestCase):
         )
 
     def test_fails_when_remote_node_is_not_prepared(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cib()
         self.config.corosync_conf.load(node_name_list=[NODE_1, NODE_2])
         self.config.http.host.check_auth(
@@ -321,8 +309,6 @@ class AddGuest(TestCase):
         )
 
     def test_fails_when_remote_node_returns_invalid_output(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cib()
         self.config.corosync_conf.load(node_name_list=[NODE_1, NODE_2])
         self.config.http.host.check_auth(
@@ -347,8 +333,6 @@ class AddGuest(TestCase):
         )
 
     def test_changed_options(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         meta_attributes = """
             <meta_attributes id="virtual_machine_id-meta_attributes">
                 <nvpair id="virtual_machine_id-meta_attributes-remote-addr"
@@ -402,8 +386,6 @@ class AddGuest(TestCase):
         )
 
     def test_nonexistent_resource(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cib()
         self.config.corosync_conf.load(node_name_list=[NODE_1, NODE_2])
 
@@ -425,8 +407,6 @@ class AddGuest(TestCase):
         )
 
     def test_validate_values(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cib()
         self.config.corosync_conf.load(node_name_list=[NODE_1, NODE_2])
 
@@ -462,8 +442,6 @@ class AddGuest(TestCase):
         )
 
     def test_unknown_host(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.env.set_known_hosts_dests(
             {
                 NODE_1: NODE_1_DEST_LIST,
@@ -487,8 +465,6 @@ class AddGuest(TestCase):
         )
 
     def test_unknown_host_skip_offline(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         pcmk_authkey_content = b"password"
         self.config.env.set_known_hosts_dests(
             {
@@ -511,8 +487,6 @@ class AddGuest(TestCase):
     def test_unknown_host_skip_offline_authkey_distribution(
         self, generate_binary_key
     ):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         generate_binary_key.return_value = b"password"
         self.config.env.set_known_hosts_dests(
             {
@@ -611,16 +585,12 @@ class NotLive(TestCase):
         )
 
     def test_addr_specified(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cib(env=self.cmd_env)
         self.config.local.push_cib()
         node_add_guest(self.env_assist.get_env())
         self.env_assist.assert_reports(fixture_reports_not_live_cib(NODE_NAME))
 
     def test_addr_not_specified(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         meta_attributes = """
             <meta_attributes id="virtual_machine_id-meta_attributes">
                 <nvpair id="virtual_machine_id-meta_attributes-remote-addr"
@@ -654,8 +624,6 @@ class NotLive(TestCase):
         )
 
     def test_unknown_host_addr_not_specified(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         meta_attributes = """
             <meta_attributes id="virtual_machine_id-meta_attributes">
                 <nvpair id="virtual_machine_id-meta_attributes-remote-addr"
@@ -690,8 +658,6 @@ class NotLive(TestCase):
         )
 
     def test_unknown_host_addr_specified(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         meta_attributes = """
             <meta_attributes id="virtual_machine_id-meta_attributes">
                 <nvpair id="virtual_machine_id-meta_attributes-remote-addr"
@@ -710,8 +676,6 @@ class NotLive(TestCase):
         self.env_assist.assert_reports(fixture_reports_not_live_cib(NODE_NAME))
 
     def test_validate_values(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cib(env=self.cmd_env)
         self.env_assist.assert_raise_library_error(
             lambda: node_add_guest(
@@ -764,8 +728,6 @@ class NotLive(TestCase):
 )
 class WithWait(TestCase):
     def setUp(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.wait = 1
         self.env_assist, self.config = get_env_tools(self)
         self.config.env.set_known_hosts_dests(KNOWN_HOSTS_DESTS)
@@ -836,8 +798,6 @@ class WithWait(TestCase):
 
 class RemoteService(TestCase):
     def setUp(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.env_assist, self.config = get_env_tools(self)
         self.config.env.set_known_hosts_dests(KNOWN_HOSTS_DESTS)
         self.config.local.load_cib()
@@ -853,8 +813,6 @@ class RemoteService(TestCase):
         )
 
     def test_fails_when_offline(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.run_pacemaker_remote(
             NODE_NAME, NODE_DEST_LIST, **FAIL_HTTP_KWARGS
         )
@@ -867,8 +825,6 @@ class RemoteService(TestCase):
         self.env_assist.assert_reports(my_reports)
 
     def test_fail_when_remotely_fail(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.run_pacemaker_remote(
             NODE_NAME,
             NODE_DEST_LIST,
@@ -886,8 +842,6 @@ class RemoteService(TestCase):
         self.env_assist.assert_reports(my_reports)
 
     def test_forceable_when_remotely_fail(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.run_pacemaker_remote(
             NODE_NAME,
             NODE_DEST_LIST,
@@ -910,8 +864,6 @@ class RemoteService(TestCase):
 
 class AuthkeyDistribution(TestCase):
     def setUp(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.env_assist, self.config = get_env_tools(self)
         self.config.env.set_known_hosts_dests(KNOWN_HOSTS_DESTS)
         self.config.local.load_cib()
@@ -924,8 +876,6 @@ class AuthkeyDistribution(TestCase):
         self.config.local.get_host_info(NODE_NAME, NODE_DEST_LIST)
 
     def test_fails_when_offline(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         pcmk_authkey_content = b"password"
         self.config.local.authkey_exists(return_value=True)
         self.config.local.open_authkey(pcmk_authkey_content)
@@ -945,8 +895,6 @@ class AuthkeyDistribution(TestCase):
         self.env_assist.assert_reports(my_reports)
 
     def test_fail_when_remotely_fail(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.push_existing_authkey_to_remote(
             NODE_NAME,
             NODE_DEST_LIST,
@@ -965,8 +913,6 @@ class AuthkeyDistribution(TestCase):
         self.env_assist.assert_reports(my_reports)
 
     def test_forceable_when_remotely_fail(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.push_existing_authkey_to_remote(
             NODE_NAME,
             NODE_DEST_LIST,

--- a/pcs_test/tier0/lib/commands/remote_node/test_node_add_remote.py
+++ b/pcs_test/tier0/lib/commands/remote_node/test_node_add_remote.py
@@ -130,8 +130,6 @@ class AddRemote(TestCase):
         self.config.env.set_known_hosts_dests(KNOWN_HOSTS_DESTS)
 
     def _config_success_base(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cluster_configs(
             cluster_node_list=[NODE_1, NODE_2]
         )
@@ -153,9 +151,6 @@ class AddRemote(TestCase):
         self.env_assist.assert_reports(REPORTS)
 
     def test_success_base_addr_same_as_name(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
-
         # validation and creation of resource is covered in resource create
         # tests
         self.config.local.load_cluster_configs(
@@ -241,8 +236,6 @@ class AddRemote(TestCase):
 
     @mock.patch("pcs.lib.commands.remote_node.generate_binary_key")
     def test_success_generated_authkey(self, generate_binary_key):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         generate_binary_key.return_value = b"password"
         self.config.local.load_cluster_configs(
             cluster_node_list=[NODE_1, NODE_2]
@@ -283,8 +276,6 @@ class AddRemote(TestCase):
         self.env_assist.assert_reports(my_reports)
 
     def test_new_offline(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cluster_configs(
             cluster_node_list=[NODE_1, NODE_2]
         )
@@ -314,8 +305,6 @@ class AddRemote(TestCase):
         )
 
     def test_can_skip_new_offline(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         pcmk_authkey_content = b"password"
         self.config.local.load_cluster_configs(
             cluster_node_list=[NODE_1, NODE_2]
@@ -340,8 +329,6 @@ class AddRemote(TestCase):
 
     @mock.patch("pcs.lib.commands.remote_node.generate_binary_key")
     def test_can_skip_all_offline(self, generate_binary_key):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         generate_binary_key.return_value = b"password"
         self.config.local.load_cluster_configs(
             cluster_node_list=[NODE_1, NODE_2]
@@ -391,8 +378,6 @@ class AddRemote(TestCase):
         )
 
     def test_fails_when_remote_node_is_not_prepared(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cluster_configs(
             cluster_node_list=[NODE_1, NODE_2]
         )
@@ -439,8 +424,6 @@ class AddRemote(TestCase):
         )
 
     def test_fails_when_remote_node_returns_invalid_output(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cluster_configs(
             cluster_node_list=[NODE_1, NODE_2]
         )
@@ -466,8 +449,6 @@ class AddRemote(TestCase):
         )
 
     def test_open_failed(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cluster_configs(
             cluster_node_list=[NODE_1, NODE_2]
         )
@@ -498,8 +479,6 @@ class AddRemote(TestCase):
         )
 
     def test_validate_addr_already_exists(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.load_cluster_configs(
             cluster_node_list=[NODE_1, NODE_2]
         )
@@ -516,8 +495,6 @@ class AddRemote(TestCase):
         )
 
     def test_unknown_host(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.env.set_known_hosts_dests(
             {
                 NODE_1: NODE_1_DEST_LIST,
@@ -541,8 +518,6 @@ class AddRemote(TestCase):
         )
 
     def test_unknown_host_skip_offline(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         pcmk_authkey_content = b"password"
         self.config.env.set_known_hosts_dests(
             {
@@ -566,8 +541,6 @@ class AddRemote(TestCase):
     def test_unknown_host_skip_offline_authkey_distribution(
         self, generate_binary_key
     ):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         generate_binary_key.return_value = b"password"
         self.config.env.set_known_hosts_dests(
             {
@@ -648,7 +621,6 @@ class AddRemote(TestCase):
 
 
 class NotLive(TestCase):
-    # pylint: disable=no-member
     def setUp(self):
         self.tmp_file = "/fake/tmp_file"
         self.cmd_env = dict(CIB_file=self.tmp_file)
@@ -750,8 +722,6 @@ class NotLive(TestCase):
 )
 class WithWait(TestCase):
     def setUp(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.wait = 1
         self.env_assist, self.config = get_env_tools(self)
         self.config.env.set_known_hosts_dests(KNOWN_HOSTS_DESTS)
@@ -823,8 +793,6 @@ class WithWait(TestCase):
 
 class AddRemotePcmkRemoteService(TestCase):
     def setUp(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.env_assist, self.config = get_env_tools(self)
         self.config.env.set_known_hosts_dests(KNOWN_HOSTS_DESTS)
         self.config.local.load_cluster_configs(
@@ -841,8 +809,6 @@ class AddRemotePcmkRemoteService(TestCase):
         )
 
     def test_fails_when_offline(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.run_pacemaker_remote(
             NODE_NAME, NODE_DEST_LIST, **FAIL_HTTP_KWARGS
         )
@@ -855,8 +821,6 @@ class AddRemotePcmkRemoteService(TestCase):
         self.env_assist.assert_reports(my_reports)
 
     def test_fail_when_remotely_fail(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.run_pacemaker_remote(
             NODE_NAME,
             NODE_DEST_LIST,
@@ -874,8 +838,6 @@ class AddRemotePcmkRemoteService(TestCase):
         self.env_assist.assert_reports(my_reports)
 
     def test_forceable_when_remotely_fail(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.run_pacemaker_remote(
             NODE_NAME,
             NODE_DEST_LIST,
@@ -896,8 +858,6 @@ class AddRemotePcmkRemoteService(TestCase):
 
 class AddRemoteAuthkeyDistribution(TestCase):
     def setUp(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.env_assist, self.config = get_env_tools(self)
         self.config.env.set_known_hosts_dests(KNOWN_HOSTS_DESTS)
         self.config.local.load_cluster_configs(
@@ -911,8 +871,6 @@ class AddRemoteAuthkeyDistribution(TestCase):
         self.config.local.get_host_info(NODE_NAME, NODE_DEST_LIST)
 
     def test_fails_when_offline(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         pcmk_authkey_content = b"password"
         self.config.local.authkey_exists(return_value=True)
         self.config.local.open_authkey(pcmk_authkey_content)
@@ -932,8 +890,6 @@ class AddRemoteAuthkeyDistribution(TestCase):
         self.env_assist.assert_reports(my_reports)
 
     def test_fail_when_remotely_fail(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.push_existing_authkey_to_remote(
             NODE_NAME,
             NODE_DEST_LIST,
@@ -952,8 +908,6 @@ class AddRemoteAuthkeyDistribution(TestCase):
         self.env_assist.assert_reports(my_reports)
 
     def test_forceable_when_remotely_fail(self):
-        # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.push_existing_authkey_to_remote(
             NODE_NAME,
             NODE_DEST_LIST,

--- a/pcs_test/tier0/lib/commands/remote_node/test_node_remove_guest.py
+++ b/pcs_test/tier0/lib/commands/remote_node/test_node_remove_guest.py
@@ -73,7 +73,6 @@ class RemoveGuest(TestCase):
 
     def find_by(self, identifier):
         # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.runner.cib.load(resources=FIXTURE_RESOURCES)
         self.config.local.destroy_pacemaker_remote(
             label=NODE_NAME, dest_list=NODE_DEST_LIST
@@ -110,7 +109,6 @@ class RemoveGuestOthers(TestCase):
 
     def test_success_with_wait(self):
         # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         wait = 10
         self.config.runner.cib.load(resources=FIXTURE_RESOURCES)
         self.config.local.destroy_pacemaker_remote(
@@ -129,7 +127,6 @@ class RemoveGuestOthers(TestCase):
 
     def test_can_skip_all_offline(self):
         # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.runner.cib.load(resources=FIXTURE_RESOURCES)
         self.config.local.destroy_pacemaker_remote(
             label=NODE_NAME, dest_list=NODE_DEST_LIST, **FAIL_HTTP_KWARGS
@@ -239,7 +236,6 @@ class MultipleResults(TestCase):
 
     def test_force(self):
         # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.destroy_pacemaker_remote(
             communication_list=[
                 dict(label="B-NAME", dest_list=self.dest_list_b),
@@ -315,7 +311,6 @@ class MultipleResults(TestCase):
 class AuthkeyRemove(TestCase):
     def setUp(self):
         # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.env_assist, self.config = get_env_tools(self)
         self.config.runner.cib.load(resources=FIXTURE_RESOURCES)
         self.config.local.destroy_pacemaker_remote(
@@ -329,7 +324,6 @@ class AuthkeyRemove(TestCase):
 
     def test_fails_when_offline(self):
         # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.remove_authkey(
             communication_list=[
                 dict(label=NODE_NAME, dest_list=NODE_DEST_LIST)
@@ -348,7 +342,6 @@ class AuthkeyRemove(TestCase):
 
     def test_fails_when_remotely_fails(self):
         # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.remove_authkey(
             communication_list=[
                 dict(label=NODE_NAME, dest_list=NODE_DEST_LIST)
@@ -370,7 +363,6 @@ class AuthkeyRemove(TestCase):
 
     def test_forceable_when_remotely_fail(self):
         # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.remove_authkey(
             communication_list=[
                 dict(label=NODE_NAME, dest_list=NODE_DEST_LIST)
@@ -406,7 +398,6 @@ class PcmkRemoteServiceDestroy(TestCase):
 
     def test_fails_when_offline(self):
         # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.destroy_pacemaker_remote(
             label=NODE_NAME, dest_list=NODE_DEST_LIST, **FAIL_HTTP_KWARGS
         )
@@ -419,7 +410,6 @@ class PcmkRemoteServiceDestroy(TestCase):
 
     def test_fails_when_remotely_fails(self):
         # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.destroy_pacemaker_remote(
             label=NODE_NAME,
             dest_list=NODE_DEST_LIST,
@@ -438,7 +428,6 @@ class PcmkRemoteServiceDestroy(TestCase):
 
     def test_forceable_when_remotely_fail(self):
         # Instance of 'Config' has no 'local' member
-        # pylint: disable=no-member
         self.config.local.destroy_pacemaker_remote(
             label=NODE_NAME,
             dest_list=NODE_DEST_LIST,

--- a/pcs_test/tier0/lib/commands/resource/test_bundle_update.py
+++ b/pcs_test/tier0/lib/commands/resource/test_bundle_update.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from functools import partial
 from textwrap import dedent
 from unittest import (

--- a/pcs_test/tier0/lib/commands/resource/test_resource_create.py
+++ b/pcs_test/tier0/lib/commands/resource/test_resource_create.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from unittest import (
     TestCase,
     mock,
@@ -77,7 +76,6 @@ def create(  # noqa: PLR0913
     enable_agent_self_validation=False,
     instance_attributes=None,
 ):
-    # pylint: disable=too-many-arguments
     return resource.create(
         env,
         "A",
@@ -131,7 +129,6 @@ def create_clone(  # noqa: PLR0913
     enable_agent_self_validation=False,
     instance_attributes=None,
 ):
-    # pylint: disable=too-many-arguments
     return resource.create_as_clone(
         env,
         "A",

--- a/pcs_test/tier0/lib/commands/resource/test_resource_enable_disable.py
+++ b/pcs_test/tier0/lib/commands/resource/test_resource_enable_disable.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import json
 from unittest import (
     TestCase,
@@ -389,7 +388,6 @@ def get_fixture_clone_group_cib(  # noqa: PLR0913
     primitive2_meta=False,
     all_meta=False,
 ):
-    # pylint: disable=too-many-arguments
     parts = ["""<resources><clone id="A-clone">"""]
     if clone_disabled:
         parts.append(

--- a/pcs_test/tier0/lib/commands/resource/test_resource_manage_unmanage.py
+++ b/pcs_test/tier0/lib/commands/resource/test_resource_manage_unmanage.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from unittest import TestCase
 
 from pcs.common.reports import codes as report_codes
@@ -393,7 +392,6 @@ def get_fixture_clone_group_cib(  # noqa: PLR0913
     primitive2_meta=False,
     all_meta=False,
 ):
-    # pylint: disable=too-many-arguments
     parts = ["""<resources><clone id="A-clone">"""]
     if clone_unmanaged:
         parts.append(

--- a/pcs_test/tier0/lib/commands/resource/test_resource_move_autoclean.py
+++ b/pcs_test/tier0/lib/commands/resource/test_resource_move_autoclean.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from unittest import (
     TestCase,
     mock,
@@ -159,7 +158,6 @@ class MoveAutocleanCommonSetup(TestCase):
     rc("pcmk_rng/api/api-result.rng"),
 )
 class MoveAutocleanSuccess(MoveAutocleanCommonSetup):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         super().setUp()
 
@@ -947,7 +945,6 @@ class MoveAutocleanValidations(MoveAutocleanCommonSetup):
     rc("pcmk_rng/api/api-result.rng"),
 )
 class MoveAutocleanFailures(MoveAutocleanCommonSetup):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         super().setUp()
 

--- a/pcs_test/tier0/lib/commands/sbd/test_enable_sbd.py
+++ b/pcs_test/tier0/lib/commands/sbd/test_enable_sbd.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import json
 from unittest import TestCase
 
@@ -532,7 +531,6 @@ class EvenNumOfNodes(TestCase):
 
 
 class OfflineNodes(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.corosync_conf_name = "corosync.conf"
@@ -1241,7 +1239,6 @@ class Validations(TestCase):
 
 
 class FailureHandling(TestCase):
-    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.corosync_conf_name = "corosync.conf"

--- a/pcs_test/tier0/lib/commands/test_acl.py
+++ b/pcs_test/tier0/lib/commands/test_acl.py
@@ -34,7 +34,6 @@ class AclCommandsTest(TestCase, ExtendedAssertionsMixin):
 @mock.patch("pcs.lib.commands.acl.get_acls", mock.Mock(side_effect=lambda x: x))
 class CibAclSection(TestCase):
     def test_push_cib_on_success(self):
-        # pylint: disable=no-self-use
         env = mock.MagicMock()
         env.get_cib = mock.Mock(return_value="cib")
         with cmd_acl.cib_acl_section(env):

--- a/pcs_test/tier0/lib/commands/test_booth.py
+++ b/pcs_test/tier0/lib/commands/test_booth.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import base64
 import os
 from textwrap import dedent
@@ -209,7 +208,6 @@ class FixtureMixin:
         return config.encode("utf-8")
 
     def fixture_group_status(self, name="booth", running=True):
-        # pylint: disable=no-self-use
         role = "Started" if running else "Stopped"
         return f"""
             <resources>
@@ -569,7 +567,6 @@ class ConfigSetupAuthfileFix(TestCase, FixtureMixin):
 
 
 class ConfigDestroy(TestCase, FixtureMixin):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.cib_path = os.path.join(settings.cib_dir, "cib.xml")
@@ -2895,7 +2892,6 @@ class TicketRevoke(TicketGrantRevokeMixin, TestCase):
 
 
 class ConfigSyncTest(TestCase, FixtureMixin):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.env_assist, self.config = get_env_tools(self)
         self.node_list = ["rh7-1", "rh7-2"]

--- a/pcs_test/tier0/lib/commands/test_fencing_topology.py
+++ b/pcs_test/tier0/lib/commands/test_fencing_topology.py
@@ -44,7 +44,6 @@ class AddLevel(TestCase):
         mock_status_dom,
         mock_status,
     ):
-        # pylint: disable=no-self-use
         mock_get_cib.return_value = "mocked cib"
         mock_status_dom.return_value = "mock get_cluster_status_dom"
         mock_status.return_value = mock.MagicMock(
@@ -57,7 +56,6 @@ class AddLevel(TestCase):
         mock_status,
         mock_push_cib,
     ):
-        # pylint: disable=no-self-use
         mock_status_dom.assert_called_once_with()
         mock_status.assert_called_once_with("mock get_cluster_status_dom")
         mock_push_cib.assert_called_once_with()
@@ -220,7 +218,6 @@ class GetConfig(TestCase):
 @patch_env("get_cib", lambda self: "mocked cib")
 class RemoveAllLevels(TestCase):
     def test_success(self, mock_push_cib, mock_get_topology, mock_remove):
-        # pylint: disable=no-self-use
         mock_get_topology.return_value = "topology el"
         lib_env = create_lib_env()
 
@@ -399,7 +396,6 @@ class Verify(TestCase):
         mock_push_cib,
         mock_verify,
     ):
-        # pylint: disable=no-self-use
         mock_status_dom.return_value = "mock get_cluster_status_dom"
         mock_status.return_value = mock.MagicMock(
             node_section=mock.MagicMock(nodes="nodes")

--- a/pcs_test/tier0/lib/commands/test_node.py
+++ b/pcs_test/tier0/lib/commands/test_node.py
@@ -176,7 +176,6 @@ class SetInstanceAttrsBase(TestCase):
 @patch_command("update_node_instance_attrs")
 @patch_command("get_local_node_name")
 class SetInstanceAttrsLocal(SetInstanceAttrsBase):
-    # pylint: disable=protected-access
     node_count = 2
 
     def test_not_possible_with_cib_file(self, mock_name, mock_attrs):
@@ -210,7 +209,6 @@ class SetInstanceAttrsLocal(SetInstanceAttrsBase):
 
 @patch_command("update_node_instance_attrs")
 class SetInstanceAttrsAll(SetInstanceAttrsBase):
-    # pylint: disable=protected-access
     node_count = 2
 
     def test_success(self, mock_attrs):
@@ -228,7 +226,6 @@ class SetInstanceAttrsAll(SetInstanceAttrsBase):
 
 @patch_command("update_node_instance_attrs")
 class SetInstanceAttrsList(SetInstanceAttrsBase):
-    # pylint: disable=protected-access
     node_count = 4
 
     def test_success(self, mock_attrs):
@@ -247,7 +244,6 @@ class SetInstanceAttrsList(SetInstanceAttrsBase):
         )
 
     def test_bad_node(self, mock_attrs):
-        # pylint: disable=no-self-use
         assert_raise_library_error(
             lambda: lib._set_instance_attrs_node_list(
                 create_env(), "attrs", ["node-1", "node-9"], False
@@ -301,7 +297,6 @@ class CibRunnerNodes(TestCase):
     @patch_env("ensure_wait_satisfiable", mock.Mock(side_effect=LibraryError))
     def test_raises_when_wait_is_not_satisfiable(self, push_cib):
         def run():
-            # pylint: disable=unused-variable
             with lib.cib_runner_nodes(self.env, "wait") as (cib, runner, nodes):
                 pass
 

--- a/pcs_test/tier0/lib/commands/test_qdevice.py
+++ b/pcs_test/tier0/lib/commands/test_qdevice.py
@@ -96,7 +96,6 @@ class QdeviceBadModelTest(QdeviceTestCase):
 @mock.patch("pcs.lib.commands.qdevice.qdevice_net.qdevice_setup")
 @mock.patch.object(LibraryEnvironment, "cmd_runner", lambda self: "mock_runner")
 class QdeviceNetSetupTest(QdeviceTestCase):
-    # pylint: disable=no-member
     def test_success(self, mock_net_setup):
         lib.qdevice_setup(self.lib_env, "net", False, False)
 
@@ -281,7 +280,6 @@ class QdeviceNetSetupTest(QdeviceTestCase):
 @mock.patch("pcs.lib.commands.qdevice.qdevice_net.qdevice_destroy")
 @mock.patch.object(LibraryEnvironment, "cmd_runner", lambda self: "mock_runner")
 class QdeviceNetDestroyTest(QdeviceTestCase):
-    # pylint: disable=no-member
     def test_success_not_used(self, mock_net_destroy, mock_status):
         mock_status.return_value = ""
 
@@ -642,7 +640,6 @@ class TestQdeviceNetStatusTextTest(QdeviceTestCase):
 
 
 class QdeviceNetEnableTest(QdeviceTestCase):
-    # pylint: disable=no-member
     def test_success(self):
         lib.qdevice_enable(self.lib_env, "net")
         self.assertEqual(
@@ -691,7 +688,6 @@ class QdeviceNetEnableTest(QdeviceTestCase):
 
 
 class QdeviceNetDisableTest(QdeviceTestCase):
-    # pylint: disable=no-member
     def test_success(self):
         lib.qdevice_disable(self.lib_env, "net")
         self.assertEqual(
@@ -741,7 +737,6 @@ class QdeviceNetDisableTest(QdeviceTestCase):
 
 @mock.patch("pcs.lib.corosync.qdevice_net.qdevice_initialized")
 class QdeviceNetStartTest(QdeviceTestCase):
-    # pylint: disable=no-member
     def test_success(self, mock_qdevice_initialized):
         mock_qdevice_initialized.return_value = True
         lib.qdevice_start(self.lib_env, "net")
@@ -837,7 +832,6 @@ class QdeviceNetStartTest(QdeviceTestCase):
 
 @mock.patch("pcs.lib.corosync.qdevice_net.qdevice_status_cluster_text")
 class QdeviceNetStopTest(QdeviceTestCase):
-    # pylint: disable=no-member
     def test_success_not_used(self, mock_status):
         mock_status.return_value = ""
 

--- a/pcs_test/tier0/lib/commands/test_resource_agent.py
+++ b/pcs_test/tier0/lib/commands/test_resource_agent.py
@@ -297,7 +297,6 @@ class ListAgents(TestCase):
 
 
 class ActionToOperation(TestCase):
-    # pylint: disable=protected-access
     @staticmethod
     def _action_dict(action):
         all_keys = {

--- a/pcs_test/tier0/lib/commands/test_sbd.py
+++ b/pcs_test/tier0/lib/commands/test_sbd.py
@@ -28,7 +28,6 @@ def _assert_equal_list_of_dictionaries_without_order(expected, actual):
 
 
 class ValidateSbdOptionsTest(TestCase):
-    # pylint: disable=protected-access
     def setUp(self):
         self.allowed_sbd_options = sorted(
             [
@@ -250,7 +249,6 @@ class ValidateSbdOptionsTest(TestCase):
         self.assertEqual([], cmd_sbd._validate_sbd_options(config))
 
     def test_watchdog_timeout_is_nonnegative_int(self):
-        # pylint: disable=no-self-use
         config = {
             "SBD_WATCHDOG_TIMEOUT": "-1",
         }
@@ -270,7 +268,6 @@ class ValidateSbdOptionsTest(TestCase):
         )
 
     def test_watchdog_timeout_is_not_int(self):
-        # pylint: disable=no-self-use
         config = {
             "SBD_WATCHDOG_TIMEOUT": "not int",
         }
@@ -290,7 +287,6 @@ class ValidateSbdOptionsTest(TestCase):
         )
 
     def test_watchdog_timeout_is_none(self):
-        # pylint: disable=no-self-use
         config = {
             "SBD_WATCHDOG_TIMEOUT": None,
         }
@@ -311,7 +307,6 @@ class ValidateSbdOptionsTest(TestCase):
 
 
 class ValidateWatchdogDictTest(TestCase):
-    # pylint: disable=protected-access
     def test_all_ok(self):
         watchdog_dict = {
             "node1": "/dev/watchdog1",
@@ -320,7 +315,6 @@ class ValidateWatchdogDictTest(TestCase):
         self.assertEqual([], cmd_sbd._validate_watchdog_dict(watchdog_dict))
 
     def test_some_not_ok(self):
-        # pylint: disable=no-self-use
         watchdog_dict = {
             "node1": "",
             "node2": None,
@@ -340,7 +334,6 @@ class ValidateWatchdogDictTest(TestCase):
 
 
 class GetFullTargetDictTest(TestCase):
-    # pylint: disable=protected-access
     def setUp(self):
         self.target_list = [
             RequestTarget("node{0}".format(i)) for i in range(1, 4)

--- a/pcs_test/tier0/lib/commands/test_status.py
+++ b/pcs_test/tier0/lib/commands/test_status.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import os
 from textwrap import dedent
 from unittest import TestCase, mock
@@ -184,7 +183,6 @@ class FullClusterStatusPlaintextBase(TestCase):
         sbd_enabled=False,
         sbd_active=False,
     ):
-        # pylint: disable=too-many-arguments
         self.config.services.is_enabled(
             "corosync",
             name="services.is_enabled.corosync",
@@ -243,7 +241,6 @@ class FullClusterStatusPlaintextBase(TestCase):
     settings, "pacemaker_api_result_schema", rc("pcmk_rng/api/api-result.rng")
 )
 class FullClusterStatusPlaintext(FullClusterStatusPlaintextBase):
-    # pylint: disable=too-many-public-methods
     def test_life_cib_mocked_corosync(self):
         self.config.env.set_corosync_conf_data("corosync conf data")
 

--- a/pcs_test/tier0/lib/commands/test_stonith_update_scsi_devices.py
+++ b/pcs_test/tier0/lib/commands/test_stonith_update_scsi_devices.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import json
 from unittest import (
     TestCase,
@@ -397,8 +396,6 @@ class UpdateScsiDevicesMixin:
         digests_attrs_list=None,
         crm_digests_xml=None,
     ):
-        # pylint: disable=too-many-arguments
-        # pylint: disable=too-many-locals
         devices_value = ",".join(sorted(devices_updated))
         self.config.runner.cib.load(
             resources=fixture_scsi(
@@ -480,7 +477,6 @@ class UpdateScsiDevicesMixin:
         digests_attrs_list=None,
         digests_attrs_list_updated=None,
     ):
-        # pylint: disable=too-many-arguments
         self.config_cib(
             devices_before=devices_before,
             devices_updated=devices_updated,

--- a/pcs_test/tier0/lib/corosync/test_config_facade_links.py
+++ b/pcs_test/tier0/lib/corosync/test_config_facade_links.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from textwrap import dedent
 from unittest import TestCase
 

--- a/pcs_test/tier0/lib/corosync/test_config_facade_nodes.py
+++ b/pcs_test/tier0/lib/corosync/test_config_facade_nodes.py
@@ -218,7 +218,6 @@ class GetNodesTest(TestCase):
 
 class AddNodesTest(TestCase):
     def test_adding_two_nodes(self):
-        # pylint: disable=no-self-use
         config = dedent(
             """\
             nodelist {
@@ -274,7 +273,6 @@ class AddNodesTest(TestCase):
         ac(expected_config, facade.config.export())
 
     def test_skipped_and_out_of_order_links_and_nodes_ids(self):
-        # pylint: disable=no-self-use
         config = dedent(
             """\
             nodelist {
@@ -378,7 +376,6 @@ class AddNodesTest(TestCase):
         ac(expected_config, facade.config.export())
 
     def test_enable_two_node(self):
-        # pylint: disable=no-self-use
         config = dedent(
             """\
             nodelist {
@@ -425,7 +422,6 @@ class AddNodesTest(TestCase):
         ac(expected_config, facade.config.export())
 
     def test_disable_two_node(self):
-        # pylint: disable=no-self-use
         config = dedent(
             """\
             nodelist {
@@ -486,7 +482,6 @@ class AddNodesTest(TestCase):
 
 class RemoveNodes(TestCase):
     def test_remove(self):
-        # pylint: disable=no-self-use
         config = dedent(
             """\
             nodelist {
@@ -568,7 +563,6 @@ class RemoveNodes(TestCase):
         ac(expected_config, facade.config.export())
 
     def test_enable_two_nodes(self):
-        # pylint: disable=no-self-use
         config = dedent(
             """\
             nodelist {
@@ -623,7 +617,6 @@ class RemoveNodes(TestCase):
         ac(expected_config, facade.config.export())
 
     def test_disable_two_nodes(self):
-        # pylint: disable=no-self-use
         config = dedent(
             """\
             nodelist {

--- a/pcs_test/tier0/lib/corosync/test_config_parser.py
+++ b/pcs_test/tier0/lib/corosync/test_config_parser.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from unittest import TestCase
 
 from pcs.lib.corosync import config_parser
@@ -800,7 +799,6 @@ class SectionTest(TestCase):
 
 
 class ParserTest(TestCase):
-    # pylint: disable=too-many-public-methods
     def test_empty(self):
         self.assertEqual(
             str(config_parser.Parser.parse("".encode("utf-8"))), ""

--- a/pcs_test/tier0/lib/corosync/test_config_validators_common.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_common.py
@@ -665,7 +665,6 @@ class TotemBase:
         raise NotImplementedError()
 
     def test_no_options(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(self.call_function({}), [])
 
     def test_all_valid(self):

--- a/pcs_test/tier0/lib/corosync/test_config_validators_create.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_create.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from unittest import TestCase
 
 from pcs.common.reports import codes as report_codes
@@ -13,8 +12,6 @@ from pcs_test.tools import fixture
 from pcs_test.tools.assertions import assert_report_item_list_equal
 from pcs_test.tools.custom_mock import patch_getaddrinfo
 
-# pylint: disable=no-self-use
-
 forbidden_characters_kwargs = dict(
     allowed_values=None,
     cannot_be_empty=False,
@@ -27,7 +24,6 @@ _FIXTURE_KNET_PING_INTERVAL_TIMEOUT_EXPECTED = (
 
 
 class Create(TestCase):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.known_addrs = patch_getaddrinfo(
             self,

--- a/pcs_test/tier0/lib/corosync/test_config_validators_links.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_links.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from unittest import TestCase
 
 from pcs.common.corosync_conf import CorosyncNodeAddressType
@@ -27,7 +26,6 @@ _FIXTURE_KNET_PING_INTERVAL_TIMEOUT_EXPECTED = (
 
 
 class AddLink(TestCase):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.new_addrs = {
             "node1": "addr1-new",
@@ -915,7 +913,6 @@ class UpdateLinkCommon(TestCase):
     # Link update validator is complex, this class tests common cases. For more
     # specific tests see other UpdateLink* classes.
     def test_no_addrs_no_options(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.update_link(
                 "0",
@@ -932,7 +929,6 @@ class UpdateLinkCommon(TestCase):
         )
 
     def test_nonexistent_link(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.update_link(
                 "1",
@@ -1455,7 +1451,6 @@ class UpdateLinkAddressesKnet(UpdateLinkAddressesMixin, TestCase):
 
 class UpdateLinkKnet(TestCase):
     def test_individual_options_set(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.update_link(
                 "2",
@@ -1556,7 +1551,6 @@ class UpdateLinkKnet(TestCase):
         )
 
     def test_individual_options_unset(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.update_link(
                 "2",
@@ -1690,7 +1684,6 @@ class UpdateLinkKnet(TestCase):
                     )
 
     def test_ping_interval_ping_timeout_initially_broken(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.update_link(
                 "2",
@@ -1712,7 +1705,6 @@ class UpdateLinkKnet(TestCase):
         )
 
     def test_forbidden_characters(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.update_link(
                 "2",
@@ -1914,7 +1906,6 @@ class UpdateLinkUdp(TestCase):
         return new_values
 
     def test_individual_options_set(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.update_link(
                 "0",
@@ -1994,7 +1985,6 @@ class UpdateLinkUdp(TestCase):
         )
 
     def test_individual_options_unset(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.update_link(
                 "0",
@@ -2101,7 +2091,6 @@ class UpdateLinkUdp(TestCase):
         )
 
     def test_forbidden_characters(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.update_link(
                 "0",

--- a/pcs_test/tier0/lib/corosync/test_config_validators_nodes.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_nodes.py
@@ -18,7 +18,6 @@ forbidden_characters_kwargs = dict(
 
 
 class AddNodes(TestCase):
-    # pylint: disable=too-many-public-methods
     fixture_coronodes_1_link = [
         CNode("node1", [CAddr("addr01", 1)], 1),
         CNode("node2", [CAddr("addr02", 1)], 2),
@@ -180,7 +179,6 @@ class AddNodes(TestCase):
         )
 
     def test_nodename_already_used(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.add_nodes(
                 [
@@ -351,7 +349,6 @@ class AddNodes(TestCase):
         )
 
     def test_node_addrs_not_unique(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.add_nodes(
                 [
@@ -403,7 +400,6 @@ class AddNodes(TestCase):
         )
 
     def test_node_addrs_already_used(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.add_nodes(
                 [
@@ -426,7 +422,6 @@ class AddNodes(TestCase):
         )
 
     def test_node_addrs_ip_version_ok(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.add_nodes(
                 [
@@ -477,7 +472,6 @@ class AddNodes(TestCase):
         )
 
     def test_node_addrs_ip_version_mismatch(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.add_nodes(
                 [
@@ -499,7 +493,6 @@ class AddNodes(TestCase):
         )
 
     def test_node_addrs_mismatch_existing_links(self):
-        # pylint: disable=no-self-use
         assert_report_item_list_equal(
             config_validators.add_nodes(
                 [
@@ -535,7 +528,6 @@ class AddNodes(TestCase):
         )
 
     def test_node_addrs_ip_version_mismatch_complex(self):
-        # pylint: disable=no-self-use
         # several cases tested:
         # * not all links are defined - testing link indexes in reports
         # * link 1 - unresolvable addresses do not trigger ip mismatch reports

--- a/pcs_test/tier0/lib/corosync/test_config_validators_quorum.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_quorum.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from unittest import TestCase
 
 from pcs.common.reports import codes as report_codes
@@ -29,7 +28,6 @@ forbidden_characters_kwargs = dict(
 
 
 class BaseQuorumOptions:
-    # pylint: disable=no-member
     def test_no_options(self):
         has_qdevice = False
         assert_report_item_list_equal(self.validator({}, has_qdevice), [])
@@ -311,7 +309,6 @@ class QuorumOptionsUpdate(BaseQuorumOptions, TestCase):
         )
 
     def test_last_man_standing_required_currently_disabled(self):
-        # pylint: disable=no-self-use
         has_qdevice = False
         assert_report_item_list_equal(
             config_validators.update_quorum_options(
@@ -335,7 +332,6 @@ class QuorumOptionsUpdate(BaseQuorumOptions, TestCase):
         )
 
     def test_last_man_standing_required_currently_enabled(self):
-        # pylint: disable=no-self-use
         has_qdevice = False
         assert_report_item_list_equal(
             config_validators.update_quorum_options(

--- a/pcs_test/tier0/lib/corosync/test_config_validators_rename_cluster.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_rename_cluster.py
@@ -8,7 +8,6 @@ from pcs_test.tools.assertions import assert_report_item_list_equal
 
 
 class RenameCluster(TestCase):
-    # pylint: disable=no-self-use
     def test_valid_cluster_name(self):
         assert_report_item_list_equal(
             config_validators.rename_cluster("my-cluster", False), []

--- a/pcs_test/tier0/lib/corosync/test_live.py
+++ b/pcs_test/tier0/lib/corosync/test_live.py
@@ -23,7 +23,6 @@ class GetLocalCorosyncConfTest(TestCase):
             self.assertEqual(lib.get_local_corosync_conf(), a_file.read())
 
     def test_error(self):
-        # pylint: disable=no-self-use
         path = rc("corosync.conf.nonexistent")
         settings.corosync_conf_file = path
         assert_raise_library_error(
@@ -89,7 +88,6 @@ class SetExpectedVotesTest(TestCase):
         self.mock_runner = mock.MagicMock(spec_set=CommandRunner)
 
     def test_success(self):
-        # pylint: disable=no-self-use
         cmd_retval = 0
         cmd_stdout = "cmd output"
         cmd_stderr = ""
@@ -103,7 +101,6 @@ class SetExpectedVotesTest(TestCase):
         )
 
     def test_error(self):
-        # pylint: disable=no-self-use
         cmd_retval = 1
         cmd_stdout = "cmd output"
         cmd_stderr = "cmd stderr"

--- a/pcs_test/tier0/lib/corosync/test_qdevice_net.py
+++ b/pcs_test/tier0/lib/corosync/test_qdevice_net.py
@@ -80,7 +80,6 @@ class QdeviceSetupTest(TestCase):
 @mock.patch("pcs.lib.corosync.qdevice_net.shutil.rmtree")
 @mock.patch("pcs.lib.corosync.qdevice_net.qdevice_initialized")
 class QdeviceDestroyTest(TestCase):
-    # pylint: disable=no-self-use
     def test_success(self, mock_initialized, mock_rmtree):
         mock_initialized.return_value = True
         lib.qdevice_destroy()
@@ -398,7 +397,6 @@ class QdeviceSignCertificateRequestTest(CertificateTestCase):
 @mock.patch("pcs.lib.corosync.qdevice_net.shutil.rmtree")
 @mock.patch("pcs.lib.corosync.qdevice_net.client_initialized")
 class ClientDestroyTest(TestCase):
-    # pylint: disable=no-self-use
     def test_success(self, mock_initialized, mock_rmtree):
         mock_initialized.return_value = True
         lib.client_destroy()
@@ -763,7 +761,6 @@ class ClientImportCertificateAndKeyTest(CertificateTestCase):
 
 
 class GetOutputCertificateTest(TestCase):
-    # pylint: disable=protected-access
     def setUp(self):
         self.file_path = "/tmp/a-file"
         self.file_data = b"certificate data from a file"

--- a/pcs_test/tier0/lib/pacemaker/test_api_result.py
+++ b/pcs_test/tier0/lib/pacemaker/test_api_result.py
@@ -19,7 +19,6 @@ from pcs_test.tools.xml import etree_to_str
 )
 class GetApiResultDom(TestCase):
     def test_valid_xml(self):
-        # pylint: disable=no-self-use
         xml = """
             <pacemaker-result api-version="2.3" request="command">
                 <status code="0" message="OK"/>
@@ -42,7 +41,6 @@ class GetApiResultDom(TestCase):
 
 
 class GetStatusFromApiResult(TestCase):
-    # pylint: disable=protected-access
     def test_errors(self):
         self.assertEqual(
             api_result.get_status_from_api_result(

--- a/pcs_test/tier0/lib/pacemaker/test_live.py
+++ b/pcs_test/tier0/lib/pacemaker/test_live.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from hashlib import md5
 from unittest import TestCase, mock
 
@@ -57,7 +56,6 @@ class GetClusterStatusMixin(TestCase):
     settings, "pacemaker_api_result_schema", rc("pcmk_rng/api/api-result.rng")
 )
 class GetClusterStatusXml(GetClusterStatusMixin, TestCase):
-    # pylint: disable=protected-access
     def test_success(self):
         self.config.runner.pcmk.load_state(stdout=self.fixture_xml())
         env = self.env_assist.get_env()
@@ -337,7 +335,6 @@ class GetCibXmlTest(TestCase):
         self.assertEqual(expected_stdout, real_xml)
 
     def test_error(self):
-        # pylint: disable=no-self-use
         expected_stdout = "some info"
         expected_stderr = "some error"
         expected_retval = 1
@@ -381,7 +378,6 @@ class GetCibXmlTest(TestCase):
         self.assertEqual(expected_stdout, real_xml)
 
     def test_scope_error(self):
-        # pylint: disable=no-self-use
         expected_stdout = "some info"
         # yes, the numbers do not match, tested and verified with
         # pacemaker-2.0.0-1.fc29.1.x86_64
@@ -416,7 +412,6 @@ class GetCibXmlTest(TestCase):
 
 
 class GetCibTest(TestCase):
-    # pylint: disable=no-self-use
     def test_success(self):
         xml = "<xml />"
         assert_xml_equal(xml, str(XmlManipulation(lib.get_cib(xml))))
@@ -635,7 +630,6 @@ class GetCibVerificationErrors(TestCase):
 
 
 class ReplaceCibConfigurationTest(TestCase):
-    # pylint: disable=no-self-use
     def test_success(self):
         xml = "<xml/>"
         expected_stdout = "expected output"
@@ -697,8 +691,6 @@ class ReplaceCibConfigurationTest(TestCase):
 
 
 class UpgradeCibTest(TestCase):
-    # pylint: disable=protected-access
-    # pylint: disable=no-self-use
     def test_success(self):
         mock_runner = get_runner("", "", 0)
         lib._upgrade_cib(mock_runner)
@@ -1190,7 +1182,6 @@ class GetLocalNodeStatusTest(TestCase):
 
 
 class RemoveNode(TestCase):
-    # pylint: disable=no-self-use
     def test_success(self):
         mock_runner = get_runner("", "", 0)
         lib.remove_node(mock_runner, "NODE_NAME")
@@ -1518,7 +1509,6 @@ class ResourceRefreshTest(TestCase):
 
 
 class ResourcesWaitingTest(TestCase):
-    # pylint: disable=no-self-use
     def test_wait_success(self):
         expected_stdout = "expected output"
         expected_stderr = "expected stderr"
@@ -1598,7 +1588,6 @@ class ResourcesWaitingTest(TestCase):
 
 
 class IsInPcmkToolHelp(TestCase):
-    # pylint: disable=protected-access
     def test_all_in_stderr(self):
         mock_runner = get_runner("", "ABCDE", 0)
         self.assertTrue(
@@ -1792,8 +1781,6 @@ class GetResourceDigests(TestCase):
 
 
 class HandleInstanceAttributesValidateViaPcmkTest(TestCase):
-    # pylint: disable=protected-access
-
     def test_valid(self):
         runner = get_runner(
             stdout="""

--- a/pcs_test/tier0/lib/pacemaker/test_state.py
+++ b/pcs_test/tier0/lib/pacemaker/test_state.py
@@ -49,7 +49,6 @@ class ChildrenTest(TestCase):
         )
 
     def wrap(self, element):
-        # pylint: disable=no-self-use
         return "{0}.{1}".format(element.tag, element.attrib["name"])
 
     def test_get_declared_section(self):
@@ -177,7 +176,6 @@ class GetPrimitiveRolesWithNodes(TestCase):
         primitives = [etree.fromstring(xml) for xml in primitives_xml]
 
         self.assertEqual(
-            # pylint: disable=protected-access
             state._get_primitive_roles_with_nodes(primitives),
             {
                 "Started": ["node1", "node5"],
@@ -187,12 +185,10 @@ class GetPrimitiveRolesWithNodes(TestCase):
         )
 
     def test_empty(self):
-        # pylint: disable=protected-access
         self.assertEqual(state._get_primitive_roles_with_nodes([]), {})
 
 
 class GetPrimitivesForStateCheck(TestCase):
-    # pylint: disable=too-many-public-methods
     status_xml = etree.fromstring(
         """
         <resources>
@@ -336,7 +332,6 @@ class GetPrimitivesForStateCheck(TestCase):
         self.assertEqual(
             [
                 elem.attrib["id"]
-                # pylint: disable=protected-access
                 for elem in state._get_primitives_for_state_check(
                     self.status, resource_id, expected_running
                 )
@@ -496,7 +491,6 @@ class CommonResourceState(TestCase):
         self.get_primitive_roles_with_nodes = patcher_roles.start()
 
     def fixture_running_state_info(self):
-        # pylint: disable=no-self-use
         return {
             "Started": ["node1"],
             "Promoted": ["node2"],

--- a/pcs_test/tier0/lib/pacemaker/test_status.py
+++ b/pcs_test/tier0/lib/pacemaker/test_status.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from collections.abc import Sequence
 from unittest import TestCase
 
@@ -324,8 +323,6 @@ def fixture_crm_mon_xml(resources: list[str]) -> str:
 
 
 class TestParsingErrorToReport(TestCase):
-    # pylint: disable=no-self-use
-
     def test_empty_resource_id(self):
         report = status.cluster_status_parsing_error_to_report(
             status.EmptyResourceIdError()
@@ -462,7 +459,6 @@ class TestParsingErrorToReport(TestCase):
 
 
 class TestPrimitiveStatusToDto(TestCase):
-    # pylint: disable=protected-access
     def test_simple(self):
         primitive_xml = etree.fromstring(fixture_primitive_xml())
 
@@ -588,7 +584,6 @@ class TestPrimitiveStatusToDto(TestCase):
 
 
 class TestGroupStatusToDto(TestCase):
-    # pylint: disable=protected-access
     def test_all_attributes(self):
         group_xml = etree.fromstring(
             fixture_group_xml(description="Test description")
@@ -733,7 +728,6 @@ class TestGroupStatusToDto(TestCase):
 
 
 class TestCloneStatusToDto(TestCase):
-    # pylint: disable=protected-access
     def test_all_attributes(self):
         clone_xml = etree.fromstring(
             fixture_clone_xml(
@@ -1047,7 +1041,6 @@ class TestCloneStatusToDto(TestCase):
 
 
 class TestBundleReplicaStatusToDto(TestCase):
-    # pylint: disable=protected-access
     def setUp(self):
         self.bundle_id = "resource-bundle"
         self.bundle_type = "podman"
@@ -1345,7 +1338,6 @@ class TestBundleReplicaStatusToDto(TestCase):
 
 
 class TestBundleStatusToDto(TestCase):
-    # pylint: disable=protected-access
     def test_no_member(self):
         bundle_xml = etree.fromstring(
             fixture_bundle_xml(replicas=[fixture_replica_xml()])

--- a/pcs_test/tier0/lib/pacemaker/test_values.py
+++ b/pcs_test/tier0/lib/pacemaker/test_values.py
@@ -97,7 +97,6 @@ class ValidateIdTest(TestCase):
         self.assertEqual(None, lib.validate_id("dum_my"))
 
     def test_invalid_empty(self):
-        # pylint: disable=no-self-use
         assert_raise_library_error(
             lambda: lib.validate_id("", "test id"),
             (
@@ -110,7 +109,6 @@ class ValidateIdTest(TestCase):
         )
 
     def test_invalid_first_character(self):
-        # pylint: disable=no-self-use
         desc = "test id"
         info = {
             "id": "",
@@ -161,7 +159,6 @@ class ValidateIdTest(TestCase):
         )
 
     def test_invalid_character(self):
-        # pylint: disable=no-self-use
         desc = "test id"
         info = {
             "id": "",

--- a/pcs_test/tier0/lib/resource_agent/test_pcs_transform.py
+++ b/pcs_test/tier0/lib/resource_agent/test_pcs_transform.py
@@ -94,8 +94,6 @@ ra_pkg = "pcs.lib.resource_agent.pcs_transform"
 @mock.patch(f"{ra_pkg}._metadata_parameter_extract_enum_values_from_desc")
 @mock.patch(f"{ra_pkg}._metadata_action_translate_role")
 class OcfUnifiedToPcs(TestCase):
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-positional-arguments
     @staticmethod
     def _fixture_metadata(name):
         return ra.ResourceAgentMetadata(
@@ -265,7 +263,6 @@ class MetadataActionTranslateRole(TestCase):
         metadata_in = self._fixture_metadata([])
         metadata_out = self._fixture_metadata([])
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_action_translate_role(metadata_in),
             metadata_out,
         )
@@ -284,7 +281,6 @@ class MetadataActionTranslateRole(TestCase):
             ]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_action_translate_role(metadata_in),
             metadata_out,
         )
@@ -303,7 +299,6 @@ class MetadataActionTranslateRole(TestCase):
             ]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_action_translate_role(metadata_in),
             metadata_out,
         )
@@ -346,7 +341,6 @@ class MetadataParameterExtractAdvancedFromDesc(TestCase):
         metadata_in = self._fixture_metadata([])
         metadata_out = self._fixture_metadata([])
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_extract_advanced_from_desc(
                 metadata_in
             ),
@@ -361,7 +355,6 @@ class MetadataParameterExtractAdvancedFromDesc(TestCase):
             [self._fixture_parameter(None, None, False)]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_extract_advanced_from_desc(
                 metadata_in
             ),
@@ -376,7 +369,6 @@ class MetadataParameterExtractAdvancedFromDesc(TestCase):
             [self._fixture_parameter("some shortdesc", None, False)]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_extract_advanced_from_desc(
                 metadata_in
             ),
@@ -393,7 +385,6 @@ class MetadataParameterExtractAdvancedFromDesc(TestCase):
                     [self._fixture_parameter(None, None, True)]
                 )
                 self.assertEqual(
-                    # pylint: disable=protected-access
                     ra.pcs_transform._metadata_parameter_extract_advanced_from_desc(
                         metadata_in
                     ),
@@ -412,7 +403,6 @@ class MetadataParameterExtractAdvancedFromDesc(TestCase):
             [self._fixture_parameter("some shortdesc", None, True)]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_extract_advanced_from_desc(
                 metadata_in
             ),
@@ -447,7 +437,6 @@ class MetadataParameterExtractAdvancedFromDesc(TestCase):
                     ]
                 )
                 self.assertEqual(
-                    # pylint: disable=protected-access
                     ra.pcs_transform._metadata_parameter_extract_advanced_from_desc(
                         metadata_in
                     ),
@@ -472,7 +461,6 @@ class MetadataParameterExtractAdvancedFromDesc(TestCase):
                     ]
                 )
                 self.assertEqual(
-                    # pylint: disable=protected-access
                     ra.pcs_transform._metadata_parameter_extract_advanced_from_desc(
                         metadata_in
                     ),
@@ -521,7 +509,6 @@ class MetadataParameterExtractEnumValuesFromDesc(TestCase):
         metadata_in = self._fixture_metadata([])
         metadata_out = self._fixture_metadata([])
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_extract_enum_values_from_desc(
                 metadata_in
             ),
@@ -536,7 +523,6 @@ class MetadataParameterExtractEnumValuesFromDesc(TestCase):
             [self._fixture_parameter("select", self.longdesc)]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_extract_enum_values_from_desc(
                 metadata_in
             ),
@@ -555,7 +541,6 @@ class MetadataParameterExtractEnumValuesFromDesc(TestCase):
             ]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_extract_enum_values_from_desc(
                 metadata_in
             ),
@@ -577,7 +562,6 @@ class MetadataParameterExtractEnumValuesFromDesc(TestCase):
             ]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_extract_enum_values_from_desc(
                 metadata_in
             ),
@@ -596,7 +580,6 @@ class MetadataParameterExtractEnumValuesFromDesc(TestCase):
             ]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_extract_enum_values_from_desc(
                 metadata_in
             ),
@@ -618,7 +601,6 @@ class MetadataParameterExtractEnumValuesFromDesc(TestCase):
             ]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_extract_enum_values_from_desc(
                 metadata_in
             ),
@@ -646,7 +628,6 @@ class MetadataParameterExtractEnumValuesFromDesc(TestCase):
             ]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_extract_enum_values_from_desc(
                 metadata_in
             ),
@@ -692,7 +673,6 @@ class MetadataParameterRemoveSelectEnumValuesFromDesc(TestCase):
         metadata_in = self._fixture_metadata([])
         metadata_out = self._fixture_metadata([])
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_remove_select_enum_values_from_desc(
                 metadata_in
             ),
@@ -707,7 +687,6 @@ class MetadataParameterRemoveSelectEnumValuesFromDesc(TestCase):
             [self._fixture_parameter("enum", self.longdesc)]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_remove_select_enum_values_from_desc(
                 metadata_in
             ),
@@ -722,7 +701,6 @@ class MetadataParameterRemoveSelectEnumValuesFromDesc(TestCase):
             [self._fixture_parameter("select", self.new_longdesc)]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_remove_select_enum_values_from_desc(
                 metadata_in
             ),
@@ -737,7 +715,6 @@ class MetadataParameterRemoveSelectEnumValuesFromDesc(TestCase):
             [self._fixture_parameter("select", "other longdesc")]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_remove_select_enum_values_from_desc(
                 metadata_in
             ),
@@ -780,7 +757,6 @@ class MetadataParameterDeduplicateDesc(TestCase):
         metadata_in = self._fixture_metadata([])
         metadata_out = self._fixture_metadata([])
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_deduplicate_desc(metadata_in),
             metadata_out,
         )
@@ -793,7 +769,6 @@ class MetadataParameterDeduplicateDesc(TestCase):
             [self._fixture_parameter("same desc", None)]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_deduplicate_desc(metadata_in),
             metadata_out,
         )
@@ -806,7 +781,6 @@ class MetadataParameterDeduplicateDesc(TestCase):
             [self._fixture_parameter("shortdesc", "longdesc")]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_deduplicate_desc(metadata_in),
             metadata_out,
         )
@@ -847,7 +821,6 @@ class MetadataParameterJoinShortLongDesc(TestCase):
         metadata_in = self._fixture_metadata([])
         metadata_out = self._fixture_metadata([])
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_join_short_long_desc(
                 metadata_in
             ),
@@ -862,7 +835,6 @@ class MetadataParameterJoinShortLongDesc(TestCase):
             [self._fixture_parameter(None, None)]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_join_short_long_desc(
                 metadata_in
             ),
@@ -877,7 +849,6 @@ class MetadataParameterJoinShortLongDesc(TestCase):
             [self._fixture_parameter("shortdesc", None)]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_join_short_long_desc(
                 metadata_in
             ),
@@ -892,7 +863,6 @@ class MetadataParameterJoinShortLongDesc(TestCase):
             [self._fixture_parameter(None, "longdesc")]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_join_short_long_desc(
                 metadata_in
             ),
@@ -907,7 +877,6 @@ class MetadataParameterJoinShortLongDesc(TestCase):
             [self._fixture_parameter("shortdesc", "shortdesc.\nlongdesc")]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_join_short_long_desc(
                 metadata_in
             ),
@@ -928,7 +897,6 @@ class MetadataParameterJoinShortLongDesc(TestCase):
             ]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_parameter_join_short_long_desc(
                 metadata_in
             ),
@@ -971,7 +939,6 @@ class MetadataRemoveUnwantedStonithParameters(TestCase):
         metadata_in = self._fixture_metadata([])
         metadata_out = self._fixture_metadata([])
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_remove_unwanted_stonith_parameters(
                 metadata_in
             ),
@@ -994,7 +961,6 @@ class MetadataRemoveUnwantedStonithParameters(TestCase):
             ]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_remove_unwanted_stonith_parameters(
                 metadata_in
             ),
@@ -1037,7 +1003,6 @@ class MetadataMakeStonithActionParameterDeprecated(TestCase):
         metadata_in = self._fixture_metadata([])
         metadata_out = self._fixture_metadata([])
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_make_stonith_action_parameter_deprecated(
                 metadata_in
             ),
@@ -1068,7 +1033,6 @@ class MetadataMakeStonithActionParameterDeprecated(TestCase):
             ]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_make_stonith_action_parameter_deprecated(
                 metadata_in
             ),
@@ -1101,7 +1065,6 @@ class MetadataMakeStonithActionParameterDeprecated(TestCase):
             ]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_make_stonith_action_parameter_deprecated(
                 metadata_in
             ),
@@ -1144,7 +1107,6 @@ class MetadataMakeStonithPortParameterNotRequired(TestCase):
         metadata_in = self._fixture_metadata([])
         metadata_out = self._fixture_metadata([])
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_make_stonith_port_parameter_not_required(
                 metadata_in
             ),
@@ -1159,7 +1121,6 @@ class MetadataMakeStonithPortParameterNotRequired(TestCase):
             [self._fixture_parameter("param", True, [])]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_make_stonith_port_parameter_not_required(
                 metadata_in
             ),
@@ -1174,7 +1135,6 @@ class MetadataMakeStonithPortParameterNotRequired(TestCase):
             [self._fixture_parameter("port", False, [])]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_make_stonith_port_parameter_not_required(
                 metadata_in
             ),
@@ -1205,7 +1165,6 @@ class MetadataMakeStonithPortParameterNotRequired(TestCase):
             ]
         )
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.pcs_transform._metadata_make_stonith_port_parameter_not_required(
                 metadata_in
             ),

--- a/pcs_test/tier0/lib/resource_agent/test_xml.py
+++ b/pcs_test/tier0/lib/resource_agent/test_xml.py
@@ -40,7 +40,6 @@ class LoadMetadataXml(TestCase):
 
         env = self.env_assist.get_env()
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.xml._load_metadata_xml(env.cmd_runner(), agent_name),
             metadata.strip(),
         )
@@ -55,7 +54,6 @@ class LoadMetadataXml(TestCase):
 
         env = self.env_assist.get_env()
         with self.assertRaises(ra.UnableToGetAgentMetadata) as cm:
-            # pylint: disable=protected-access
             ra.xml._load_metadata_xml(env.cmd_runner(), agent_name)
         self.assertEqual(cm.exception.agent_name, "ocf:pacemaker:Dummy")
         self.assertEqual(cm.exception.message, "error message")
@@ -77,7 +75,6 @@ class LoadFakeAgentMetadataXml(TestCase):
 
         env = self.env_assist.get_env()
         self.assertEqual(
-            # pylint: disable=protected-access
             ra.xml._load_fake_agent_metadata_xml(env.cmd_runner(), agent_name),
             metadata.strip(),
         )
@@ -90,7 +87,6 @@ class LoadFakeAgentMetadataXml(TestCase):
 
         env = self.env_assist.get_env()
         with self.assertRaises(ra.UnableToGetAgentMetadata) as cm:
-            # pylint: disable=protected-access
             ra.xml._load_fake_agent_metadata_xml(env.cmd_runner(), agent_name)
         self.assertEqual(cm.exception.agent_name, "pacemaker-fenced")
         self.assertEqual(cm.exception.message, "error message")
@@ -100,7 +96,6 @@ class LoadFakeAgentMetadataXml(TestCase):
 
         env = self.env_assist.get_env()
         with self.assertRaises(ra.UnableToGetAgentMetadata) as cm:
-            # pylint: disable=protected-access
             ra.xml._load_fake_agent_metadata_xml(env.cmd_runner(), agent_name)
         self.assertEqual(cm.exception.agent_name, "unknown")
         self.assertEqual(cm.exception.message, "Unknown agent")
@@ -246,7 +241,6 @@ class LoadCrmAttributeMetadataXml(LoadCrmMetadataXmlBaseMixin, TestCase):
 
 
 class GetOcfVersion(TestCase):
-    # pylint: disable=protected-access
     def test_no_version_element(self):
         self.assertEqual(
             ra.xml._get_ocf_version(
@@ -304,7 +298,6 @@ class GetOcfVersion(TestCase):
 
 
 class MetadataXmlToDom(TestCase):
-    # pylint: disable=protected-access
     def test_not_xml(self):
         with self.assertRaises(etree.XMLSyntaxError):
             ra.xml._metadata_xml_to_dom("not an xml")
@@ -314,7 +307,6 @@ class MetadataXmlToDom(TestCase):
             ra.xml._metadata_xml_to_dom("<resource-agent/>")
 
     def test_no_version_valid(self):
-        # pylint: disable=no-self-use
         metadata = """
             <resource-agent name="agent">
             </resource-agent>
@@ -334,7 +326,6 @@ class MetadataXmlToDom(TestCase):
             )
 
     def test_ocf_1_0_valid(self):
-        # pylint: disable=no-self-use
         metadata = """
             <resource-agent name="agent">
                 <version>1.0</version>
@@ -355,7 +346,6 @@ class MetadataXmlToDom(TestCase):
             )
 
     def test_ocf_1_1_valid(self):
-        # pylint: disable=no-self-use
         metadata = """
             <resource-agent name="agent">
                 <version>1.1</version>

--- a/pcs_test/tier0/lib/test_cluster_property.py
+++ b/pcs_test/tier0/lib/test_cluster_property.py
@@ -280,8 +280,6 @@ def warning_reports(report_list):
 
 
 class TestValidateSetClusterProperties(TestCase):
-    # pylint: disable=too-many-instance-attributes
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.mock_service_manager = mock.Mock(spec=ServiceManagerInterface)
         self.facade = ResourceAgentFacade(
@@ -807,7 +805,6 @@ class TestValidateSetClusterProperties(TestCase):
 
 class TestGetClusterPropertySetElementLegacy(TestCase):
     def test_return_first_set(self):
-        # pylint: disable=no-self-use
         cib = etree.fromstring(FIXTURE_TWO_PROPERTY_SETS)
         id_provider = IdProvider(cib)
         set_element = (
@@ -821,7 +818,6 @@ class TestGetClusterPropertySetElementLegacy(TestCase):
         )
 
     def test_no_set_create_cib_bootstrap_options_set(self):
-        # pylint: disable=no-self-use
         cib = etree.fromstring(FIXTURE_NO_SET)
         id_provider = IdProvider(cib)
         set_element = (

--- a/pcs_test/tier0/lib/test_external.py
+++ b/pcs_test/tier0/lib/test_external.py
@@ -132,7 +132,6 @@ class CommandRunnerTest(TestCase):
             command, env_extend={"b": "B", "c": "{C}"}
         )
         # check that env_extend did not affect initial env of runner
-        # pylint: disable=protected-access
         self.assertEqual(runner._env_vars, global_env)
 
         self.assertEqual(real_stdout, expected_stdout)
@@ -471,7 +470,6 @@ class IsProxySetTest(TestCase):
         )
 
     def test_HTTP_PROXY(self):
-        # pylint: disable=invalid-name
         self.assertFalse(
             lib.is_proxy_set(
                 {
@@ -490,7 +488,6 @@ class IsProxySetTest(TestCase):
         )
 
     def test_HTTPS_PROXY(self):
-        # pylint: disable=invalid-name
         self.assertTrue(
             lib.is_proxy_set(
                 {
@@ -509,7 +506,6 @@ class IsProxySetTest(TestCase):
         )
 
     def test_ALL_PROXY(self):
-        # pylint: disable=invalid-name
         self.assertTrue(
             lib.is_proxy_set(
                 {

--- a/pcs_test/tier0/lib/test_sbd.py
+++ b/pcs_test/tier0/lib/test_sbd.py
@@ -25,7 +25,6 @@ class TestException(Exception):
 
 
 class EvenNumberOfNodesAndNoQdevice(TestCase):
-    # pylint: disable=protected-access
     def setUp(self):
         self.mock_corosync_conf = mock.MagicMock(spec_set=CorosyncConfigFacade)
 
@@ -412,7 +411,6 @@ class GetLocalSbdDeviceListTest(TestCase):
         self.assertEqual(0, mock_sbd_config.call_count)
 
     def test_config_read_error(self, mock_sbd_config, mock_config_exists):
-        # pylint: disable=no-self-use
         mock_config_exists.return_value = True
         node = "local node"
         error = "error string"
@@ -438,7 +436,6 @@ class GetLocalSbdDeviceListTest(TestCase):
 
 @mock.patch("pcs.lib.sbd.get_local_sbd_device_list")
 class IsDeviceSetLocalTest(TestCase):
-    # pylint: disable=protected-access
     def test_no_device(self, mock_device_list):
         mock_device_list.return_value = []
         self.assertFalse(lib_sbd._is_device_set_local())
@@ -570,7 +567,6 @@ class ValidateDeviceDictTest(TestCase):
         self.assertEqual([], lib_sbd.validate_nodes_devices(device_dict))
 
     def test_some_not_ok(self):
-        # pylint: disable=no-self-use
         too_many_devices = [
             "/dev" + str(i) for i in range(settings.sbd_max_device_num)
         ] + ["dev/sda2"]

--- a/pcs_test/tier0/test_capabilities.py
+++ b/pcs_test/tier0/test_capabilities.py
@@ -8,7 +8,6 @@ from pcs_test import PROJECT_ROOT
 
 class TestCapabilities(TestCase):
     def test_parsable(self):
-        # pylint: disable=no-self-use
         capabilities_dir = os.path.join(PROJECT_ROOT, "pcsd")
         dom = etree.parse(os.path.join(capabilities_dir, "capabilities.xml"))
         etree.RelaxNG(

--- a/pcs_test/tier1/cib_resource/test_bundle.py
+++ b/pcs_test/tier1/cib_resource/test_bundle.py
@@ -275,7 +275,6 @@ class BundleCreate(BundleCreateCommon):
 
 
 class BundleUpdate(BundleCreateCommon):
-    # pylint: disable=too-many-public-methods
     empty_cib = rc("cib-empty.xml")
 
     success_xml = """

--- a/pcs_test/tier1/cib_resource/test_clone_unclone.py
+++ b/pcs_test/tier1/cib_resource/test_clone_unclone.py
@@ -289,7 +289,6 @@ class Clone(
         lambda cib: etree.tostring(etree.parse(cib).findall(".//resources")[0])
     ),
 ):
-    # pylint: disable=too-many-public-methods
     empty_cib = rc("cib-empty.xml")
 
     def setUp(self):

--- a/pcs_test/tier1/cib_resource/test_create.py
+++ b/pcs_test/tier1/cib_resource/test_create.py
@@ -15,8 +15,6 @@ from pcs_test.tools.assertions import AssertPcsMixin
 from pcs_test.tools.bin_mock import get_mock_settings
 from pcs_test.tools.pcs_runner import PcsRunner
 
-# pylint: disable=too-many-lines
-
 ERRORS_HAVE_OCCURRED = (
     "Error: Errors have occurred, therefore pcs is unable to continue\n"
 )
@@ -400,7 +398,6 @@ class SuccessOperations(ResourceTest):
         )
 
     def test_op_with_OCF_CHECK_LEVEL(self):
-        # pylint: disable=invalid-name
         self.assert_effect(
             (
                 "resource create R ocf:pcsmock:minimal --no-default-ops "
@@ -968,7 +965,6 @@ class Promotable(TestCase, AssertPcsMixin):
         wait=False,
         enable_agent_self_validation=False,
     ):
-        # pylint: disable=unused-argument
         return locals()
 
     @mock.patch("pcs.cli.reports.output.print_to_stderr")
@@ -1197,7 +1193,6 @@ class FailOrWarnGroupCloneBundleCombinationFuture(
 
 
 class FailOrWarn(ResourceTest):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         super().setUp()
         self.pcs_runner.mock_settings = get_mock_settings()

--- a/pcs_test/tier1/cib_resource/test_enable_disable.py
+++ b/pcs_test/tier1/cib_resource/test_enable_disable.py
@@ -16,10 +16,7 @@ from pcs_test.tools.pcs_runner import PcsRunner
 class EnableDisable(
     TestCase,
     get_assert_pcs_effect_mixin(
-        lambda cib: etree.tostring(
-            # pylint:disable=undefined-variable
-            etree.parse(cib).findall(".//resources")[0]
-        )
+        lambda cib: etree.tostring(etree.parse(cib).findall(".//resources")[0])
     ),
 ):
     empty_cib = rc("cib-empty.xml")

--- a/pcs_test/tier1/cib_resource/test_manage_unmanage.py
+++ b/pcs_test/tier1/cib_resource/test_manage_unmanage.py
@@ -15,10 +15,7 @@ from pcs_test.tools.pcs_runner import PcsRunner
 class ManageUnmanage(
     TestCase,
     get_assert_pcs_effect_mixin(
-        lambda cib: etree.tostring(
-            # pylint:disable=undefined-variable
-            etree.parse(cib).findall(".//resources")[0]
-        )
+        lambda cib: etree.tostring(etree.parse(cib).findall(".//resources")[0])
     ),
 ):
     empty_cib = rc("cib-empty.xml")

--- a/pcs_test/tier1/cib_resource/test_operation_add.py
+++ b/pcs_test/tier1/cib_resource/test_operation_add.py
@@ -63,7 +63,6 @@ class OperationAdd(TestCase, get_assert_pcs_effect_mixin(get_cib_resources)):
         )
 
     def test_add_with_OCF_CHECK_LEVEL(self):
-        # pylint: disable=invalid-name
         self.assert_effect(
             (
                 "resource op add R start interval=20s OCF_CHECK_LEVEL=1 "

--- a/pcs_test/tier1/cib_resource/test_resource_stonith_is_forbidden.py
+++ b/pcs_test/tier1/cib_resource/test_resource_stonith_is_forbidden.py
@@ -18,7 +18,6 @@ class ResourceStonithIsForbidden(
         lambda cib: etree.tostring(etree.parse(cib).findall(".//resources")[0])
     ),
 ):
-    # pylint: disable=too-many-public-methods
     empty_cib = rc("cib-empty.xml")
 
     def setUp(self):

--- a/pcs_test/tier1/cib_resource/test_stonith_resource_is_forbidden.py
+++ b/pcs_test/tier1/cib_resource/test_stonith_resource_is_forbidden.py
@@ -18,7 +18,6 @@ class StonithIsForbidden(
         lambda cib: etree.tostring(etree.parse(cib).findall(".//resources")[0])
     ),
 ):
-    # pylint: disable=too-many-public-methods
     empty_cib = rc("cib-empty.xml")
 
     def setUp(self):

--- a/pcs_test/tier1/legacy/test_acl.py
+++ b/pcs_test/tier1/legacy/test_acl.py
@@ -26,7 +26,6 @@ ERRORS_HAVE_OCCURRED = (
 
 
 class ACLTest(TestCase, AssertPcsMixin):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.temp_cib = get_tmp_file("tier1_acl")
         write_file_to_tmpfile(empty_cib, self.temp_cib)

--- a/pcs_test/tier1/legacy/test_cluster.py
+++ b/pcs_test/tier1/legacy/test_cluster.py
@@ -46,7 +46,6 @@ class UidGidTest(TestCase):
         )
 
     def test_uidgid(self):  # noqa: PLR0915
-        # pylint: disable=too-many-statements
         stdout, stderr, retval = self._pcs("cluster uidgid".split())
         self.assertEqual(stdout, "")
         self.assertEqual(stderr, "No uidgids configured\n")

--- a/pcs_test/tier1/legacy/test_constraints.py
+++ b/pcs_test/tier1/legacy/test_constraints.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import datetime
 import os
 import unittest
@@ -107,7 +106,6 @@ CIB_FIXTURE = ConstraintTestCibFixture("fixture_tier1_constraints", empty_cib)
 
 @skip_unless_crm_rule()
 class ConstraintTest(unittest.TestCase, AssertPcsMixin):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.temp_cib = get_tmp_file("tier1_constraints")
         write_file_to_tmpfile(empty_cib, self.temp_cib)
@@ -484,7 +482,6 @@ class ConstraintTest(unittest.TestCase, AssertPcsMixin):
 
     # see also BundleColocation
     def test_colocation_constraints(self):  # noqa: PLR0915
-        # pylint: disable=too-many-statements
         self.fixture_resources()
         # pcs no longer allows creating masters but supports existing ones. In
         # order to test it, we need to put a master in the CIB without pcs.
@@ -875,7 +872,6 @@ class ConstraintTest(unittest.TestCase, AssertPcsMixin):
 
     # see also BundleColocation
     def test_colocation_sets(self):  # noqa: PLR0915
-        # pylint: disable=too-many-statements
         self.fixture_resources()
         self.assert_pcs_success(
             "resource create D7 ocf:pcsmock:minimal".split()
@@ -1390,7 +1386,6 @@ class ConstraintTest(unittest.TestCase, AssertPcsMixin):
 
     # see also BundleOrder
     def test_order_sets(self):  # noqa: PLR0915
-        # pylint: disable=too-many-statements
         self.fixture_resources()
         self.assert_pcs_success(
             "resource create D7 ocf:pcsmock:minimal".split()
@@ -1730,7 +1725,6 @@ Error: invalid option 'foo', allowed options are: 'id', 'kind', 'symmetrical'
         )
 
     def test_master_slave_constraint(self):  # noqa: PLR0915
-        # pylint: disable=too-many-statements
         os.system(
             "CIB_file="
             + self.temp_cib.name
@@ -1947,7 +1941,6 @@ Error: invalid option 'foo', allowed options are: 'id', 'kind', 'symmetrical'
         )
 
     def test_clone_constraint(self):  # noqa: PLR0915
-        # pylint: disable=too-many-statements
         os.system(
             "CIB_file="
             + self.temp_cib.name
@@ -2348,7 +2341,6 @@ Error: invalid option 'foo', allowed options are: 'id', 'kind', 'symmetrical'
         )
 
     def test_guest_node_constraints_remove(self):
-        # pylint: disable=too-many-statements
         self.temp_corosync_conf = get_tmp_file("tier1_test_constraints")
         write_file_to_tmpfile(rc("corosync.conf"), self.temp_corosync_conf)
         self.fixture_resources()
@@ -2720,7 +2712,6 @@ Error: duplicate constraint already exists, use --force to override
         )
 
     def test_duplicate_set_constraints(self):  # noqa: PLR0915
-        # pylint: disable=too-many-statements
         self.fixture_resources()
         stdout, stderr, retval = pcs(
             self.temp_cib.name, "constraint order set D1 D2".split()
@@ -2970,7 +2961,6 @@ Error: duplicate constraint already exists, use --force to override
         )
 
     def test_constraints_custom_id(self):  # noqa: PLR0915
-        # pylint: disable=too-many-statements
         self.fixture_resources()
         stdout, stderr, retval = pcs(
             self.temp_cib.name,
@@ -4196,7 +4186,6 @@ class LocationPrefersAvoidsMixin(
         self.temp_cib.close()
 
     def xml_score(self, score):
-        # pylint: disable=no-self-use
         return score if score else "INFINITY"
 
     @staticmethod
@@ -4362,7 +4351,6 @@ class LocationAdd(ConstraintEffect):
 
 @skip_unless_crm_rule()
 class ExpiredConstraints(ConstraintBaseTest):
-    # pylint: disable=too-many-public-methods
     # Setting tomorrow to the day after tomorrow in case the tests run close to
     # midnight.
     _tomorrow = (datetime.date.today() + datetime.timedelta(days=2)).strftime(

--- a/pcs_test/tier1/legacy/test_node.py
+++ b/pcs_test/tier1/legacy/test_node.py
@@ -621,7 +621,6 @@ class NodeAttributeTest(
         lambda cib: etree.tostring(etree.parse(cib).findall(".//nodes")[0])
     ),
 ):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.temp_cib = get_tmp_file("tier1_node_attribute")
         write_file_to_tmpfile(empty_cib, self.temp_cib)
@@ -640,7 +639,6 @@ class NodeAttributeTest(
                     '<instance_attributes id="nodes-{0}">'.format(node_id),
                 ]
             )
-            # pylint: disable=invalid-name
             nv = '<nvpair id="nodes-{id}-{name}" name="{name}" value="{val}"/>'
             for name, value in attrs.get(node_name, {}).items():
                 xml_lines.append(nv.format(id=node_id, name=name, val=value))

--- a/pcs_test/tier1/legacy/test_resource.py
+++ b/pcs_test/tier1/legacy/test_resource.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from textwrap import dedent
 from unittest import TestCase, skip
 
@@ -244,7 +243,6 @@ CIB_FIXTURE = ResourceTestCibFixture("fixture_tier1_resource", empty_cib)
 
 
 class Resource(TestCase, AssertPcsMixin):
-    # pylint: disable=too-many-public-methods
     def setUp(self):
         self.temp_cib = get_tmp_file("tier1_resource")
         self.temp_large_cib = get_tmp_file("tier1_resource_large")
@@ -2940,7 +2938,6 @@ class Resource(TestCase, AssertPcsMixin):
         )
 
     def test_relocate_stickiness(self):
-        # pylint: disable=too-many-statements
         self.assert_pcs_success(
             "resource create D1 ocf:pcsmock:minimal --no-default-ops".split()
         )

--- a/pcs_test/tier1/legacy/test_stonith.py
+++ b/pcs_test/tier1/legacy/test_stonith.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from textwrap import dedent
 from threading import Lock
 from unittest import TestCase
@@ -752,7 +751,6 @@ class LevelTestsBase(TestCase, AssertPcsMixin):
         write_data_to_tmpfile(cib, self.temp_cib)
 
     def fixture_cib_config_cache(self):
-        # pylint: disable=global-statement
         global _fixture_stonith_level_cache  # noqa: PLW0603
         with _fixture_stonith_level_cache_lock:
             if _fixture_stonith_level_cache is None:

--- a/pcs_test/tier1/legacy/test_utils.py
+++ b/pcs_test/tier1/legacy/test_utils.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import sys
 import xml.dom.minidom
 from io import StringIO
@@ -21,7 +20,6 @@ TestCase.maxDiff = None
 
 
 class UtilsTest(TestCase):
-    # pylint: disable=too-many-public-methods
     @staticmethod
     def get_cib_empty():
         return xml.dom.minidom.parse(empty_cib)
@@ -88,7 +86,6 @@ class UtilsTest(TestCase):
         return cib_dom
 
     def test_dom_get_resources(self):  # noqa: PLR0915
-        # pylint: disable=too-many-statements
         def test_dom_get(method, dom, ok_ids, bad_ids):
             for element_id in ok_ids:
                 self.assert_element_id(method(dom, element_id), element_id)
@@ -1453,7 +1450,7 @@ class UtilsTest(TestCase):
         )
 
         self.assertEqual(len(dom_get_child_elements(el)), 1)
-        u = dom_get_child_elements(el)[0]  # pylint: disable=invalid-name
+        u = dom_get_child_elements(el)[0]
         self.assertEqual(u.tagName, "utilization")
         self.assertEqual(u.getAttribute("id"), "test_id-utilization")
         self.assertEqual(len(dom_get_child_elements(u)), 2)
@@ -1498,7 +1495,7 @@ class UtilsTest(TestCase):
             },
         )
 
-        u = dom_get_child_elements(el)[0]  # pylint: disable=invalid-name
+        u = dom_get_child_elements(el)[0]
         self.assertEqual(len(dom_get_child_elements(u)), 1)
         self.assertEqual(
             dom_get_child_elements(u)[0].getAttribute("id"),
@@ -1522,7 +1519,7 @@ class UtilsTest(TestCase):
         )
 
         self.assertEqual(len(dom_get_child_elements(el)), 1)
-        u = dom_get_child_elements(el)[0]  # pylint: disable=invalid-name
+        u = dom_get_child_elements(el)[0]
         self.assertEqual(u.tagName, "meta_attributes")
         self.assertEqual(u.getAttribute("id"), "test_id-meta_attributes")
         self.assertEqual(len(dom_get_child_elements(u)), 2)
@@ -1561,7 +1558,7 @@ class UtilsTest(TestCase):
         ).documentElement
         utils.dom_update_meta_attr(el, [("key", "another_val"), ("key2", "")])
 
-        u = dom_get_child_elements(el)[0]  # pylint: disable=invalid-name
+        u = dom_get_child_elements(el)[0]
         self.assertEqual(len(dom_get_child_elements(u)), 1)
         self.assertEqual(
             dom_get_child_elements(u)[0].getAttribute("id"),
@@ -1613,7 +1610,6 @@ class UtilsTest(TestCase):
 class RunParallelTest(TestCase):
     @staticmethod
     def fixture_create_worker(log, name, sleepSeconds=0):
-        # pylint: disable=invalid-name
         def worker():
             sleep(sleepSeconds)
             log.append(name)
@@ -1657,7 +1653,6 @@ class TouchCibFile(TestCase):
     )
     @mock.patch("pcs.utils.err")
     def test_exception_is_transformed_correctly(self, err):
-        # pylint: disable=no-self-use
         filename = "/fake/filename"
         utils.touch_cib_file(filename)
         err.assert_called_once_with(

--- a/pcs_test/tier1/test_status.py
+++ b/pcs_test/tier1/test_status.py
@@ -137,7 +137,6 @@ class StonithWarningTest(TestCase, AssertPcsMixin):
 
 
 class ResourceStonithStatusBase(AssertPcsMixin):
-    # pylint: disable=too-many-public-methods
     command = None
     no_resources_msg = None
     all_resources_output = None

--- a/pcs_test/tools/assertions.py
+++ b/pcs_test/tools/assertions.py
@@ -21,7 +21,6 @@ def prepare_diff(first, second):
 
 
 def ac(a, b):
-    # pylint: disable=invalid-name
     """
     Compare the actual output 'a' and an expected output 'b', print diff b a
     """
@@ -67,8 +66,6 @@ class AssertPcsMixin:
         stderr_regexp=None,
         despace=False,
     ):
-        # pylint: disable=too-many-arguments
-        # pylint: disable=too-many-positional-arguments
         # It is common that successful commands don't print anything, so we
         # default stdout and stderr to an empty string if not specified
         # otherwise.
@@ -155,7 +152,6 @@ class AssertPcsMixin:
         returncode=0,
         despace=False,
     ):
-        # pylint: disable=too-many-arguments
         self.__check_output_specified(
             stdout_full, stdout_start, stdout_regexp, "stdout"
         )

--- a/pcs_test/tools/bin_mock/pcmk/crm_resource_mock.py
+++ b/pcs_test/tools/bin_mock/pcmk/crm_resource_mock.py
@@ -26,7 +26,6 @@ def get_arg_values(argv, name):
 
 
 def main():  # noqa: PLR0912,PLR0915
-    # pylint: disable=too-many-branches
     argv = sys.argv[1:]
     if not argv:
         raise AssertionError()

--- a/pcs_test/tools/case_analysis.py
+++ b/pcs_test/tools/case_analysis.py
@@ -8,7 +8,6 @@ def test_failed(test):
     # Borrowed from
     # https://stackoverflow.com/questions/4414234/getting-pythons-unittest-results-in-a-teardown-method/39606065#39606065
     # for Python versions 3.4 to 3.11
-    # pylint: disable=protected-access
     if hasattr(test._outcome, "errors"):
         # Python 3.4 - 3.10 (These 2 methods have no side effects)
         result = test.defaultTestResult()

--- a/pcs_test/tools/cib.py
+++ b/pcs_test/tools/cib.py
@@ -64,7 +64,6 @@ def get_assert_pcs_effect_mixin(get_cib_part):
             stderr_start=None,
             stderr_regexp=None,
         ):
-            # pylint: disable=too-many-arguments
             self.assert_pcs_success(
                 command,
                 stdout_full=stdout_full,
@@ -88,7 +87,6 @@ def get_assert_pcs_effect_mixin(get_cib_part):
             stderr_start=None,
             stderr_regexp=None,
         ):
-            # pylint: disable=too-many-arguments
             alternative_list = (
                 alternative_cmds
                 if isinstance(alternative_cmds[0], list)

--- a/pcs_test/tools/color_text_runner/format.py
+++ b/pcs_test/tools/color_text_runner/format.py
@@ -84,7 +84,6 @@ class Format:
         if not hasattr(test, "_testMethodName"):
             return test.id()
 
-        # pylint: disable=protected-access
         parts = test._testMethodName.split("_")
         if parts[0].startswith("test"):
             parts[0] = self._output.lightgrey("test") + parts[0][len("test") :]
@@ -114,7 +113,6 @@ class Format:
         return overview
 
     def test_name(self, test):
-        # pylint: disable=protected-access
         if isinstance(test, unittest.case._SubTest):
             test = test.test_case
         return "{module_name}.{class_name}.{method_name}".format(
@@ -125,7 +123,6 @@ class Format:
 
     def description(self, test, descriptions):
         subtest_desc = None
-        # pylint: disable=protected-access
         if isinstance(test, unittest.case._SubTest):
             subtest_desc = test._subDescription()
             test = test.test_case

--- a/pcs_test/tools/color_text_runner/result.py
+++ b/pcs_test/tools/color_text_runner/result.py
@@ -28,7 +28,6 @@ class ColorTextTestResult(VanillaTextTestResult):
         self.verbosity = 2 if self.traditional_verbose else verbosity
 
         self._format = Format(Output(self.rich_format))
-        # pylint: disable=invalid-name
         self.reportWriter = self.__chooseWriter()(
             self.stream,
             self._format,
@@ -110,7 +109,7 @@ class ColorTextTestResult(VanillaTextTestResult):
         for line in error_lines:
             self.stream.writeln(line)
 
-    def __chooseWriter(self):  # pylint: disable=invalid-name
+    def __chooseWriter(self):
         if self.measure_time:
             return TimeWriter
         if self.traditional_verbose:

--- a/pcs_test/tools/color_text_runner/writer.py
+++ b/pcs_test/tools/color_text_runner/writer.py
@@ -2,7 +2,6 @@ import datetime
 
 
 class Writer:
-    # pylint: disable=invalid-name
     def __init__(
         self,
         stream,

--- a/pcs_test/tools/command_env/assistant.py
+++ b/pcs_test/tools/command_env/assistant.py
@@ -177,7 +177,6 @@ def patch_env(call_queue, config, init_env):
 
 
 class EnvAssistant:
-    # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         config=None,
@@ -244,7 +243,6 @@ class EnvAssistant:
             # occurs, any changes to corosync.conf are done just in memory and
             # nothing gets reported. So an explicit check is necessary.
             corosync_conf_orig = self.__original_mocked_corosync_conf
-            # pylint: disable=protected-access
             corosync_conf_env = self._env._corosync_conf_data
             if corosync_conf_orig and corosync_conf_orig != corosync_conf_env:
                 raise AssertionError(
@@ -262,7 +260,6 @@ class EnvAssistant:
         user_groups: StringIterable | None = None,
     ):
         self.__call_queue = CallQueue(self.__config.calls)
-        # pylint: disable=attribute-defined-outside-init
         self._env = LibraryEnvironment(
             mock.MagicMock(logging.Logger),
             MockLibraryReportProcessor(),

--- a/pcs_test/tools/command_env/config.py
+++ b/pcs_test/tools/command_env/config.py
@@ -17,7 +17,6 @@ class Spy:
 
 
 class Config:
-    # pylint: disable=too-many-instance-attributes
     def __init__(self):
         self.__calls = CallListBuilder()
         self.runner = self.__wrap_helper(
@@ -29,14 +28,13 @@ class Config:
         )
         self.corosync_conf = self.__wrap_helper(CorosyncConf(self.__calls))
         self.fcntl = self.__wrap_helper(FcntlConfig(self.__calls))
-        # pylint: disable=invalid-name
         self.fs = self.__wrap_helper(FsConfig(self.__calls))
         self.raw_file = self.__wrap_helper(RawFileConfig(self.__calls))
         self.services = self.__wrap_helper(ServiceManagerConfig(self.__calls))
 
         self.spy = None
 
-    def add_extension(self, name, Extension):  # pylint: disable=invalid-name
+    def add_extension(self, name, Extension):
         if hasattr(self, name):
             raise AssertionError(
                 f"Config (integration tests) has the extension '{name}' already."

--- a/pcs_test/tools/command_env/config_http.py
+++ b/pcs_test/tools/command_env/config_http.py
@@ -36,7 +36,6 @@ def _mutual_exclusive(param_names, **kwargs):
 
 
 class HttpConfig:
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, call_collection, wrap_helper):
         self.__calls = call_collection
 

--- a/pcs_test/tools/command_env/config_http_booth.py
+++ b/pcs_test/tools/command_env/config_http_booth.py
@@ -86,7 +86,6 @@ class BoothShortcuts:
         communication_list=None,
         name="http.booth.save_files",
     ):
-        # pylint: disable=too-many-arguments
         param_list = [("data_json", json.dumps(files_data))]
         if rewrite_existing:
             param_list.append(("rewrite_existing", "1"))

--- a/pcs_test/tools/command_env/config_http_files.py
+++ b/pcs_test/tools/command_env/config_http_files.py
@@ -22,7 +22,6 @@ class FilesShortcuts:
         communication_list=None,
         name="http.files.put_files",
     ):
-        # pylint: disable=too-many-arguments
         """
         Create a call for the files distribution to the nodes.
 

--- a/pcs_test/tools/command_env/config_http_status.py
+++ b/pcs_test/tools/command_env/config_http_status.py
@@ -22,7 +22,6 @@ class StatusShortcuts:
         report_list=None,
         cluster_status_plaintext="",
     ):
-        # pylint: disable=too-many-arguments
         """
         Create a call for getting cluster status in plaintext
 
@@ -74,7 +73,6 @@ class StatusShortcuts:
         corosync_online_nodes=None,
         corosync_offline_nodes=None,
     ):
-        # pylint: disable=too-many-arguments
         """
         Create a call for getting cluster info from status.
 

--- a/pcs_test/tools/command_env/config_raw_file.py
+++ b/pcs_test/tools/command_env/config_raw_file.py
@@ -98,7 +98,6 @@ class RawFileConfig:
         string instead -- the key of a call instead of which this new call is to
             be placed
         """
-        # pylint: disable=too-many-arguments
         call = RawFileWriteCall(
             file_type_code,
             path,
@@ -136,7 +135,6 @@ class RawFileConfig:
         string instead -- the key of a call instead of which this new call is to
             be placed
         """
-        # pylint: disable=too-many-arguments
         call = RawFileRemoveCall(
             file_type_code,
             path,

--- a/pcs_test/tools/command_env/config_runner.py
+++ b/pcs_test/tools/command_env/config_runner.py
@@ -31,7 +31,6 @@ class RunnerConfig:
         instead=None,
         env=None,
     ):
-        # pylint: disable=too-many-arguments
         """
         Place new call to a config.
 

--- a/pcs_test/tools/command_env/config_runner_booth.py
+++ b/pcs_test/tools/command_env/config_runner_booth.py
@@ -133,7 +133,6 @@ class BoothShortcuts:
         instead=None,
         before=None,
     ):
-        # pylint: disable=too-many-arguments
         """
         Create a call for granting a ticket
 
@@ -172,7 +171,6 @@ class BoothShortcuts:
         instead=None,
         before=None,
     ):
-        # pylint: disable=too-many-arguments
         """
         Create a call for revoking a ticket
 

--- a/pcs_test/tools/command_env/config_runner_cib.py
+++ b/pcs_test/tools/command_env/config_runner_cib.py
@@ -48,7 +48,6 @@ class CibShortcuts:
             MODIFIER_GENERATORS - please refer it when you are adding params
             here)
         """
-        # pylint: disable=too-many-arguments
         if (returncode != 0 or stderr is not None) and (
             modifiers is not None or filename is not None or modifier_shortcuts
         ):

--- a/pcs_test/tools/command_env/config_runner_pcmk.py
+++ b/pcs_test/tools/command_env/config_runner_pcmk.py
@@ -30,8 +30,6 @@ RULE_NOT_YET_IN_EFFECT_RETURNCODE = 111
 
 
 class PcmkShortcuts:
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-public-methods
     def __init__(self, calls):
         self.__calls = calls
         self.default_wait_timeout = DEFAULT_WAIT_TIMEOUT
@@ -824,8 +822,6 @@ class PcmkShortcuts:
         int returncode -- crm_resource's returncode
         dict env -- CommandRunner environment variables
         """
-        # arguments are used via locals()
-        # pylint: disable=unused-argument
         all_args = locals()
         del all_args["self"]
         all_args["action"] = "--move"
@@ -862,7 +858,6 @@ class PcmkShortcuts:
         int returncode -- crm_resource's returncode
         """
         # arguments are used via locals()
-        # pylint: disable=unused-argument
         all_args = locals()
         del all_args["self"]
         all_args["action"] = "--ban"
@@ -901,7 +896,6 @@ class PcmkShortcuts:
         dict env -- CommandRunner environment variables
         """
         # arguments are used via locals()
-        # pylint: disable=unused-argument
         all_args = locals()
         del all_args["self"]
         all_args["action"] = "--clear"
@@ -1248,7 +1242,6 @@ class PcmkShortcuts:
         env=None,
         name="runner.pcmk.resource_agent_self_validation",
     ):
-        # pylint: disable=too-many-locals
         if output and stdout:
             raise AssertionError("Cannot specify both output and stdout")
         cmd = [
@@ -1314,7 +1307,6 @@ class PcmkShortcuts:
         env=None,
         name="runner.pcmk.stonith_agent_self_validation",
     ):
-        # pylint: disable=too-many-locals
         if output and stdout:
             raise AssertionError("Cannot specify both output and stdout")
         cmd = [

--- a/pcs_test/tools/command_env/mock_node_communicator.py
+++ b/pcs_test/tools/command_env/mock_node_communicator.py
@@ -128,8 +128,6 @@ def _communication_to_response(  # noqa: PLR0913
     error_msg,
     raw_data,
 ):
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-positional-arguments
     return Response(
         MockCurlSimple(
             info={pycurl.RESPONSE_CODE: response_code},
@@ -194,7 +192,6 @@ def create_communication(  # noqa: PLR0913
     string error_msg -- see Response
     string raw_data -- see data attrib in RequestData
     """
-    # pylint: disable=too-many-arguments
     # We don't care about tokens, see _communication_to_response.
     common = dict(
         action=action,
@@ -445,7 +442,6 @@ class NodeCommunicator:
                     real_request.target.dest_list,
                 )
 
-            # pylint: disable=protected-access
             if not _compare_request_data(
                 expected_request._data.structured_data,
                 real_request._data.structured_data,

--- a/pcs_test/tools/command_env/tools.py
+++ b/pcs_test/tools/command_env/tools.py
@@ -40,7 +40,6 @@ def get_env_tools(
     runner.pcmk.default_wait_error_returncode = default_wait_error_returncode
 
     if local_extensions:
-        # pylint: disable=invalid-name
         for name, ExtensionClass in local_extensions.items():
             env_assistant.config.add_extension(
                 name,

--- a/pcs_test/tools/custom_mock.py
+++ b/pcs_test/tools/custom_mock.py
@@ -22,7 +22,6 @@ from pcs_test.tools.assertions import assert_report_item_list_equal
 
 def get_getaddrinfo_mock(resolvable_addr_list):
     def socket_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):  # noqa: A002
-        # pylint: disable=redefined-builtin
         del port, family, type, proto, flags
         if host not in resolvable_addr_list:
             raise socket.gaierror(1, "")
@@ -184,7 +183,6 @@ class MockLibraryReportProcessor(ReportProcessor):
 
 
 class MockCurl:
-    # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         info=None,
@@ -305,16 +303,13 @@ class MockCurlMulti:
             )
 
     def select(self, timeout=1):
-        # pylint: disable=no-self-use
         del timeout
         return 0
 
     def perform(self):
-        # pylint: disable=no-self-use
         return (0, 0)
 
     def timeout(self):
-        # pylint: disable=no-self-use
         return 0
 
     def info_read(self):
@@ -333,7 +328,6 @@ class MockCurlMulti:
                 else:
                     ok_list.append(handle)
             except pycurl.error as e:
-                # pylint: disable=unbalanced-tuple-unpacking
                 errno, msg = e.args
                 err_list.append((handle, errno, msg))
             self._processed_list.append(handle)

--- a/pcs_test/tools/fixture_cib.py
+++ b/pcs_test/tools/fixture_cib.py
@@ -61,8 +61,6 @@ class CachedCibFixture(AssertPcsMixin):
         return self._pcs_runner
 
     def assertEqual(self, first, second, msg=None):
-        # pylint: disable=invalid-name
-        # pylint: disable=no-self-use
         if first != second:
             raise AssertionError(
                 f"{msg}\n{first} != {second}" if msg else f"{first} != {second}"

--- a/pcs_test/tools/misc.py
+++ b/pcs_test/tools/misc.py
@@ -122,15 +122,12 @@ def read_test_resource(name):
 
 
 def cmp3(a, b):
-    # pylint: disable=invalid-name
-
     # python3 doesn't have the cmp function, this is an official workaround
     # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
     return (a > b) - (a < b)
 
 
 def compare_version(a, b):
-    # pylint: disable=invalid-name
     if a[0] == b[0]:
         if a[1] == b[1]:
             return cmp3(a[2], b[2])

--- a/pcs_test/tools/parallel_test_runner.py
+++ b/pcs_test/tools/parallel_test_runner.py
@@ -33,7 +33,6 @@ class ParallelTestManager:
 
 
 class VanillaTextTestResult(unittest.TextTestResult):
-    # pylint: disable=no-self-use
     def get_failed_names(self) -> list[str]:
         return []
 
@@ -74,7 +73,6 @@ class VanillaTextTestResult(unittest.TextTestResult):
 class ParallelTestResult:
     """Representation of test result that can be pickled"""
 
-    # pylint: disable=too-many-instance-attributes
     tests_run: int = 0
     was_successful: bool = True
     error_reports: list[str] = field(default_factory=list)
@@ -94,7 +92,6 @@ class ParallelTestResult:
         vanilla: bool,
         last_slash: bool,
     ) -> None:
-        # pylint: disable=import-outside-toplevel too-many-branches
         summary_lines = []
         if self.error_count or self.failure_count or self.skip_count or vanilla:
             summary_lines.append("")
@@ -173,7 +170,6 @@ class ParallelTestResult:
 class ParallelTestRunner(unittest.TextTestRunner):
     def _makeResult(self):
         return self.resultclass(
-            # pylint: disable=protected-access
             unittest.runner._WritelnDecorator(StringIO()),
             self.descriptions,
             self.verbosity,

--- a/pcs_test/tools/pcs_runner.py
+++ b/pcs_test/tools/pcs_runner.py
@@ -65,7 +65,6 @@ def _run(
     env_vars = {"LC_ALL": "C"}
     env_vars.update(dict(env_extend) if env_extend else {})
 
-    # pylint: disable=subprocess-popen-preexec-fn
     with subprocess.Popen(
         args,
         stdin=subprocess.DEVNULL,


### PR DESCRIPTION
Following upgrades linters, I am deleting also unused old py linter comments.

<!-- testing-farm = {"lock":"false","comment-id":"5037101411","data":[{"id":"78bacbb1-8ced-461d-b9f8-9bebbb5e87e4","name":"CentOS-Stream-10","runTime":540.554835,"created":"2026-07-21T17:23:26.121573","updated":"2026-07-21T17:23:26.121579","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/78bacbb1-8ced-461d-b9f8-9bebbb5e87e4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/78bacbb1-8ced-461d-b9f8-9bebbb5e87e4/pipeline.log\">pipeline</a>"]}]} -->