### PR TITLE
Update imports at the top of the file

### DIFF
--- a/pcs/cli/alert/output.py
+++ b/pcs/cli/alert/output.py
@@ -1,10 +1,7 @@
 import shlex
 from collections.abc import Sequence
 
-from pcs.cli.common.output import (
-    INDENT_STEP,
-    pairs_to_cmd,
-)
+from pcs.cli.common.output import INDENT_STEP, pairs_to_cmd
 from pcs.cli.nvset import nvset_dto_to_lines
 from pcs.common.pacemaker.alert import (
     CibAlertDto,
@@ -13,11 +10,7 @@ from pcs.common.pacemaker.alert import (
     CibAlertSelectDto,
 )
 from pcs.common.pacemaker.nvset import CibNvsetDto
-from pcs.common.str_tools import (
-    format_list,
-    format_optional,
-    indent,
-)
+from pcs.common.str_tools import format_list, format_optional, indent
 
 
 def _description_to_lines(desc: str | None) -> list[str]:

--- a/pcs/cli/booth/env.py
+++ b/pcs/cli/booth/env.py
@@ -1,10 +1,7 @@
 from pcs.cli.file import metadata
 from pcs.cli.reports import output
 from pcs.common import file as pcs_file
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
+from pcs.common import file_type_codes, reports
 from pcs.common.reports.item import ReportItem
 from pcs.lib.errors import LibraryError
 

--- a/pcs/cli/client.py
+++ b/pcs/cli/client.py
@@ -2,10 +2,7 @@ import contextlib
 import os
 from typing import Any, cast
 
-from pcs import (
-    settings,
-    utils,
-)
+from pcs import settings, utils
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.common.parse_args import Argv, InputModifiers
 from pcs.cli.file import metadata as cli_metadata

--- a/pcs/cli/common/errors.py
+++ b/pcs/cli/common/errors.py
@@ -1,7 +1,4 @@
-from pcs.common.str_tools import (
-    format_list_base,
-    quote_items,
-)
+from pcs.common.str_tools import format_list_base, quote_items
 from pcs.common.types import StringSequence
 
 ERR_NODE_LIST_AND_ALL_MUTUALLY_EXCLUSIVE = (

--- a/pcs/cli/common/output.py
+++ b/pcs/cli/common/output.py
@@ -4,10 +4,7 @@ from collections.abc import Iterable
 from shlex import quote
 from shutil import get_terminal_size
 
-from pcs.common.types import (
-    StringIterable,
-    StringSequence,
-)
+from pcs.common.types import StringIterable, StringSequence
 
 INDENT_STEP = 2
 SUBSEQUENT_INDENT_STEP = 4

--- a/pcs/cli/common/parse_args.py
+++ b/pcs/cli/common/parse_args.py
@@ -3,10 +3,7 @@ from collections.abc import Mapping
 from functools import partial
 from typing import Final
 
-from pcs.cli.common.errors import (
-    SEE_MAN_CHANGES,
-    CmdLineInputError,
-)
+from pcs.cli.common.errors import SEE_MAN_CHANGES, CmdLineInputError
 from pcs.cli.reports.output import deprecation_warning
 from pcs.common.const import INFINITY
 from pcs.common.str_tools import (
@@ -15,11 +12,7 @@ from pcs.common.str_tools import (
     format_plural,
 )
 from pcs.common.tools import timeout_to_seconds
-from pcs.common.types import (
-    StringCollection,
-    StringIterable,
-    StringSequence,
-)
+from pcs.common.types import StringCollection, StringIterable, StringSequence
 
 # sys.argv always returns a list, we don't need StringSequence in here
 Argv = list[str]

--- a/pcs/cli/constraint/command.py
+++ b/pcs/cli/constraint/command.py
@@ -2,11 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.parse_args import (
-    Argv,
-    InputModifiers,
-    ensure_unique_args,
-)
+from pcs.cli.common.parse_args import Argv, InputModifiers, ensure_unique_args
 from pcs.cli.constraint import parse_args
 from pcs.common.pacemaker.constraint import (
     get_all_constraints_ids,

--- a/pcs/cli/constraint/location/command.py
+++ b/pcs/cli/constraint/location/command.py
@@ -12,10 +12,7 @@ from pcs.cli.reports.output import deprecation_warning
 from pcs.cli.reports.preprocessor import (
     get_duplicate_constraint_exists_preprocessor,
 )
-from pcs.common import (
-    const,
-    reports,
-)
+from pcs.common import const, reports
 from pcs.common.pacemaker.constraint import get_all_location_constraints_ids
 from pcs.common.str_tools import format_list
 from pcs.common.types import StringIterable

--- a/pcs/cli/constraint/output/__init__.py
+++ b/pcs/cli/constraint/output/__init__.py
@@ -1,9 +1,4 @@
-from . import (
-    colocation,
-    location,
-    order,
-    ticket,
-)
+from . import colocation, location, order, ticket
 from .all import (
     CibConstraintLocationAnyDto,
     constraints_to_cmd,

--- a/pcs/cli/constraint/output/all.py
+++ b/pcs/cli/constraint/output/all.py
@@ -18,12 +18,7 @@ from pcs.common.pacemaker.constraint import (
 )
 from pcs.common.types import CibRuleInEffectStatus
 
-from . import (
-    colocation,
-    location,
-    order,
-    ticket,
-)
+from . import colocation, location, order, ticket
 
 
 def constraints_to_text(

--- a/pcs/cli/constraint/output/colocation.py
+++ b/pcs/cli/constraint/output/colocation.py
@@ -1,10 +1,7 @@
 from collections.abc import Iterable
 from shlex import quote
 
-from pcs.cli.common.output import (
-    INDENT_STEP,
-    pairs_to_cmd,
-)
+from pcs.cli.common.output import INDENT_STEP, pairs_to_cmd
 from pcs.cli.reports.output import warn
 from pcs.cli.rule import rule_expression_dto_to_lines
 from pcs.common.pacemaker.constraint import (
@@ -12,11 +9,7 @@ from pcs.common.pacemaker.constraint import (
     CibConstraintColocationDto,
     CibConstraintColocationSetDto,
 )
-from pcs.common.str_tools import (
-    format_name_value_list,
-    format_optional,
-    indent,
-)
+from pcs.common.str_tools import format_name_value_list, format_optional, indent
 from pcs.common.types import StringCollection
 
 from . import set as _set

--- a/pcs/cli/constraint/output/location.py
+++ b/pcs/cli/constraint/output/location.py
@@ -2,10 +2,7 @@ import shlex
 from collections import defaultdict
 from collections.abc import Callable, Iterable
 
-from pcs.cli.common.output import (
-    INDENT_STEP,
-    pairs_to_cmd,
-)
+from pcs.cli.common.output import INDENT_STEP, pairs_to_cmd
 from pcs.cli.reports.output import warn
 from pcs.cli.rule import rule_expression_dto_to_lines
 from pcs.common.pacemaker.constraint import (
@@ -14,15 +11,8 @@ from pcs.common.pacemaker.constraint import (
     CibConstraintLocationSetDto,
 )
 from pcs.common.pacemaker.rule import CibRuleExpressionDto
-from pcs.common.pacemaker.tools import (
-    abs_score,
-    is_negative_score,
-)
-from pcs.common.str_tools import (
-    format_optional,
-    indent,
-    pairs_to_text,
-)
+from pcs.common.pacemaker.tools import abs_score, is_negative_score
+from pcs.common.str_tools import format_optional, indent, pairs_to_text
 
 from . import set as _set
 

--- a/pcs/cli/constraint/output/order.py
+++ b/pcs/cli/constraint/output/order.py
@@ -1,22 +1,14 @@
 from collections.abc import Iterable
 from shlex import quote
 
-from pcs.cli.common.output import (
-    INDENT_STEP,
-    bool_to_cli_value,
-    pairs_to_cmd,
-)
+from pcs.cli.common.output import INDENT_STEP, bool_to_cli_value, pairs_to_cmd
 from pcs.cli.reports.output import warn
 from pcs.common.pacemaker.constraint import (
     CibConstraintOrderAttributesDto,
     CibConstraintOrderDto,
     CibConstraintOrderSetDto,
 )
-from pcs.common.str_tools import (
-    format_optional,
-    indent,
-    pairs_to_text,
-)
+from pcs.common.str_tools import format_optional, indent, pairs_to_text
 
 from . import set as _set
 

--- a/pcs/cli/constraint/output/ticket.py
+++ b/pcs/cli/constraint/output/ticket.py
@@ -1,20 +1,13 @@
 from collections.abc import Iterable
 from shlex import quote
 
-from pcs.cli.common.output import (
-    INDENT_STEP,
-    pairs_to_cmd,
-)
+from pcs.cli.common.output import INDENT_STEP, pairs_to_cmd
 from pcs.common.pacemaker.constraint import (
     CibConstraintTicketAttributesDto,
     CibConstraintTicketDto,
     CibConstraintTicketSetDto,
 )
-from pcs.common.str_tools import (
-    format_optional,
-    indent,
-    pairs_to_text,
-)
+from pcs.common.str_tools import format_optional, indent, pairs_to_text
 
 from . import set as _set
 

--- a/pcs/cli/constraint/parse_args.py
+++ b/pcs/cli/constraint/parse_args.py
@@ -1,9 +1,5 @@
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.parse_args import (
-    Argv,
-    KeyValueParser,
-    split_list,
-)
+from pcs.cli.common.parse_args import Argv, KeyValueParser, split_list
 
 
 def prepare_resource_sets(

--- a/pcs/cli/constraint_colocation/command.py
+++ b/pcs/cli/constraint_colocation/command.py
@@ -1,13 +1,7 @@
-from typing import (
-    Any,
-    cast,
-)
+from typing import Any, cast
 
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.parse_args import (
-    Argv,
-    InputModifiers,
-)
+from pcs.cli.common.parse_args import Argv, InputModifiers
 from pcs.cli.constraint import command
 from pcs.cli.constraint.output import print_config
 from pcs.cli.reports.output import deprecation_warning

--- a/pcs/cli/constraint_order/command.py
+++ b/pcs/cli/constraint_order/command.py
@@ -1,13 +1,7 @@
-from typing import (
-    Any,
-    cast,
-)
+from typing import Any, cast
 
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.parse_args import (
-    Argv,
-    InputModifiers,
-)
+from pcs.cli.common.parse_args import Argv, InputModifiers
 from pcs.cli.constraint import command
 from pcs.cli.constraint.output import print_config
 from pcs.cli.reports.preprocessor import (

--- a/pcs/cli/constraint_ticket/command.py
+++ b/pcs/cli/constraint_ticket/command.py
@@ -2,10 +2,7 @@ import dataclasses
 from typing import Any, cast
 
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.parse_args import (
-    Argv,
-    InputModifiers,
-)
+from pcs.cli.common.parse_args import Argv, InputModifiers
 from pcs.cli.constraint import command
 from pcs.cli.constraint.output import print_config
 from pcs.cli.constraint_ticket import parse_args

--- a/pcs/cli/constraint_ticket/parse_args.py
+++ b/pcs/cli/constraint_ticket/parse_args.py
@@ -1,8 +1,5 @@
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.parse_args import (
-    Argv,
-    KeyValueParser,
-)
+from pcs.cli.common.parse_args import Argv, KeyValueParser
 
 
 def separate_tail_option_candidates(

--- a/pcs/cli/dr.py
+++ b/pcs/cli/dr.py
@@ -5,11 +5,7 @@ from dacite import DaciteError
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.common.parse_args import InputModifiers
 from pcs.cli.reports.output import error
-from pcs.common.dr import (
-    DrConfigDto,
-    DrConfigSiteDto,
-    DrSiteStatusDto,
-)
+from pcs.common.dr import DrConfigDto, DrConfigSiteDto, DrSiteStatusDto
 from pcs.common.interface import dto
 from pcs.common.reports import codes as report_codes
 from pcs.common.str_tools import indent

--- a/pcs/cli/host.py
+++ b/pcs/cli/host.py
@@ -1,10 +1,7 @@
 from typing import Any
 from urllib.parse import urlparse
 
-from pcs import (
-    settings,
-    utils,
-)
+from pcs import settings, utils
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.common.parse_args import (
     Argv,

--- a/pcs/cli/nvset.py
+++ b/pcs/cli/nvset.py
@@ -1,10 +1,7 @@
 from collections.abc import Iterable, Mapping
 from dataclasses import replace
 
-from pcs.cli.rule import (
-    get_in_effect_label,
-    rule_expression_dto_to_lines,
-)
+from pcs.cli.rule import get_in_effect_label, rule_expression_dto_to_lines
 from pcs.common.pacemaker.nvset import CibNvpairDto, CibNvsetDto
 from pcs.common.str_tools import (
     format_name_optional_value_or_id_list,

--- a/pcs/cli/query/resource.py
+++ b/pcs/cli/query/resource.py
@@ -25,10 +25,7 @@ from pcs.common.resource_status import (
     can_be_promotable,
     can_be_unique,
 )
-from pcs.common.str_tools import (
-    format_list,
-    format_optional,
-)
+from pcs.common.str_tools import format_list, format_optional
 
 
 def _handle_query_result(result: bool, quiet: bool) -> SystemExit:

--- a/pcs/cli/reports/__init__.py
+++ b/pcs/cli/reports/__init__.py
@@ -1,6 +1,3 @@
-from . import (
-    messages,
-    output,
-)
+from . import messages, output
 from .output import process_library_reports
 from .processor import ReportProcessorToConsole

--- a/pcs/cli/reports/messages.py
+++ b/pcs/cli/reports/messages.py
@@ -3,14 +3,7 @@ from functools import partial
 from typing import Any, get_type_hints
 
 from pcs.common import file_type_codes
-from pcs.common.reports import (
-    codes,
-    const,
-    dto,
-    item,
-    messages,
-    types,
-)
+from pcs.common.reports import codes, const, dto, item, messages, types
 from pcs.common.str_tools import (
     format_list,
     format_optional,

--- a/pcs/cli/reports/output.py
+++ b/pcs/cli/reports/output.py
@@ -1,10 +1,7 @@
 import sys
 
 from pcs.cli.common.tools import print_to_stderr
-from pcs.common.reports import (
-    ReportItemList,
-    ReportItemSeverity,
-)
+from pcs.common.reports import ReportItemList, ReportItemSeverity
 from pcs.common.reports.utils import add_context_to_message
 
 from .messages import report_item_msg_from_dto

--- a/pcs/cli/reports/preprocessor.py
+++ b/pcs/cli/reports/preprocessor.py
@@ -5,10 +5,7 @@ from pcs.cli.common.tools import print_to_stderr
 from pcs.cli.constraint import output
 from pcs.common import reports
 from pcs.common.pacemaker.constraint import CibConstraintsDto
-from pcs.common.str_tools import (
-    format_list,
-    indent,
-)
+from pcs.common.str_tools import format_list, indent
 from pcs.common.types import StringIterable
 from pcs.lib.errors import LibraryError
 

--- a/pcs/cli/reports/processor.py
+++ b/pcs/cli/reports/processor.py
@@ -1,21 +1,13 @@
 from collections.abc import Callable, Iterable
 
 from pcs.cli.common.tools import print_to_stderr
-from pcs.common.reports import (
-    ReportItem,
-    ReportItemSeverity,
-    ReportProcessor,
-)
+from pcs.common.reports import ReportItem, ReportItemSeverity, ReportProcessor
 from pcs.common.reports.dto import ReportItemDto
 from pcs.common.reports.types import SeverityLevel
 from pcs.common.reports.utils import add_context_to_message
 
 from .messages import report_item_msg_from_dto
-from .output import (
-    deprecation_warning,
-    error,
-    warn,
-)
+from .output import deprecation_warning, error, warn
 
 ReportItemPreprocessor = Callable[[ReportItem], ReportItem | None]
 

--- a/pcs/cli/resource/command.py
+++ b/pcs/cli/resource/command.py
@@ -2,11 +2,7 @@ import json
 from typing import Any
 
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.output import (
-    format_cmd_list,
-    lines_to_str,
-    smart_wrap_text,
-)
+from pcs.cli.common.output import format_cmd_list, lines_to_str, smart_wrap_text
 from pcs.cli.common.parse_args import (
     FUTURE_OPTION,
     OUTPUT_FORMAT_OPTION,

--- a/pcs/cli/resource/common.py
+++ b/pcs/cli/resource/common.py
@@ -11,11 +11,7 @@ from pcs.common.status_dto import (
     GroupStatusDto,
     PrimitiveStatusDto,
 )
-from pcs.common.str_tools import (
-    format_list,
-    format_optional,
-    format_plural,
-)
+from pcs.common.str_tools import format_list, format_optional, format_plural
 
 RESOURCE_NOT_RUNNING = "Resource '{resource_id}' is not running on any nodes"
 

--- a/pcs/cli/resource/relations.py
+++ b/pcs/cli/resource/relations.py
@@ -3,10 +3,7 @@ from typing import Any
 
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.common.parse_args import InputModifiers
-from pcs.cli.common.printable_tree import (
-    PrintableTreeNode,
-    tree_to_lines,
-)
+from pcs.cli.common.printable_tree import PrintableTreeNode, tree_to_lines
 from pcs.common.interface import dto
 from pcs.common.pacemaker.resource.relations import (
     RelationEntityDto,
@@ -14,10 +11,7 @@ from pcs.common.pacemaker.resource.relations import (
     ResourceRelationType,
 )
 from pcs.common.str_tools import format_optional
-from pcs.common.types import (
-    StringCollection,
-    StringSequence,
-)
+from pcs.common.types import StringCollection, StringSequence
 
 
 def show_resource_relations_cmd(

--- a/pcs/cli/routing/acl.py
+++ b/pcs/cli/routing/acl.py
@@ -1,7 +1,4 @@
-from pcs import (
-    acl,
-    usage,
-)
+from pcs import acl, usage
 from pcs.cli.common.errors import raise_command_replaced
 from pcs.cli.common.routing import create_router
 

--- a/pcs/cli/routing/alert.py
+++ b/pcs/cli/routing/alert.py
@@ -1,7 +1,4 @@
-from pcs import (
-    alert,
-    usage,
-)
+from pcs import alert, usage
 from pcs.cli.alert import command as alert_command
 from pcs.cli.common.errors import raise_command_replaced
 from pcs.cli.common.routing import create_router

--- a/pcs/cli/routing/booth.py
+++ b/pcs/cli/routing/booth.py
@@ -1,7 +1,4 @@
-from pcs import (
-    settings,
-    usage,
-)
+from pcs import settings, usage
 from pcs.cli.booth import command
 from pcs.cli.common.routing import create_router
 

--- a/pcs/cli/routing/cluster.py
+++ b/pcs/cli/routing/cluster.py
@@ -1,9 +1,5 @@
 import pcs.cli.cluster.command as cluster_command
-from pcs import (
-    cluster,
-    status,
-    usage,
-)
+from pcs import cluster, status, usage
 from pcs.cli.common.errors import raise_command_replaced
 from pcs.cli.common.routing import create_router
 

--- a/pcs/cli/routing/config.py
+++ b/pcs/cli/routing/config.py
@@ -1,7 +1,4 @@
-from pcs import (
-    config,
-    usage,
-)
+from pcs import config, usage
 from pcs.cli.common.routing import create_router
 
 config_cmd = create_router(

--- a/pcs/cli/routing/constraint.py
+++ b/pcs/cli/routing/constraint.py
@@ -1,19 +1,13 @@
 from typing import Any
 
 import pcs.cli.constraint_colocation.command as colocation_command
-from pcs import (
-    constraint,
-    usage,
-)
+from pcs import constraint, usage
 from pcs.cli.common.errors import (
     CmdLineInputError,
     raise_command_removed,
     raise_command_replaced,
 )
-from pcs.cli.common.parse_args import (
-    Argv,
-    InputModifiers,
-)
+from pcs.cli.common.parse_args import Argv, InputModifiers
 from pcs.cli.common.routing import create_router
 from pcs.cli.constraint import command as constraint_command
 from pcs.cli.constraint.location import command as location_command

--- a/pcs/cli/routing/host.py
+++ b/pcs/cli/routing/host.py
@@ -1,6 +1,4 @@
-from pcs import (
-    usage,
-)
+from pcs import usage
 from pcs.cli import host
 from pcs.cli.common.routing import create_router
 

--- a/pcs/cli/routing/node.py
+++ b/pcs/cli/routing/node.py
@@ -1,10 +1,7 @@
 from functools import partial
 from typing import Any
 
-from pcs import (
-    node,
-    usage,
-)
+from pcs import node, usage
 from pcs.cli.common.parse_args import Argv, InputModifiers
 from pcs.cli.common.routing import create_router
 from pcs.cli.node import command as node_command

--- a/pcs/cli/routing/pcsd.py
+++ b/pcs/cli/routing/pcsd.py
@@ -1,7 +1,4 @@
-from pcs import (
-    pcsd,
-    usage,
-)
+from pcs import pcsd, usage
 from pcs.cli.common.routing import create_router
 
 pcsd_cmd = create_router(

--- a/pcs/cli/routing/qdevice.py
+++ b/pcs/cli/routing/qdevice.py
@@ -1,7 +1,4 @@
-from pcs import (
-    qdevice,
-    usage,
-)
+from pcs import qdevice, usage
 from pcs.cli.common.routing import create_router
 
 qdevice_cmd = create_router(

--- a/pcs/cli/routing/quorum.py
+++ b/pcs/cli/routing/quorum.py
@@ -1,7 +1,4 @@
-from pcs import (
-    quorum,
-    usage,
-)
+from pcs import quorum, usage
 from pcs.cli.common.routing import create_router
 
 quorum_cmd = create_router(

--- a/pcs/cli/routing/resource.py
+++ b/pcs/cli/routing/resource.py
@@ -1,10 +1,7 @@
 from functools import partial
 
 import pcs.cli.resource.command as resource_cli
-from pcs import (
-    resource,
-    usage,
-)
+from pcs import resource, usage
 from pcs.cli.cib.element import command as cib_element_cmd
 from pcs.cli.common.routing import create_router
 from pcs.cli.resource.relations import show_resource_relations_cmd

--- a/pcs/cli/routing/resource_stonith_common.py
+++ b/pcs/cli/routing/resource_stonith_common.py
@@ -3,10 +3,7 @@ from typing import Any
 from pcs import resource
 from pcs.cli.common.errors import command_replaced
 from pcs.cli.common.parse_args import InputModifiers
-from pcs.cli.common.routing import (
-    CliCmdInterface,
-    create_router,
-)
+from pcs.cli.common.routing import CliCmdInterface, create_router
 
 
 def resource_defaults_cmd(parent_cmd: list[str]) -> CliCmdInterface:

--- a/pcs/cli/routing/status.py
+++ b/pcs/cli/routing/status.py
@@ -1,15 +1,9 @@
 from typing import Any
 
-from pcs import (
-    status,
-    usage,
-)
+from pcs import status, usage
 from pcs.cli.booth.command import status as booth_status_cmd
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.parse_args import (
-    Argv,
-    InputModifiers,
-)
+from pcs.cli.common.parse_args import Argv, InputModifiers
 from pcs.cli.common.routing import create_router
 from pcs.cli.query import resource
 from pcs.cli.status import command as status_command

--- a/pcs/cli/rule.py
+++ b/pcs/cli/rule.py
@@ -1,12 +1,6 @@
 from pcs.common.pacemaker.rule import CibRuleExpressionDto
-from pcs.common.str_tools import (
-    format_name_value_list,
-    indent,
-)
-from pcs.common.types import (
-    CibRuleExpressionType,
-    CibRuleInEffectStatus,
-)
+from pcs.common.str_tools import format_name_value_list, indent
+from pcs.common.types import CibRuleExpressionType, CibRuleInEffectStatus
 
 _in_effect_label_map = {
     CibRuleInEffectStatus.NOT_YET_IN_EFFECT: "not yet in effect",

--- a/pcs/cli/status/command.py
+++ b/pcs/cli/status/command.py
@@ -1,10 +1,7 @@
 from typing import Any
 
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.parse_args import (
-    Argv,
-    InputModifiers,
-)
+from pcs.cli.common.parse_args import Argv, InputModifiers
 
 
 def wait_for_pcmk_idle(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:

--- a/pcs/cli/stonith/command.py
+++ b/pcs/cli/stonith/command.py
@@ -1,11 +1,7 @@
 from typing import Any
 
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.output import (
-    format_cmd_list,
-    lines_to_str,
-    smart_wrap_text,
-)
+from pcs.cli.common.output import format_cmd_list, lines_to_str, smart_wrap_text
 from pcs.cli.common.parse_args import (
     OUTPUT_FORMAT_VALUE_CMD,
     OUTPUT_FORMAT_VALUE_JSON,

--- a/pcs/cli/stonith/levels/command.py
+++ b/pcs/cli/stonith/levels/command.py
@@ -2,10 +2,7 @@ import json
 from typing import Any
 
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.output import (
-    format_cmd_list,
-    lines_to_str,
-)
+from pcs.cli.common.output import format_cmd_list, lines_to_str
 from pcs.cli.common.parse_args import (
     OUTPUT_FORMAT_VALUE_CMD,
     OUTPUT_FORMAT_VALUE_JSON,

--- a/pcs/cli/stonith/levels/output.py
+++ b/pcs/cli/stonith/levels/output.py
@@ -7,10 +7,7 @@ from pcs.common.pacemaker.fencing_topology import (
     CibFencingTopologyDto,
 )
 from pcs.common.str_tools import indent
-from pcs.common.types import (
-    StringCollection,
-    StringSequence,
-)
+from pcs.common.types import StringCollection, StringSequence
 
 
 def _get_targets_with_levels_str(

--- a/pcs/cli/tag/command.py
+++ b/pcs/cli/tag/command.py
@@ -1,11 +1,7 @@
 from typing import Any
 
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.parse_args import (
-    Argv,
-    InputModifiers,
-    group_by_keywords,
-)
+from pcs.cli.common.parse_args import Argv, InputModifiers, group_by_keywords
 from pcs.cli.tag.output import print_config
 
 

--- a/pcs/common/async_tasks/dto.py
+++ b/pcs/common/async_tasks/dto.py
@@ -4,11 +4,7 @@ from typing import Any
 from pcs.common.interface.dto import DataTransferObject
 from pcs.common.reports.dto import ReportItemDto
 
-from .types import (
-    TaskFinishType,
-    TaskKillReason,
-    TaskState,
-)
+from .types import TaskFinishType, TaskKillReason, TaskState
 
 
 @dataclass(frozen=True)

--- a/pcs/common/communication/__init__.py
+++ b/pcs/common/communication/__init__.py
@@ -1,5 +1,1 @@
-from . import (
-    const,
-    dto,
-    types,
-)
+from . import const, dto, types

--- a/pcs/common/corosync_conf.py
+++ b/pcs/common/corosync_conf.py
@@ -2,10 +2,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 from pcs.common.interface.dto import DataTransferObject
-from pcs.common.types import (
-    CorosyncNodeAddressType,
-    CorosyncTransportType,
-)
+from pcs.common.types import CorosyncNodeAddressType, CorosyncTransportType
 
 
 @dataclass(frozen=True)

--- a/pcs/common/node_communicator.py
+++ b/pcs/common/node_communicator.py
@@ -2,10 +2,7 @@ import base64
 import io
 import re
 from collections.abc import Generator, Iterable, Mapping, Sequence
-from dataclasses import (
-    dataclass,
-    field,
-)
+from dataclasses import dataclass, field
 from urllib.parse import urlencode
 
 # We should ignore SIGPIPE when using pycurl.NOSIGNAL - see the libcurl tutorial
@@ -19,10 +16,7 @@ except ImportError:
 
 from pcs import settings
 from pcs.common import pcs_pycurl as pycurl
-from pcs.common.host import (
-    Destination,
-    PcsKnownHost,
-)
+from pcs.common.host import Destination, PcsKnownHost
 from pcs.common.types import StringIterable
 
 

--- a/pcs/common/pacemaker/__init__.py
+++ b/pcs/common/pacemaker/__init__.py
@@ -1,6 +1,1 @@
-from . import (
-    nvset,
-    resource,
-    role,
-    rule,
-)
+from . import nvset, resource, role, rule

--- a/pcs/common/pacemaker/constraint/all.py
+++ b/pcs/common/pacemaker/constraint/all.py
@@ -7,18 +7,9 @@ from .colocation import (
     CibConstraintColocationDto,
     CibConstraintColocationSetDto,
 )
-from .location import (
-    CibConstraintLocationDto,
-    CibConstraintLocationSetDto,
-)
-from .order import (
-    CibConstraintOrderDto,
-    CibConstraintOrderSetDto,
-)
-from .ticket import (
-    CibConstraintTicketDto,
-    CibConstraintTicketSetDto,
-)
+from .location import CibConstraintLocationDto, CibConstraintLocationSetDto
+from .order import CibConstraintOrderDto, CibConstraintOrderSetDto
+from .ticket import CibConstraintTicketDto, CibConstraintTicketSetDto
 
 
 @dataclass(frozen=True)

--- a/pcs/common/pacemaker/resource/operations.py
+++ b/pcs/common/pacemaker/resource/operations.py
@@ -1,10 +1,7 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-from pcs.common.const import (
-    PcmkOnFailAction,
-    PcmkRoleType,
-)
+from pcs.common.const import PcmkOnFailAction, PcmkRoleType
 from pcs.common.interface.dto import DataTransferObject
 from pcs.common.pacemaker.nvset import CibNvsetDto
 

--- a/pcs/common/pacemaker/rule.py
+++ b/pcs/common/pacemaker/rule.py
@@ -2,10 +2,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 from pcs.common.interface.dto import DataTransferObject
-from pcs.common.types import (
-    CibRuleExpressionType,
-    CibRuleInEffectStatus,
-)
+from pcs.common.types import CibRuleExpressionType, CibRuleInEffectStatus
 
 
 @dataclass(frozen=True)

--- a/pcs/common/reports/__init__.py
+++ b/pcs/common/reports/__init__.py
@@ -1,10 +1,4 @@
-from . import (
-    codes,
-    const,
-    item,
-    messages,
-    types,
-)
+from . import codes, const, item, messages, types
 from .conversions import report_dto_to_item
 from .dto import ReportItemDto
 from .item import (
@@ -16,7 +10,4 @@ from .item import (
     get_severity,
     get_severity_from_flags,
 )
-from .processor import (
-    ReportProcessor,
-    has_errors,
-)
+from .processor import ReportProcessor, has_errors

--- a/pcs/common/reports/conversions.py
+++ b/pcs/common/reports/conversions.py
@@ -1,15 +1,8 @@
 from pcs.common.tools import get_all_subclasses
 
 from . import messages
-from .dto import (
-    ReportItemDto,
-    ReportItemMessageDto,
-)
-from .item import (
-    ReportItem,
-    ReportItemContext,
-    ReportItemSeverity,
-)
+from .dto import ReportItemDto, ReportItemMessageDto
+from .item import ReportItem, ReportItemContext, ReportItemSeverity
 
 
 def report_dto_to_item(

--- a/pcs/common/reports/dto.py
+++ b/pcs/common/reports/dto.py
@@ -4,11 +4,7 @@ from typing import Any
 
 from pcs.common.interface.dto import DataTransferObject
 
-from .types import (
-    ForceCode,
-    MessageCode,
-    SeverityLevel,
-)
+from .types import ForceCode, MessageCode, SeverityLevel
 
 
 @dataclass(frozen=True)

--- a/pcs/common/reports/item.py
+++ b/pcs/common/reports/item.py
@@ -1,10 +1,7 @@
 from dataclasses import dataclass
 from typing import Any
 
-from pcs.common.interface.dto import (
-    ImplementsFromDto,
-    ImplementsToDto,
-)
+from pcs.common.interface.dto import ImplementsFromDto, ImplementsToDto
 
 from .dto import (
     ReportItemContextDto,
@@ -12,12 +9,7 @@ from .dto import (
     ReportItemMessageDto,
     ReportItemSeverityDto,
 )
-from .types import (
-    ForceCode,
-    ForceFlags,
-    MessageCode,
-    SeverityLevel,
-)
+from .types import ForceCode, ForceFlags, MessageCode, SeverityLevel
 
 
 @dataclass(frozen=True)

--- a/pcs/common/reports/processor.py
+++ b/pcs/common/reports/processor.py
@@ -3,11 +3,7 @@ from logging import Logger
 
 from pcs.common.reports.utils import add_context_to_message
 
-from .item import (
-    ReportItem,
-    ReportItemList,
-    ReportItemSeverity,
-)
+from .item import ReportItem, ReportItemList, ReportItemSeverity
 
 
 class ReportProcessor(abc.ABC):

--- a/pcs/common/resource_agent/__init__.py
+++ b/pcs/common/resource_agent/__init__.py
@@ -1,4 +1,1 @@
-from . import (
-    const,
-    dto,
-)
+from . import const, dto

--- a/pcs/common/services/__init__.py
+++ b/pcs/common/services/__init__.py
@@ -1,6 +1,1 @@
-from . import (
-    drivers,
-    errors,
-    interfaces,
-    types,
-)
+from . import drivers, errors, interfaces, types

--- a/pcs/common/services/drivers/systemd.py
+++ b/pcs/common/services/drivers/systemd.py
@@ -4,10 +4,7 @@ import re
 from pcs.common.types import StringIterable
 
 from .. import errors
-from ..interfaces import (
-    ExecutorInterface,
-    ServiceManagerInterface,
-)
+from ..interfaces import ExecutorInterface, ServiceManagerInterface
 
 
 class SystemdDriver(ServiceManagerInterface):

--- a/pcs/common/services/drivers/sysvinit_rhel.py
+++ b/pcs/common/services/drivers/sysvinit_rhel.py
@@ -1,10 +1,7 @@
 import os.path
 
 from .. import errors
-from ..interfaces import (
-    ExecutorInterface,
-    ServiceManagerInterface,
-)
+from ..interfaces import ExecutorInterface, ServiceManagerInterface
 
 
 class SysVInitRhelDriver(ServiceManagerInterface):

--- a/pcs/common/ssl.py
+++ b/pcs/common/ssl.py
@@ -3,10 +3,7 @@ import ssl
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import (
-    hashes,
-    serialization,
-)
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 

--- a/pcs/common/status_dto.py
+++ b/pcs/common/status_dto.py
@@ -1,10 +1,7 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-from pcs.common.const import (
-    PcmkRoleType,
-    PcmkStatusRoleType,
-)
+from pcs.common.const import PcmkRoleType, PcmkStatusRoleType
 from pcs.common.interface.dto import DataTransferObject
 
 

--- a/pcs/common/str_tools.py
+++ b/pcs/common/str_tools.py
@@ -3,10 +3,7 @@ from collections.abc import Iterable as IterableAbc
 from collections.abc import Mapping, Sequence, Sized
 from typing import Any, TypeVar
 
-from pcs.common.types import (
-    StringIterable,
-    StringSequence,
-)
+from pcs.common.types import StringIterable, StringSequence
 
 
 def indent(line_list: StringIterable, indent_step: int = 2) -> list[str]:

--- a/pcs/config.py
+++ b/pcs/config.py
@@ -15,14 +15,7 @@ from io import BytesIO
 from typing import cast
 from xml.dom.minidom import parse
 
-from pcs import (
-    cluster,
-    quorum,
-    settings,
-    status,
-    usage,
-    utils,
-)
+from pcs import cluster, quorum, settings, status, usage, utils
 from pcs.cli.alert.output import config_dto_to_lines as alerts_to_lines
 from pcs.cli.cluster_property.output import (
     PropertyConfigurationFacade,
@@ -30,17 +23,11 @@ from pcs.cli.cluster_property.output import (
 )
 from pcs.cli.common import middleware
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.output import (
-    INDENT_STEP,
-    smart_wrap_text,
-)
+from pcs.cli.common.output import INDENT_STEP, smart_wrap_text
 from pcs.cli.constraint.output import constraints_to_text
 from pcs.cli.nvset import nvset_dto_list_to_lines
 from pcs.cli.reports import process_library_reports
-from pcs.cli.reports.output import (
-    print_to_stderr,
-    warn,
-)
+from pcs.cli.reports.output import print_to_stderr, warn
 from pcs.cli.resource.output import (
     ResourcesConfigurationFacade,
     resources_to_text,

--- a/pcs/constraint.py
+++ b/pcs/constraint.py
@@ -8,14 +8,8 @@ from xml.dom.minidom import parseString
 import pcs.cli.constraint_order.command as order_command
 from pcs import utils
 from pcs.cli.common import parse_args
-from pcs.cli.common.errors import (
-    CmdLineInputError,
-    raise_command_replaced,
-)
-from pcs.cli.common.output import (
-    INDENT_STEP,
-    lines_to_str,
-)
+from pcs.cli.common.errors import CmdLineInputError, raise_command_replaced
+from pcs.cli.common.output import INDENT_STEP, lines_to_str
 from pcs.cli.constraint.location.command import (
     RESOURCE_TYPE_REGEXP,
     RESOURCE_TYPE_RESOURCE,
@@ -27,16 +21,8 @@ from pcs.cli.constraint.output import (
     print_config,
 )
 from pcs.cli.reports import process_library_reports
-from pcs.cli.reports.output import (
-    deprecation_warning,
-    print_to_stderr,
-    warn,
-)
-from pcs.common import (
-    const,
-    pacemaker,
-    reports,
-)
+from pcs.cli.reports.output import deprecation_warning, print_to_stderr, warn
+from pcs.common import const, pacemaker, reports
 from pcs.common.pacemaker.constraint import (
     CibConstraintColocationSetDto,
     CibConstraintLocationSetDto,
@@ -48,22 +34,11 @@ from pcs.common.pacemaker.constraint import (
 from pcs.common.pacemaker.resource.list import CibResourcesDto
 from pcs.common.pacemaker.types import CibResourceDiscovery
 from pcs.common.reports import ReportItem
-from pcs.common.str_tools import (
-    format_list,
-    indent,
-)
-from pcs.common.types import (
-    StringCollection,
-    StringIterable,
-    StringSequence,
-)
+from pcs.common.str_tools import format_list, indent
+from pcs.common.types import StringCollection, StringIterable, StringSequence
 from pcs.lib.cib.constraint.order import ATTRIB as order_attrib
 from pcs.lib.node import get_existing_nodes_names
-from pcs.lib.pacemaker.values import (
-    SCORE_INFINITY,
-    is_true,
-    sanitize_id,
-)
+from pcs.lib.pacemaker.values import SCORE_INFINITY, is_true, sanitize_id
 
 DEFAULT_ACTION = const.PCMK_ACTION_START
 DEFAULT_ROLE = const.PCMK_ROLE_STARTED

--- a/pcs/daemon/async_tasks/scheduler.py
+++ b/pcs/daemon/async_tasks/scheduler.py
@@ -14,16 +14,8 @@ from pcs.daemon.async_tasks.types import Command
 from pcs.daemon.log import pcsd as pcsd_logger
 from pcs.lib.auth.types import AuthUser
 
-from .task import (
-    Task,
-    TaskConfig,
-    TaskState,
-    UnknownMessageError,
-)
-from .worker.executor import (
-    task_executor,
-    worker_init,
-)
+from .task import Task, TaskConfig, TaskState, UnknownMessageError
+from .worker.executor import task_executor, worker_init
 from .worker.types import Message
 
 

--- a/pcs/daemon/async_tasks/task.py
+++ b/pcs/daemon/async_tasks/task.py
@@ -18,12 +18,7 @@ from pcs.common.reports.dto import ReportItemDto
 from pcs.lib.auth.types import AuthUser
 
 from .types import Command
-from .worker.types import (
-    Message,
-    TaskExecuted,
-    TaskFinished,
-    WorkerCommand,
-)
+from .worker.types import Message, TaskExecuted, TaskFinished, WorkerCommand
 
 
 class UnknownMessageError(Exception):

--- a/pcs/daemon/env.py
+++ b/pcs/daemon/env.py
@@ -5,10 +5,7 @@ from collections import namedtuple
 from functools import lru_cache
 
 from pcs import settings
-from pcs.common.validate import (
-    is_integer,
-    is_port_number,
-)
+from pcs.common.validate import is_integer, is_port_number
 
 try:
     from pcs.daemon.app import webui

--- a/pcs/daemon/http_server.py
+++ b/pcs/daemon/http_server.py
@@ -1,10 +1,7 @@
 import shutil
 
 from tornado.httpserver import HTTPServer
-from tornado.netutil import (
-    bind_sockets,
-    bind_unix_socket,
-)
+from tornado.netutil import bind_sockets, bind_unix_socket
 
 from pcs.daemon import log
 from pcs.daemon.ssl import PcsdSSL

--- a/pcs/daemon/ruby_pcsd.py
+++ b/pcs/daemon/ruby_pcsd.py
@@ -1,23 +1,13 @@
 import json
 import logging
-from base64 import (
-    b64decode,
-    b64encode,
-    binascii,
-)
+from base64 import b64decode, b64encode, binascii
 from collections import namedtuple
 
 import pycurl
 from tornado.curl_httpclient import CurlError
 from tornado.gen import convert_yielded
-from tornado.httpclient import (
-    AsyncHTTPClient,
-    HTTPClientError,
-)
-from tornado.httputil import (
-    HTTPHeaders,
-    HTTPServerRequest,
-)
+from tornado.httpclient import AsyncHTTPClient, HTTPClientError
+from tornado.httputil import HTTPHeaders, HTTPServerRequest
 from tornado.web import HTTPError
 
 from pcs.daemon import log

--- a/pcs/lib/auth/config/__init__.py
+++ b/pcs/lib/auth/config/__init__.py
@@ -1,6 +1,1 @@
-from . import (
-    exporter,
-    facade,
-    parser,
-    types,
-)
+from . import exporter, facade, parser, types

--- a/pcs/lib/auth/config/facade.py
+++ b/pcs/lib/auth/config/facade.py
@@ -5,10 +5,7 @@ from typing import cast
 from pcs.common.tools import get_unique_uuid
 from pcs.lib.interface.config import FacadeInterface
 
-from .types import (
-    TOKEN_ENTRY_DATETIME_FORMAT,
-    TokenEntry,
-)
+from .types import TOKEN_ENTRY_DATETIME_FORMAT, TokenEntry
 
 
 class Facade(FacadeInterface):

--- a/pcs/lib/auth/config/parser.py
+++ b/pcs/lib/auth/config/parser.py
@@ -3,10 +3,7 @@ import dacite
 from pcs.common import file_type_codes as code
 from pcs.common import reports
 from pcs.lib.file.json import JsonParser
-from pcs.lib.interface.config import (
-    ParserErrorException,
-    ParserInterface,
-)
+from pcs.lib.interface.config import ParserErrorException, ParserInterface
 
 from .types import TokenEntry
 

--- a/pcs/lib/auth/provider.py
+++ b/pcs/lib/auth/provider.py
@@ -12,10 +12,7 @@ from . import const
 from .config.facade import Facade
 from .config.parser import ParserError
 from .pam import authenticate_user
-from .tools import (
-    UserGroupsError,
-    get_user_groups,
-)
+from .tools import UserGroupsError, get_user_groups
 from .types import AuthUser
 
 

--- a/pcs/lib/auth/tools.py
+++ b/pcs/lib/auth/tools.py
@@ -2,10 +2,7 @@ import grp
 import pwd
 from typing import TYPE_CHECKING
 
-from .types import (
-    AuthUser,
-    DesiredUser,
-)
+from .types import AuthUser, DesiredUser
 
 if TYPE_CHECKING:
     from pcs.common.tools import StringCollection

--- a/pcs/lib/booth/config_files.py
+++ b/pcs/lib/booth/config_files.py
@@ -1,10 +1,7 @@
 import os
 
 from pcs import settings
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
+from pcs.common import file_type_codes, reports
 from pcs.common.reports.item import ReportItem
 from pcs.lib.file.instance import FileInstance
 

--- a/pcs/lib/booth/config_parser.py
+++ b/pcs/lib/booth/config_parser.py
@@ -2,10 +2,7 @@ import re
 from collections import namedtuple
 
 from pcs.common import reports
-from pcs.common.reports import (
-    ReportItem,
-    get_severity,
-)
+from pcs.common.reports import ReportItem, get_severity
 from pcs.lib.booth import constants
 from pcs.lib.interface.config import (
     ExporterInterface,

--- a/pcs/lib/booth/env.py
+++ b/pcs/lib/booth/env.py
@@ -1,12 +1,6 @@
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
+from pcs.common import file_type_codes, reports
 from pcs.common.reports.item import ReportItem
-from pcs.lib.booth import (
-    config_validators,
-    constants,
-)
+from pcs.lib.booth import config_validators, constants
 from pcs.lib.errors import LibraryError
 from pcs.lib.file import raw_file
 from pcs.lib.file.instance import FileInstance

--- a/pcs/lib/cib/constraint/colocation.py
+++ b/pcs/lib/cib/constraint/colocation.py
@@ -17,15 +17,9 @@ from pcs.lib.cib.constraint.resource_set import (
 )
 from pcs.lib.cib.rule import RuleInEffectEval
 from pcs.lib.cib.rule.cib_to_dto import rule_element_to_dto
-from pcs.lib.cib.tools import (
-    check_new_id_applicable,
-    role_constructor,
-)
+from pcs.lib.cib.tools import check_new_id_applicable, role_constructor
 from pcs.lib.errors import LibraryError
-from pcs.lib.pacemaker.values import (
-    SCORE_INFINITY,
-    is_score,
-)
+from pcs.lib.pacemaker.values import SCORE_INFINITY, is_score
 from pcs.lib.tools import get_optional_value
 
 _DESCRIPTION = "constraint id"

--- a/pcs/lib/cib/constraint/constraint.py
+++ b/pcs/lib/cib/constraint/constraint.py
@@ -1,18 +1,11 @@
 from collections.abc import Callable
 from typing import cast
 
-from lxml.etree import (
-    SubElement,
-    _Element,
-)
+from lxml.etree import SubElement, _Element
 
 from pcs.common import reports
 from pcs.lib.cib.constraint import resource_set
-from pcs.lib.cib.tools import (
-    ElementNotFound,
-    find_unique_id,
-    get_element_by_id,
-)
+from pcs.lib.cib.tools import ElementNotFound, find_unique_id, get_element_by_id
 from pcs.lib.errors import LibraryError
 from pcs.lib.xml_tools import get_root
 

--- a/pcs/lib/cib/constraint/location.py
+++ b/pcs/lib/cib/constraint/location.py
@@ -3,10 +3,7 @@ from collections.abc import Mapping
 from lxml import etree
 from lxml.etree import _Element
 
-from pcs.common import (
-    const,
-    reports,
-)
+from pcs.common import const, reports
 from pcs.common.pacemaker.constraint import (
     CibConstraintLocationAttributesDto,
     CibConstraintLocationDto,
@@ -20,11 +17,7 @@ from pcs.lib import validate
 from pcs.lib.cib import rule
 from pcs.lib.cib.const import TAG_CONSTRAINT_LOCATION as TAG
 from pcs.lib.cib.const import TAG_RULE
-from pcs.lib.cib.tools import (
-    IdProvider,
-    Version,
-    role_constructor,
-)
+from pcs.lib.cib.tools import IdProvider, Version, role_constructor
 from pcs.lib.pacemaker.values import sanitize_id
 from pcs.lib.tools import get_optional_value
 

--- a/pcs/lib/cib/fencing_topology.py
+++ b/pcs/lib/cib/fencing_topology.py
@@ -2,10 +2,7 @@ from collections.abc import Sequence
 from typing import Any, Final, TypeVar, cast
 
 from lxml import etree
-from lxml.etree import (
-    _Attrib,
-    _Element,
-)
+from lxml.etree import _Attrib, _Element
 
 from pcs.common import reports
 from pcs.common.fencing_topology import (
@@ -44,10 +41,7 @@ from pcs.lib.cib.tools import (
 )
 from pcs.lib.errors import LibraryError
 from pcs.lib.pacemaker.state import _Element as StateElement
-from pcs.lib.pacemaker.values import (
-    sanitize_id,
-    validate_id,
-)
+from pcs.lib.pacemaker.values import sanitize_id, validate_id
 
 _DEVICES_ATTRIBUTE: Final = "devices"
 

--- a/pcs/lib/cib/node.py
+++ b/pcs/lib/cib/node.py
@@ -11,10 +11,7 @@ from pcs.lib.cib.const import TAG_NODE
 from pcs.lib.cib.nvpair import update_nvset
 from pcs.lib.cib.tools import get_nodes
 from pcs.lib.errors import LibraryError
-from pcs.lib.xml_tools import (
-    append_when_useful,
-    get_root,
-)
+from pcs.lib.xml_tools import append_when_useful, get_root
 
 
 def get_all_node_elements(nodes_section: _Element) -> list[_Element]:

--- a/pcs/lib/cib/nvpair_multi.py
+++ b/pcs/lib/cib/nvpair_multi.py
@@ -6,10 +6,7 @@ from lxml.etree import _Element
 
 from pcs.common import reports
 from pcs.common.const import INFINITY
-from pcs.common.pacemaker.nvset import (
-    CibNvpairDto,
-    CibNvsetDto,
-)
+from pcs.common.pacemaker.nvset import CibNvpairDto, CibNvsetDto
 from pcs.common.reports import ReportItemList
 from pcs.common.types import StringIterable
 from pcs.lib import validate
@@ -28,10 +25,7 @@ from pcs.lib.cib.tools import (
     Version,
     create_subelement_id,
 )
-from pcs.lib.xml_tools import (
-    export_attributes,
-    remove_one_element,
-)
+from pcs.lib.xml_tools import export_attributes, remove_one_element
 
 NvsetTag = NewType("NvsetTag", str)
 NVSET_INSTANCE = NvsetTag("instance_attributes")

--- a/pcs/lib/cib/remove_elements.py
+++ b/pcs/lib/cib/remove_elements.py
@@ -13,15 +13,9 @@ from pcs.common.resource_status import (
     ResourcesStatusFacade,
     ResourceState,
 )
-from pcs.common.types import (
-    StringCollection,
-    StringSequence,
-)
+from pcs.common.types import StringCollection, StringSequence
 from pcs.lib.cib import const
-from pcs.lib.cib.constraint.common import (
-    is_constraint,
-    is_set_constraint,
-)
+from pcs.lib.cib.constraint.common import is_constraint, is_set_constraint
 from pcs.lib.cib.constraint.location import (
     is_location_constraint,
     is_location_rule,

--- a/pcs/lib/cib/resource/agent.py
+++ b/pcs/lib/cib/resource/agent.py
@@ -3,22 +3,13 @@ from typing import Any
 
 from pcs.common.const import PcmkRoleType
 from pcs.common.interface.dto import to_dict
-from pcs.common.pacemaker.nvset import (
-    CibNvpairDto,
-    CibNvsetDto,
-)
+from pcs.common.pacemaker.nvset import CibNvpairDto, CibNvsetDto
 from pcs.common.pacemaker.resource.operations import (
     OCF_CHECK_LEVEL_INSTANCE_ATTRIBUTE_NAME,
     CibResourceOperationDto,
 )
-from pcs.lib.cib.resource.types import (
-    ResourceOperationIn,
-    ResourceOperationOut,
-)
-from pcs.lib.resource_agent import (
-    ResourceAgentAction,
-    ResourceAgentMetadata,
-)
+from pcs.lib.cib.resource.types import ResourceOperationIn, ResourceOperationOut
+from pcs.lib.resource_agent import ResourceAgentAction, ResourceAgentMetadata
 
 # Operation monitor is always required, even if creating default actions was
 # not requested or a resource/stonith agent does not specify it. See

--- a/pcs/lib/cib/resource/clone.py
+++ b/pcs/lib/cib/resource/clone.py
@@ -15,18 +15,12 @@ from typing import cast
 from lxml import etree
 from lxml.etree import _Element
 
-from pcs.common import (
-    const,
-)
+from pcs.common import const
 from pcs.common.pacemaker import nvset
 from pcs.common.pacemaker.resource.clone import CibResourceCloneDto
 from pcs.common.reports import ReportItemList
 from pcs.common.tools import Version
-from pcs.lib.cib import (
-    nvpair,
-    nvpair_multi,
-    rule,
-)
+from pcs.lib.cib import nvpair, nvpair_multi, rule
 from pcs.lib.cib.const import TAG_RESOURCE_CLONE as TAG_CLONE
 from pcs.lib.cib.const import TAG_RESOURCE_MASTER as TAG_MASTER
 from pcs.lib.cib.nvpair_multi import (
@@ -37,10 +31,7 @@ from pcs.lib.cib.nvpair_multi import (
 )
 from pcs.lib.cib.resource.operations import get_resource_operations
 from pcs.lib.cib.tools import IdProvider
-from pcs.lib.pacemaker.values import (
-    is_true,
-    validate_id,
-)
+from pcs.lib.pacemaker.values import is_true, validate_id
 
 ALL_TAGS = [TAG_CLONE, TAG_MASTER]
 

--- a/pcs/lib/cib/resource/common.py
+++ b/pcs/lib/cib/resource/common.py
@@ -6,17 +6,12 @@ from pcs.common.reports.item import ReportItemList
 from pcs.common.types import StringCollection
 from pcs.lib.cib import nvpair
 from pcs.lib.cib.const import TAG_LIST_RESOURCE
-from pcs.lib.cib.tools import (
-    ElementSearcher,
-    IdProvider,
-)
+from pcs.lib.cib.tools import ElementSearcher, IdProvider
 from pcs.lib.xml_tools import find_parent
 
 from .bundle import get_inner_resource as get_bundle_inner_resource
 from .bundle import is_bundle
-from .clone import (
-    get_inner_primitives as get_clone_inner_primitive_resources,
-)
+from .clone import get_inner_primitives as get_clone_inner_primitive_resources
 from .clone import get_inner_resource as get_clone_inner_resource
 from .clone import is_any_clone
 from .group import get_inner_resources as get_group_inner_resources

--- a/pcs/lib/cib/resource/group.py
+++ b/pcs/lib/cib/resource/group.py
@@ -1,15 +1,9 @@
 from typing import cast
 
-from lxml.etree import (
-    SubElement,
-    _Element,
-)
+from lxml.etree import SubElement, _Element
 
 from pcs.common.pacemaker.resource.group import CibResourceGroupDto
-from pcs.lib.cib import (
-    nvpair_multi,
-    rule,
-)
+from pcs.lib.cib import nvpair_multi, rule
 from pcs.lib.cib.const import TAG_RESOURCE_GROUP as TAG
 
 

--- a/pcs/lib/cib/resource/guest_node.py
+++ b/pcs/lib/cib/resource/guest_node.py
@@ -4,10 +4,7 @@ from typing import cast
 from lxml.etree import _Element
 
 from pcs.common import reports
-from pcs.common.reports.item import (
-    ReportItem,
-    ReportItemList,
-)
+from pcs.common.reports.item import ReportItem, ReportItemList
 from pcs.common.types import StringCollection
 from pcs.lib import validate
 from pcs.lib.cib.node import PacemakerNode

--- a/pcs/lib/cib/resource/hierarchy.py
+++ b/pcs/lib/cib/resource/hierarchy.py
@@ -2,10 +2,7 @@ from collections.abc import Iterable
 
 from lxml.etree import _Element
 
-from . import (
-    clone,
-    group,
-)
+from . import clone, group
 
 
 def move_resources_to_group(

--- a/pcs/lib/cib/resource/stonith.py
+++ b/pcs/lib/cib/resource/stonith.py
@@ -5,10 +5,7 @@ from typing import cast
 from lxml.etree import _Element
 
 from pcs.common import reports
-from pcs.common.reports import (
-    ReportItem,
-    ReportItemList,
-)
+from pcs.common.reports import ReportItem, ReportItemList
 from pcs.common.tools import timeout_to_seconds
 from pcs.common.types import StringIterable
 from pcs.lib.cib.const import TAG_RESOURCE_PRIMITIVE
@@ -24,10 +21,7 @@ from pcs.lib.pacemaker.live import get_resource_digests
 from pcs.lib.pacemaker.state import get_resource_state
 from pcs.lib.xml_tools import get_root
 
-from . import (
-    common,
-    operations,
-)
+from . import common, operations
 
 
 def is_stonith(resource_el: _Element) -> bool:

--- a/pcs/lib/cib/resource/validations.py
+++ b/pcs/lib/cib/resource/validations.py
@@ -6,10 +6,7 @@ from pcs.common import reports
 from pcs.lib.validate import validate_add_remove_items
 
 from . import group
-from .bundle import (
-    get_parent_bundle,
-    is_bundle,
-)
+from .bundle import get_parent_bundle, is_bundle
 from .clone import (
     get_parent_any_clone,
     is_any_clone,

--- a/pcs/lib/cib/rule/cib_to_dto.py
+++ b/pcs/lib/cib/rule/cib_to_dto.py
@@ -2,14 +2,8 @@ from typing import cast
 
 from lxml.etree import _Element
 
-from pcs.common.pacemaker.rule import (
-    CibRuleDateCommonDto,
-    CibRuleExpressionDto,
-)
-from pcs.common.types import (
-    CibRuleExpressionType,
-    CibRuleInEffectStatus,
-)
+from pcs.common.pacemaker.rule import CibRuleDateCommonDto, CibRuleExpressionDto
+from pcs.common.types import CibRuleExpressionType, CibRuleInEffectStatus
 from pcs.lib.xml_tools import export_attributes
 
 from .cib_to_str import RuleToStr

--- a/pcs/lib/cib/rule/cib_to_str.py
+++ b/pcs/lib/cib/rule/cib_to_str.py
@@ -3,10 +3,7 @@ from typing import cast
 
 from lxml.etree import _Element
 
-from pcs.common.str_tools import (
-    format_name_value_list,
-    quote,
-)
+from pcs.common.str_tools import format_name_value_list, quote
 from pcs.lib.xml_tools import export_attributes
 
 

--- a/pcs/lib/cib/rule/parsed_to_cib.py
+++ b/pcs/lib/cib/rule/parsed_to_cib.py
@@ -2,10 +2,7 @@ from lxml import etree
 from lxml.etree import _Element
 
 from pcs.common.tools import Version
-from pcs.lib.cib.tools import (
-    IdProvider,
-    create_subelement_id,
-)
+from pcs.lib.cib.tools import IdProvider, create_subelement_id
 
 from .expression_part import (
     DATE_OP_GT,

--- a/pcs/lib/cib/rule/validator.py
+++ b/pcs/lib/cib/rule/validator.py
@@ -1,8 +1,5 @@
 import dataclasses
-from collections import (
-    Counter,
-    OrderedDict,
-)
+from collections import Counter, OrderedDict
 
 from dateutil import parser as dateutil_parser
 

--- a/pcs/lib/cib/tag.py
+++ b/pcs/lib/cib/tag.py
@@ -1,7 +1,4 @@
-from collections import (
-    Counter,
-    OrderedDict,
-)
+from collections import Counter, OrderedDict
 from collections.abc import Iterable
 from typing import cast
 
@@ -10,15 +7,8 @@ from lxml.etree import _Element
 
 from pcs.common import reports
 from pcs.common.pacemaker.tag import CibTagDto
-from pcs.common.reports import (
-    ReportItem,
-    ReportItemList,
-)
-from pcs.common.types import (
-    StringCollection,
-    StringIterable,
-    StringSequence,
-)
+from pcs.common.reports import ReportItem, ReportItemList
+from pcs.common.types import StringCollection, StringIterable, StringSequence
 from pcs.lib.cib.resource.common import find_resources
 from pcs.lib.cib.tools import (
     ElementSearcher,
@@ -26,16 +16,9 @@ from pcs.lib.cib.tools import (
     get_configuration_elements_by_id,
 )
 from pcs.lib.pacemaker.values import validate_id
-from pcs.lib.xml_tools import (
-    find_parent,
-    move_elements,
-    remove_one_element,
-)
+from pcs.lib.xml_tools import find_parent, move_elements, remove_one_element
 
-from .const import (
-    TAG_OBJREF,
-    TAG_TAG,
-)
+from .const import TAG_OBJREF, TAG_TAG
 
 
 def is_tag(element: _Element) -> bool:

--- a/pcs/lib/cib/tools.py
+++ b/pcs/lib/cib/tools.py
@@ -2,34 +2,18 @@ import contextlib
 import re
 from typing import cast
 
-from lxml.etree import (
-    _Element,
-    _ElementTree,
-)
+from lxml.etree import _Element, _ElementTree
 
-from pcs.common import (
-    const,
-    reports,
-)
+from pcs.common import const, reports
 from pcs.common.pacemaker import role
 from pcs.common.reports import codes as report_codes
-from pcs.common.reports.item import (
-    ReportItem,
-    ReportItemList,
-)
+from pcs.common.reports.item import ReportItem, ReportItemList
 from pcs.common.tools import Version
 from pcs.common.types import StringCollection, StringIterable
 from pcs.lib.cib import sections
 from pcs.lib.errors import LibraryError
-from pcs.lib.pacemaker.values import (
-    sanitize_id,
-    validate_id,
-)
-from pcs.lib.xml_tools import (
-    get_root,
-    get_sub_element,
-    remove_one_element,
-)
+from pcs.lib.pacemaker.values import sanitize_id, validate_id
+from pcs.lib.xml_tools import get_root, get_sub_element, remove_one_element
 
 _VERSION_FORMAT = r"(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<rev>\d+))?$"
 _ELEMENTS_WITH_IDREF_WITHOUT_ID_XPATH = """

--- a/pcs/lib/commands/acl.py
+++ b/pcs/lib/commands/acl.py
@@ -2,10 +2,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from pcs.lib.cib import acl
-from pcs.lib.cib.tools import (
-    IdProvider,
-    get_acls,
-)
+from pcs.lib.cib.tools import IdProvider, get_acls
 from pcs.lib.env import LibraryEnvironment
 from pcs.lib.errors import LibraryError
 

--- a/pcs/lib/commands/alert.py
+++ b/pcs/lib/commands/alert.py
@@ -9,10 +9,7 @@ from pcs.lib.cib.nvpair import (
     arrange_first_meta_attributes,
 )
 from pcs.lib.cib.rule.in_effect import get_rule_evaluator
-from pcs.lib.cib.tools import (
-    IdProvider,
-    get_alerts,
-)
+from pcs.lib.cib.tools import IdProvider, get_alerts
 from pcs.lib.env import LibraryEnvironment
 from pcs.lib.errors import LibraryError
 

--- a/pcs/lib/commands/booth.py
+++ b/pcs/lib/commands/booth.py
@@ -8,10 +8,7 @@ from lxml.etree import _Element
 
 from pcs import settings
 from pcs.common import file_type_codes, reports
-from pcs.common.booth_dto import (
-    BoothConfigAndAuthfileDto,
-    BoothConfigFileDto,
-)
+from pcs.common.booth_dto import BoothConfigAndAuthfileDto, BoothConfigFileDto
 from pcs.common.file import FileAlreadyExists, RawFileError
 from pcs.common.reports import ReportProcessor
 from pcs.common.reports import codes as report_codes

--- a/pcs/lib/commands/constraint/__init__.py
+++ b/pcs/lib/commands/constraint/__init__.py
@@ -1,7 +1,1 @@
-from . import (
-    colocation,
-    common,
-    location,
-    order,
-    ticket,
-)
+from . import colocation, common, location, order, ticket

--- a/pcs/lib/commands/constraint/location.py
+++ b/pcs/lib/commands/constraint/location.py
@@ -1,9 +1,6 @@
 from collections.abc import Mapping
 
-from pcs.common import (
-    const,
-    reports,
-)
+from pcs.common import const, reports
 from pcs.lib import validate
 from pcs.lib.cib.constraint import location
 from pcs.lib.cib.tools import (

--- a/pcs/lib/commands/dr.py
+++ b/pcs/lib/commands/dr.py
@@ -1,10 +1,7 @@
 from collections.abc import Iterable, Mapping
 from typing import Any, cast
 
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
+from pcs.common import file_type_codes, reports
 from pcs.common.dr import (
     DrConfigDto,
     DrConfigNodeDto,

--- a/pcs/lib/commands/fencing_topology.py
+++ b/pcs/lib/commands/fencing_topology.py
@@ -1,9 +1,6 @@
 from typing import Any
 
-from pcs.common.fencing_topology import (
-    FencingTargetType,
-    FencingTargetValue,
-)
+from pcs.common.fencing_topology import FencingTargetType, FencingTargetValue
 from pcs.common.pacemaker.fencing_topology import CibFencingTopologyDto
 from pcs.common.types import StringSequence
 from pcs.lib.cib import fencing_topology as cib_fencing_topology

--- a/pcs/lib/commands/pcsd.py
+++ b/pcs/lib/commands/pcsd.py
@@ -1,8 +1,5 @@
 from pcs import settings
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
+from pcs.common import file_type_codes, reports
 from pcs.common.file import RawFileError
 from pcs.common.reports.item import ReportItem
 from pcs.common.tools import format_os_error

--- a/pcs/lib/commands/qdevice.py
+++ b/pcs/lib/commands/qdevice.py
@@ -5,10 +5,7 @@ from pcs.common import reports
 from pcs.common.file import RawFileError
 from pcs.common.reports import ReportProcessor
 from pcs.common.reports import codes as report_codes
-from pcs.common.reports.item import (
-    ReportItem,
-    get_severity,
-)
+from pcs.common.reports.item import ReportItem, get_severity
 from pcs.common.services.errors import ManageServiceError
 from pcs.common.services.interfaces import ServiceManagerInterface
 from pcs.lib import external

--- a/pcs/lib/commands/resource_agent.py
+++ b/pcs/lib/commands/resource_agent.py
@@ -6,10 +6,7 @@ from pcs.common.pacemaker.resource.operations import (
     OCF_CHECK_LEVEL_INSTANCE_ATTRIBUTE_NAME,
     ListCibResourceOperationDto,
 )
-from pcs.common.reports import (
-    ReportItemSeverity,
-    ReportProcessor,
-)
+from pcs.common.reports import ReportItemSeverity, ReportProcessor
 from pcs.lib.cib.resource.agent import (
     get_default_operations,
     operation_dto_to_legacy_dict,

--- a/pcs/lib/commands/services.py
+++ b/pcs/lib/commands/services.py
@@ -1,10 +1,7 @@
 from pcs import settings
 from pcs.common import file_type_codes, reports
 from pcs.common.services.errors import ManageServiceError
-from pcs.common.services_dto import (
-    ServicesInfoResultDto,
-    ServiceStatusDto,
-)
+from pcs.common.services_dto import ServicesInfoResultDto, ServiceStatusDto
 from pcs.common.types import StringIterable
 from pcs.lib.env import LibraryEnvironment
 from pcs.lib.errors import LibraryError

--- a/pcs/lib/commands/status.py
+++ b/pcs/lib/commands/status.py
@@ -6,19 +6,13 @@ from typing import NamedTuple
 from lxml.etree import _Element
 
 from pcs import settings
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
+from pcs.common import file_type_codes, reports
 from pcs.common.node_communicator import Communicator
 from pcs.common.reports import ReportProcessor
 from pcs.common.reports.item import ReportItem
 from pcs.common.services.interfaces import ServiceManagerInterface
 from pcs.common.status_dto import ResourcesStatusDto
-from pcs.common.str_tools import (
-    format_list,
-    indent,
-)
+from pcs.common.str_tools import format_list, indent
 from pcs.common.types import (
     CibRuleInEffectStatus,
     StringIterable,
@@ -31,11 +25,7 @@ from pcs.lib.cib.constraint.location import get_all_as_dtos
 from pcs.lib.cib.resource import stonith
 from pcs.lib.cib.resource.bundle import verify as verify_bundles
 from pcs.lib.cib.rule.in_effect import get_rule_evaluator
-from pcs.lib.cib.tools import (
-    get_constraints,
-    get_crm_config,
-    get_resources,
-)
+from pcs.lib.cib.tools import get_constraints, get_crm_config, get_resources
 from pcs.lib.communication.nodes import CheckReachability
 from pcs.lib.communication.tools import run as run_communication
 from pcs.lib.env import LibraryEnvironment

--- a/pcs/lib/commands/stonith.py
+++ b/pcs/lib/commands/stonith.py
@@ -7,10 +7,7 @@ from pcs.common.reports import ReportProcessor
 from pcs.common.reports.item import ReportItem
 from pcs.common.types import StringCollection
 from pcs.lib.cib import resource
-from pcs.lib.cib.nvpair import (
-    INSTANCE_ATTRIBUTES_TAG,
-    get_value,
-)
+from pcs.lib.cib.nvpair import INSTANCE_ATTRIBUTES_TAG, get_value
 from pcs.lib.cib.tools import IdProvider
 from pcs.lib.commands.resource import (
     _are_meta_disabled,
@@ -18,18 +15,9 @@ from pcs.lib.commands.resource import (
     resource_environment,
 )
 from pcs.lib.communication.corosync import GetCorosyncOnlineTargets
-from pcs.lib.communication.scsi import (
-    Unfence,
-    UnfenceMpath,
-)
-from pcs.lib.communication.tools import (
-    AllSameDataMixin,
-    run_and_raise,
-)
-from pcs.lib.env import (
-    LibraryEnvironment,
-    WaitType,
-)
+from pcs.lib.communication.scsi import Unfence, UnfenceMpath
+from pcs.lib.communication.tools import AllSameDataMixin, run_and_raise
+from pcs.lib.env import LibraryEnvironment, WaitType
 from pcs.lib.errors import LibraryError
 from pcs.lib.external import CommandRunner
 from pcs.lib.node import get_existing_nodes_names

--- a/pcs/lib/communication/cluster.py
+++ b/pcs/lib/communication/cluster.py
@@ -17,10 +17,7 @@ from pcs.lib.communication.tools import (
     SimpleResponseProcessingMixin,
     SkipOfflineMixin,
 )
-from pcs.lib.corosync.live import (
-    QuorumStatusException,
-    QuorumStatusFacade,
-)
+from pcs.lib.corosync.live import QuorumStatusException, QuorumStatusFacade
 from pcs.lib.node_communication import response_to_report_item
 
 

--- a/pcs/lib/communication/qdevice_net.py
+++ b/pcs/lib/communication/qdevice_net.py
@@ -2,10 +2,7 @@ import base64
 import binascii
 
 from pcs.common import reports
-from pcs.common.node_communicator import (
-    Request,
-    RequestData,
-)
+from pcs.common.node_communicator import Request, RequestData
 from pcs.common.reports.item import ReportItem
 from pcs.lib.communication.qdevice import QdeviceBase
 from pcs.lib.communication.tools import (

--- a/pcs/lib/communication/sbd.py
+++ b/pcs/lib/communication/sbd.py
@@ -1,10 +1,7 @@
 import json
 
 from pcs.common import reports
-from pcs.common.node_communicator import (
-    Request,
-    RequestData,
-)
+from pcs.common.node_communicator import Request, RequestData
 from pcs.common.reports import ReportItemSeverity
 from pcs.common.reports.item import ReportItem
 from pcs.lib.communication.tools import (

--- a/pcs/lib/communication/scsi.py
+++ b/pcs/lib/communication/scsi.py
@@ -6,10 +6,7 @@ from pcs.common import reports
 from pcs.common.communication import const
 from pcs.common.communication.dto import InternalCommunicationResultDto
 from pcs.common.interface.dto import from_dict
-from pcs.common.node_communicator import (
-    Request,
-    RequestData,
-)
+from pcs.common.node_communicator import Request, RequestData
 from pcs.common.types import StringIterable
 from pcs.lib.communication.tools import (
     AllAtOnceStrategyMixin,

--- a/pcs/lib/corosync/config_parser.py
+++ b/pcs/lib/corosync/config_parser.py
@@ -3,10 +3,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
+from pcs.common import file_type_codes, reports
 from pcs.lib.corosync import constants
 from pcs.lib.interface.config import (
     ExporterInterface,

--- a/pcs/lib/corosync/config_validators.py
+++ b/pcs/lib/corosync/config_validators.py
@@ -1,7 +1,4 @@
-from collections import (
-    Counter,
-    defaultdict,
-)
+from collections import Counter, defaultdict
 from collections.abc import (
     Callable,
     Collection,
@@ -27,10 +24,7 @@ from pcs.common.types import StringCollection
 from pcs.lib import validate
 from pcs.lib.cib.node import PacemakerNode
 from pcs.lib.corosync import constants
-from pcs.lib.corosync.node import (
-    CorosyncNode,
-    get_address_type,
-)
+from pcs.lib.corosync.node import CorosyncNode, get_address_type
 
 _QDEVICE_NET_REQUIRED_OPTIONS = (
     "algorithm",

--- a/pcs/lib/corosync/node.py
+++ b/pcs/lib/corosync/node.py
@@ -10,10 +10,7 @@ from pcs.common.corosync_conf import (
 )
 from pcs.common.interface.dto import ImplementsToDto
 from pcs.lib.errors import LibraryError
-from pcs.lib.validate import (
-    is_ipv4_address,
-    is_ipv6_address,
-)
+from pcs.lib.validate import is_ipv4_address, is_ipv6_address
 
 
 @dataclass(frozen=True)

--- a/pcs/lib/corosync/qdevice_net.py
+++ b/pcs/lib/corosync/qdevice_net.py
@@ -6,10 +6,7 @@ from collections.abc import Callable, Sequence
 
 from pcs import settings
 from pcs.common import reports
-from pcs.common.node_communicator import (
-    NodeCommunicatorFactory,
-    RequestTarget,
-)
+from pcs.common.node_communicator import NodeCommunicatorFactory, RequestTarget
 from pcs.common.str_tools import join_multilines
 from pcs.common.tools import format_os_error
 from pcs.common.types import StringSequence

--- a/pcs/lib/dr/env.py
+++ b/pcs/lib/dr/env.py
@@ -3,10 +3,7 @@ from pcs.lib.file.instance import FileInstance
 from pcs.lib.file.toolbox import FileToolbox
 from pcs.lib.file.toolbox import for_file_type as get_file_toolbox
 
-from .config.facade import (
-    DrRole,
-    Facade,
-)
+from .config.facade import DrRole, Facade
 
 
 class DrEnv:

--- a/pcs/lib/file/instance.py
+++ b/pcs/lib/file/instance.py
@@ -1,22 +1,10 @@
 from typing import Any
 
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
-from pcs.common.file import (
-    FileMetadata,
-    RawFileInterface,
-)
-from pcs.lib.file import (
-    metadata,
-    raw_file,
-)
+from pcs.common import file_type_codes, reports
+from pcs.common.file import FileMetadata, RawFileInterface
+from pcs.lib.file import metadata, raw_file
 from pcs.lib.file import toolbox as file_toolbox
-from pcs.lib.interface.config import (
-    FacadeInterface,
-    ParserErrorException,
-)
+from pcs.lib.interface.config import FacadeInterface, ParserErrorException
 
 
 class FileInstance:

--- a/pcs/lib/file/raw_file.py
+++ b/pcs/lib/file/raw_file.py
@@ -8,11 +8,7 @@ from io import BytesIO
 # have to import RawFile from common and Ghost file from here in other
 # places
 from pcs.common import reports
-from pcs.common.file import (
-    FileMetadata,
-    RawFileError,
-    RawFileInterface,
-)
+from pcs.common.file import FileMetadata, RawFileError, RawFileInterface
 from pcs.common.file import RawFile as RealFile  # noqa: F401
 
 # TODO add logging (logger / debug reports ?)

--- a/pcs/lib/file/toolbox.py
+++ b/pcs/lib/file/toolbox.py
@@ -22,10 +22,7 @@ from pcs.lib.interface.config import (
 from pcs.lib.pcs_cfgsync.config.facade import Facade as CfgsyncCtlFacade
 from pcs.lib.permissions import config as pcs_settings_conf
 
-from .json import (
-    JsonExporter,
-    JsonParser,
-)
+from .json import JsonExporter, JsonParser
 
 
 @dataclass(frozen=True)

--- a/pcs/lib/interface/config.py
+++ b/pcs/lib/interface/config.py
@@ -1,9 +1,6 @@
 from typing import Any
 
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
+from pcs.common import file_type_codes, reports
 
 
 class ParserErrorException(Exception):

--- a/pcs/lib/node.py
+++ b/pcs/lib/node.py
@@ -3,19 +3,10 @@ from collections.abc import Iterable
 from lxml.etree import _Element
 
 from pcs.common import reports
-from pcs.common.reports import (
-    ReportItemList,
-    ReportItemSeverity,
-)
+from pcs.common.reports import ReportItemList, ReportItemSeverity
 from pcs.common.reports.item import ReportItem
-from pcs.lib.cib.node import (
-    PacemakerNode,
-    get_node_names,
-)
-from pcs.lib.cib.resource import (
-    guest_node,
-    remote_node,
-)
+from pcs.lib.cib.node import PacemakerNode, get_node_names
+from pcs.lib.cib.resource import guest_node, remote_node
 from pcs.lib.corosync.config_facade import ConfigFacade as CorosyncConfigFacade
 from pcs.lib.corosync.node import CorosyncNode
 from pcs.lib.xml_tools import get_root

--- a/pcs/lib/node_communication.py
+++ b/pcs/lib/node_communication.py
@@ -8,10 +8,7 @@ from pcs.common.node_communicator import (
     NodeTargetFactory,
     RequestTarget,
 )
-from pcs.common.reports import (
-    ReportItemSeverity,
-    ReportProcessor,
-)
+from pcs.common.reports import ReportItemSeverity, ReportProcessor
 from pcs.common.reports.item import ReportItem, ReportItemList
 from pcs.common.types import StringIterable
 from pcs.lib.errors import LibraryError

--- a/pcs/lib/pacemaker/state.py
+++ b/pcs/lib/pacemaker/state.py
@@ -8,18 +8,12 @@ from typing import Any
 
 from lxml import etree
 
-from pcs.common import (
-    const,
-    reports,
-)
+from pcs.common import const, reports
 from pcs.common.pacemaker.role import (
     get_value_primary as get_primary_role_value,
 )
 from pcs.common.reports.item import ReportItem
-from pcs.lib.pacemaker.values import (
-    is_false,
-    is_true,
-)
+from pcs.lib.pacemaker.values import is_false, is_true
 from pcs.lib.xml_tools import find_parent
 
 

--- a/pcs/lib/pacemaker/values.py
+++ b/pcs/lib/pacemaker/values.py
@@ -2,10 +2,7 @@ import re
 
 from pcs import settings
 from pcs.common import reports
-from pcs.common.reports.item import (
-    ReportItem,
-    ReportItemList,
-)
+from pcs.common.reports.item import ReportItem, ReportItemList
 from pcs.common.tools import timeout_to_seconds
 from pcs.common.validate import is_integer
 from pcs.lib.errors import LibraryError

--- a/pcs/lib/permissions/config/__init__.py
+++ b/pcs/lib/permissions/config/__init__.py
@@ -1,6 +1,1 @@
-from . import (
-    exporter,
-    facade,
-    parser,
-    types,
-)
+from . import exporter, facade, parser, types

--- a/pcs/lib/permissions/config/parser.py
+++ b/pcs/lib/permissions/config/parser.py
@@ -5,10 +5,7 @@ import dacite
 from pcs.common import file_type_codes as code
 from pcs.common import reports
 from pcs.lib.file.json import JsonParser, JsonParserException
-from pcs.lib.interface.config import (
-    ParserErrorException,
-    ParserInterface,
-)
+from pcs.lib.interface.config import ParserErrorException, ParserInterface
 
 from .types import ConfigV2
 

--- a/pcs/lib/resource_agent/list.py
+++ b/pcs/lib/resource_agent/list.py
@@ -3,14 +3,8 @@ from pcs.common import reports
 from pcs.common.str_tools import split_multiline
 from pcs.lib.external import CommandRunner
 
-from .error import (
-    AgentNameGuessFoundMoreThanOne,
-    AgentNameGuessFoundNone,
-)
-from .types import (
-    ResourceAgentName,
-    StandardProviderTuple,
-)
+from .error import AgentNameGuessFoundMoreThanOne, AgentNameGuessFoundNone
+from .types import ResourceAgentName, StandardProviderTuple
 
 _IGNORED_AGENTS = frozenset(
     [

--- a/pcs/lib/resource_agent/name.py
+++ b/pcs/lib/resource_agent/name.py
@@ -2,10 +2,7 @@ import re
 
 from . import const
 from .error import InvalidResourceAgentName
-from .types import (
-    ResourceAgentMetadata,
-    ResourceAgentName,
-)
+from .types import ResourceAgentMetadata, ResourceAgentName
 
 
 def split_resource_agent_name(full_agent_name: str) -> ResourceAgentName:

--- a/pcs/lib/resource_agent/xml.py
+++ b/pcs/lib/resource_agent/xml.py
@@ -12,10 +12,7 @@ from pcs.lib.pacemaker.api_result import (
 from pcs.lib.xml_tools import etree_to_str
 
 from . import const
-from .error import (
-    UnableToGetAgentMetadata,
-    UnsupportedOcfVersion,
-)
+from .error import UnableToGetAgentMetadata, UnsupportedOcfVersion
 from .types import (
     CrmAttrAgent,
     CrmResourceAgent,

--- a/pcs/lib/services.py
+++ b/pcs/lib/services.py
@@ -1,8 +1,5 @@
 from pcs import settings
-from pcs.common import (
-    reports,
-    services,
-)
+from pcs.common import reports, services
 from pcs.common.types import StringSequence
 from pcs.lib.errors import LibraryError
 from pcs.lib.external import CommandRunner

--- a/pcs/lib/tools.py
+++ b/pcs/lib/tools.py
@@ -2,10 +2,7 @@ import os
 import tempfile
 import uuid
 from collections.abc import Callable, Generator, Mapping
-from contextlib import (
-    AbstractContextManager,
-    contextmanager,
-)
+from contextlib import AbstractContextManager, contextmanager
 from typing import IO, Literal, TypeVar, overload
 
 from pcs.common import reports

--- a/pcs/pcsd.py
+++ b/pcs/pcsd.py
@@ -2,25 +2,13 @@ import contextlib
 import json
 import os
 import sys
-from typing import (
-    Any,
-    cast,
-)
+from typing import Any, cast
 
 import pcs.common.ssl
-from pcs import (
-    settings,
-    utils,
-)
+from pcs import settings, utils
 from pcs.cli.common.errors import CmdLineInputError
-from pcs.cli.common.parse_args import (
-    Argv,
-    InputModifiers,
-)
-from pcs.cli.reports import (
-    output,
-    process_library_reports,
-)
+from pcs.cli.common.parse_args import Argv, InputModifiers
+from pcs.cli.reports import output, process_library_reports
 from pcs.cli.reports.output import deprecation_warning, print_to_stderr
 from pcs.common import file as pcs_file
 from pcs.common import reports

--- a/pcs/quorum.py
+++ b/pcs/quorum.py
@@ -1,9 +1,6 @@
 from typing import Any
 
-from pcs import (
-    stonith,
-    utils,
-)
+from pcs import stonith, utils
 from pcs.cli.cluster_property.output import PropertyConfigurationFacade
 from pcs.cli.common import parse_args
 from pcs.cli.common.errors import CmdLineInputError
@@ -15,10 +12,7 @@ from pcs.cli.common.parse_args import (
 )
 from pcs.cli.common.tools import print_to_stderr
 from pcs.cli.reports import process_library_reports
-from pcs.common.str_tools import (
-    format_list,
-    indent,
-)
+from pcs.common.str_tools import format_list, indent
 from pcs.lib.node import get_existing_nodes_names
 from pcs.lib.pacemaker.values import is_false
 

--- a/pcs/snmp/updaters/v1.py
+++ b/pcs/snmp/updaters/v1.py
@@ -1,10 +1,6 @@
 import logging
 
-from pcs.snmp.agentx.types import (
-    IntegerType,
-    Oid,
-    StringType,
-)
+from pcs.snmp.agentx.types import IntegerType, Oid, StringType
 from pcs.snmp.agentx.updater import AgentxUpdaterBase
 from pcs.utils import run_pcsdcli
 

--- a/pcs_test/api_v2_client.py
+++ b/pcs_test/api_v2_client.py
@@ -14,18 +14,9 @@ from pcs.common.async_tasks.dto import (
     TaskIdentDto,
     TaskResultDto,
 )
-from pcs.common.async_tasks.types import (
-    TaskFinishType,
-    TaskState,
-)
-from pcs.common.interface.dto import (
-    from_dict,
-    to_dict,
-)
-from pcs.common.node_communicator import (
-    HostNotFound,
-    NodeTargetFactory,
-)
+from pcs.common.async_tasks.types import TaskFinishType, TaskState
+from pcs.common.interface.dto import from_dict, to_dict
+from pcs.common.node_communicator import HostNotFound, NodeTargetFactory
 from pcs.common.reports import ReportItemDto
 from pcs.utils import read_known_hosts_file
 

--- a/pcs_test/tier0/cli/booth/test_env.py
+++ b/pcs_test/tier0/cli/booth/test_env.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.booth import env
 from pcs.common import file_type_codes

--- a/pcs_test/tier0/cli/cluster/test_command.py
+++ b/pcs_test/tier0/cli/cluster/test_command.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.cluster import command
 from pcs.cli.common.errors import CmdLineInputError

--- a/pcs_test/tier0/cli/cluster_property/test_command.py
+++ b/pcs_test/tier0/cli/cluster_property/test_command.py
@@ -1,9 +1,6 @@
 import json
 from textwrap import dedent
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.cluster_property import command as cluster_property
 from pcs.cli.common.errors import CmdLineInputError

--- a/pcs_test/tier0/cli/common/test_lib_wrapper.py
+++ b/pcs_test/tier0/cli/common/test_lib_wrapper.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.common.lib_wrapper import Library
 

--- a/pcs_test/tier0/cli/constraint/location/test_command.py
+++ b/pcs_test/tier0/cli/constraint/location/test_command.py
@@ -1,14 +1,8 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.constraint.location import command as location_command
-from pcs.common import (
-    const,
-    reports,
-)
+from pcs.common import const, reports
 
 from pcs_test.tools.constraints_dto import get_all_constraints
 from pcs_test.tools.custom_mock import RuleInEffectEvalMock

--- a/pcs_test/tier0/cli/constraint/test_command.py
+++ b/pcs_test/tier0/cli/constraint/test_command.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.constraint import command as constraint_command

--- a/pcs_test/tier0/cli/constraint_colocation/test_command.py
+++ b/pcs_test/tier0/cli/constraint_colocation/test_command.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.constraint_colocation import command as colocation_command

--- a/pcs_test/tier0/cli/constraint_ticket/test_command.py
+++ b/pcs_test/tier0/cli/constraint_ticket/test_command.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.common.parse_args import InputModifiers

--- a/pcs_test/tier0/cli/query/test_resource.py
+++ b/pcs_test/tier0/cli/query/test_resource.py
@@ -1,8 +1,5 @@
 from collections.abc import Sequence
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.common.parse_args import Argv

--- a/pcs_test/tier0/cli/reports/test_messages.py
+++ b/pcs_test/tier0/cli/reports/test_messages.py
@@ -3,13 +3,7 @@ from unittest import TestCase
 
 from pcs.cli.reports import messages as cli_messages
 from pcs.common import file_type_codes
-from pcs.common.reports import (
-    codes,
-    const,
-    item,
-    messages,
-    types,
-)
+from pcs.common.reports import codes, const, item, messages, types
 
 
 class AllClassesTested(TestCase):

--- a/pcs_test/tier0/cli/reports/test_preprocessor.py
+++ b/pcs_test/tier0/cli/reports/test_preprocessor.py
@@ -1,8 +1,5 @@
 from textwrap import dedent
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.reports.preprocessor import (
     get_duplicate_constraint_exists_preprocessor,

--- a/pcs_test/tier0/cli/resource/test_defaults.py
+++ b/pcs_test/tier0/cli/resource/test_defaults.py
@@ -1,25 +1,16 @@
 import json
 from dataclasses import replace
 from textwrap import dedent
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import resource
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.common.interface import dto
 from pcs.common.pacemaker.defaults import CibDefaultsDto
-from pcs.common.pacemaker.nvset import (
-    CibNvpairDto,
-    CibNvsetDto,
-)
+from pcs.common.pacemaker.nvset import CibNvpairDto, CibNvsetDto
 from pcs.common.pacemaker.rule import CibRuleExpressionDto
 from pcs.common.reports import codes as report_codes
-from pcs.common.types import (
-    CibRuleExpressionType,
-    CibRuleInEffectStatus,
-)
+from pcs.common.types import CibRuleExpressionType, CibRuleInEffectStatus
 
 from pcs_test.tools.misc import dict_to_modifiers
 

--- a/pcs_test/tier0/cli/resource/test_parse_args.py
+++ b/pcs_test/tier0/cli/resource/test_parse_args.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.common.parse_args import InputModifiers

--- a/pcs_test/tier0/cli/resource/test_relations.py
+++ b/pcs_test/tier0/cli/resource/test_relations.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.resource import relations

--- a/pcs_test/tier0/cli/resource/test_remove.py
+++ b/pcs_test/tier0/cli/resource/test_remove.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.common.parse_args import InputModifiers

--- a/pcs_test/tier0/cli/resource/test_update.py
+++ b/pcs_test/tier0/cli/resource/test_update.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.resource import command

--- a/pcs_test/tier0/cli/stonith/test_config.py
+++ b/pcs_test/tier0/cli/stonith/test_config.py
@@ -9,9 +9,7 @@ from pcs.common.pacemaker.cibsecret import (
     CibResourceSecretDto,
     CibResourceSecretListDto,
 )
-from pcs.common.pacemaker.fencing_topology import (
-    CibFencingTopologyDto,
-)
+from pcs.common.pacemaker.fencing_topology import CibFencingTopologyDto
 from pcs.common.pacemaker.resource.list import CibResourcesDto
 
 from pcs_test.tools.misc import dict_to_modifiers

--- a/pcs_test/tier0/cli/tag/test_command.py
+++ b/pcs_test/tier0/cli/tag/test_command.py
@@ -1,15 +1,9 @@
 from textwrap import dedent
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.tag import command
-from pcs.common.pacemaker.tag import (
-    CibTagDto,
-    CibTagListDto,
-)
+from pcs.common.pacemaker.tag import CibTagDto, CibTagListDto
 from pcs.lib.errors import LibraryError
 
 from pcs_test.tools.misc import dict_to_modifiers

--- a/pcs_test/tier0/cli/test_dr.py
+++ b/pcs_test/tier0/cli/test_dr.py
@@ -1,8 +1,5 @@
 from textwrap import dedent
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli import dr
 from pcs.cli.common.errors import CmdLineInputError

--- a/pcs_test/tier0/cli/test_nvset.py
+++ b/pcs_test/tier0/cli/test_nvset.py
@@ -3,15 +3,9 @@ from textwrap import dedent
 from unittest import TestCase
 
 from pcs.cli import nvset
-from pcs.common.pacemaker.nvset import (
-    CibNvpairDto,
-    CibNvsetDto,
-)
+from pcs.common.pacemaker.nvset import CibNvpairDto, CibNvsetDto
 from pcs.common.pacemaker.rule import CibRuleExpressionDto
-from pcs.common.types import (
-    CibRuleExpressionType,
-    CibRuleInEffectStatus,
-)
+from pcs.common.types import CibRuleExpressionType, CibRuleInEffectStatus
 
 
 def fixture_dto(in_effect):

--- a/pcs_test/tier0/cli/test_quorum.py
+++ b/pcs_test/tier0/cli/test_quorum.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import quorum
 from pcs.cli.common.errors import CmdLineInputError

--- a/pcs_test/tier0/cli/test_resource.py
+++ b/pcs_test/tier0/cli/test_resource.py
@@ -1,19 +1,13 @@
 from random import shuffle
 from textwrap import dedent
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import resource
 from pcs.cli.common.errors import CmdLineInputError
 from pcs.cli.reports.processor import ReportItemSeverity
 from pcs.common.reports.codes import FORCE
 
-from pcs_test.tools.assertions import (
-    AssertPcsMixin,
-    ac,
-)
+from pcs_test.tools.assertions import AssertPcsMixin, ac
 from pcs_test.tools.misc import dict_to_modifiers
 
 

--- a/pcs_test/tier0/cli/test_rule.py
+++ b/pcs_test/tier0/cli/test_rule.py
@@ -3,14 +3,8 @@ from textwrap import dedent
 from unittest import TestCase
 
 from pcs.cli import rule
-from pcs.common.pacemaker.rule import (
-    CibRuleDateCommonDto,
-    CibRuleExpressionDto,
-)
-from pcs.common.types import (
-    CibRuleExpressionType,
-    CibRuleInEffectStatus,
-)
+from pcs.common.pacemaker.rule import CibRuleDateCommonDto, CibRuleExpressionDto
+from pcs.common.types import CibRuleExpressionType, CibRuleInEffectStatus
 
 
 class RuleDtoToLinesMixin:

--- a/pcs_test/tier0/cli/test_status.py
+++ b/pcs_test/tier0/cli/test_status.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import status
 from pcs.cli.common.errors import CmdLineInputError

--- a/pcs_test/tier0/cli/test_stonith.py
+++ b/pcs_test/tier0/cli/test_stonith.py
@@ -1,8 +1,5 @@
 from textwrap import dedent
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import stonith
 from pcs.cli.common.errors import CmdLineInputError

--- a/pcs_test/tier0/common/communication/test_logger.py
+++ b/pcs_test/tier0/common/communication/test_logger.py
@@ -1,9 +1,6 @@
 import logging
 from textwrap import dedent
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
 from pcs.common import pcs_pycurl as pycurl

--- a/pcs_test/tier0/common/reports/test_item.py
+++ b/pcs_test/tier0/common/reports/test_item.py
@@ -1,16 +1,9 @@
 from collections.abc import Mapping
-from dataclasses import (
-    dataclass,
-    field,
-)
+from dataclasses import dataclass, field
 from typing import Any
 from unittest import TestCase
 
-from pcs.common.reports import (
-    dto,
-    item,
-    types,
-)
+from pcs.common.reports import dto, item, types
 
 REPORT_CODE = types.MessageCode("REPORT_CODE")
 OUTER_REPORT_CODE = types.MessageCode("OUTER_REPORT_CODE")

--- a/pcs_test/tier0/common/services/drivers/test_systemd.py
+++ b/pcs_test/tier0/common/services/drivers/test_systemd.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.common.services import errors
 from pcs.common.services.drivers import SystemdDriver

--- a/pcs_test/tier0/common/services/drivers/test_sysvinit_rhel.py
+++ b/pcs_test/tier0/common/services/drivers/test_sysvinit_rhel.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.common.services import errors
 from pcs.common.services.drivers import SysVInitRhelDriver

--- a/pcs_test/tier0/common/test_capabilities.py
+++ b/pcs_test/tier0/common/test_capabilities.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.common import capabilities
 

--- a/pcs_test/tier0/common/test_node_communicator.py
+++ b/pcs_test/tier0/common/test_node_communicator.py
@@ -1,8 +1,5 @@
 import io
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 import pcs.common.node_communicator as lib
 from pcs import settings
@@ -10,10 +7,7 @@ from pcs.common import host
 from pcs.common import pcs_pycurl as pycurl
 from pcs.common.host import Destination
 
-from pcs_test.tools.custom_mock import (
-    MockCurl,
-    MockCurlMulti,
-)
+from pcs_test.tools.custom_mock import MockCurl, MockCurlMulti
 
 PORT = settings.pcsd_default_port
 

--- a/pcs_test/tier0/daemon/app/test_api_v0_tools.py
+++ b/pcs_test/tier0/daemon/app/test_api_v0_tools.py
@@ -19,10 +19,7 @@ from pcs.daemon.app.api_v0_tools import (
     reports_to_str,
     run_library_command_in_scheduler,
 )
-from pcs.daemon.async_tasks.scheduler import (
-    Scheduler,
-    TaskNotFoundError,
-)
+from pcs.daemon.async_tasks.scheduler import Scheduler, TaskNotFoundError
 from pcs.daemon.async_tasks.types import Command
 from pcs.lib.auth.types import AuthUser
 

--- a/pcs_test/tier0/daemon/app/test_app_gui.py
+++ b/pcs_test/tier0/daemon/app/test_app_gui.py
@@ -17,10 +17,7 @@ from pcs.daemon.app.auth_provider import (
 from pcs.lib.auth.provider import AuthProvider
 from pcs.lib.auth.types import AuthUser
 
-from pcs_test.tier0.daemon.app import (
-    fixtures_app,
-    fixtures_app_webui,
-)
+from pcs_test.tier0.daemon.app import fixtures_app, fixtures_app_webui
 from pcs_test.tools.misc import skip_unless_webui_installed
 
 # Don't write errors to test output.

--- a/pcs_test/tier0/daemon/app/test_app_spa.py
+++ b/pcs_test/tier0/daemon/app/test_app_spa.py
@@ -12,14 +12,8 @@ except ImportError:
 from pcs.lib.auth.provider import AuthProvider
 from pcs.lib.auth.types import AuthUser
 
-from pcs_test.tier0.daemon.app import (
-    fixtures_app,
-    fixtures_app_webui,
-)
-from pcs_test.tools.misc import (
-    get_tmp_dir,
-    skip_unless_webui_installed,
-)
+from pcs_test.tier0.daemon.app import fixtures_app, fixtures_app_webui
+from pcs_test.tools.misc import get_tmp_dir, skip_unless_webui_installed
 
 PREFIX = "/ui/"
 

--- a/pcs_test/tier0/daemon/async_tasks/helpers.py
+++ b/pcs_test/tier0/daemon/async_tasks/helpers.py
@@ -4,15 +4,9 @@ from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime
 from queue import Queue
-from unittest import (
-    IsolatedAsyncioTestCase,
-    mock,
-)
+from unittest import IsolatedAsyncioTestCase, mock
 
-from pcs.common.async_tasks.dto import (
-    CommandDto,
-    CommandOptionsDto,
-)
+from pcs.common.async_tasks.dto import CommandDto, CommandOptionsDto
 from pcs.common.async_tasks.types import TaskState
 from pcs.common.reports.item import ReportItemMessage
 from pcs.common.reports.types import MessageCode

--- a/pcs_test/tier0/daemon/async_tasks/test_integration.py
+++ b/pcs_test/tier0/daemon/async_tasks/test_integration.py
@@ -8,14 +8,8 @@ from queue import Queue
 from unittest import mock
 
 from pcs import settings
-from pcs.common.async_tasks.dto import (
-    CommandDto,
-    CommandOptionsDto,
-)
-from pcs.common.async_tasks.types import (
-    TaskFinishType,
-    TaskKillReason,
-)
+from pcs.common.async_tasks.dto import CommandDto, CommandOptionsDto
+from pcs.common.async_tasks.types import TaskFinishType, TaskKillReason
 from pcs.daemon.async_tasks.scheduler import TaskNotFoundError
 from pcs.daemon.async_tasks.types import Command
 from pcs.daemon.async_tasks.worker import executor
@@ -26,10 +20,7 @@ from pcs.daemon.async_tasks.worker.types import (
     TaskFinished,
 )
 
-from .dummy_commands import (
-    RESULT,
-    test_command_map,
-)
+from .dummy_commands import RESULT, test_command_map
 from .helpers import (
     AUTH_USER,
     DATETIME_NOW,

--- a/pcs_test/tier0/daemon/async_tasks/test_scheduler.py
+++ b/pcs_test/tier0/daemon/async_tasks/test_scheduler.py
@@ -15,21 +15,11 @@ from pcs.common.async_tasks.types import (
 from pcs.common.reports import ReportItem
 from pcs.common.reports.messages import CibUpgradeSuccessful
 from pcs.daemon.async_tasks import scheduler
-from pcs.daemon.async_tasks.task import (
-    Task,
-    TaskConfig,
-)
+from pcs.daemon.async_tasks.task import Task, TaskConfig
 from pcs.daemon.async_tasks.worker.executor import task_executor
-from pcs.daemon.async_tasks.worker.types import (
-    Message,
-    TaskExecuted,
-)
+from pcs.daemon.async_tasks.worker.types import Message, TaskExecuted
 
-from .helpers import (
-    ANOTHER_AUTH_USER,
-    AUTH_USER,
-    SchedulerBaseAsyncTestCase,
-)
+from .helpers import ANOTHER_AUTH_USER, AUTH_USER, SchedulerBaseAsyncTestCase
 
 WORKER1_PID = 2222
 WORKER2_PID = 3333

--- a/pcs_test/tier0/daemon/async_tasks/test_task.py
+++ b/pcs_test/tier0/daemon/async_tasks/test_task.py
@@ -1,15 +1,9 @@
 from datetime import timedelta
-from unittest import (
-    IsolatedAsyncioTestCase,
-    mock,
-)
+from unittest import IsolatedAsyncioTestCase, mock
 
 import pcs.daemon.async_tasks.task as tasks
 from pcs.common.async_tasks import types
-from pcs.common.async_tasks.dto import (
-    CommandDto,
-    CommandOptionsDto,
-)
+from pcs.common.async_tasks.dto import CommandDto, CommandOptionsDto
 from pcs.common.reports import ReportItemDto
 from pcs.daemon.async_tasks.types import Command
 from pcs.daemon.async_tasks.worker.types import (

--- a/pcs_test/tier0/daemon/async_tasks/test_worker.py
+++ b/pcs_test/tier0/daemon/async_tasks/test_worker.py
@@ -1,15 +1,9 @@
 from multiprocessing import Queue
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.common import reports
 from pcs.common.async_tasks import types
-from pcs.common.async_tasks.dto import (
-    CommandDto,
-    CommandOptionsDto,
-)
+from pcs.common.async_tasks.dto import CommandDto, CommandOptionsDto
 from pcs.daemon.async_tasks.types import Command
 from pcs.daemon.async_tasks.worker import executor
 from pcs.daemon.async_tasks.worker.types import (
@@ -19,16 +13,8 @@ from pcs.daemon.async_tasks.worker.types import (
     WorkerCommand,
 )
 
-from .dummy_commands import (
-    RESULT,
-    test_command_map,
-    test_legacy_api_commands,
-)
-from .helpers import (
-    AUTH_USER,
-    MockOsKillMixin,
-    PermissionsCheckerMock,
-)
+from .dummy_commands import RESULT, test_command_map, test_legacy_api_commands
+from .helpers import AUTH_USER, MockOsKillMixin, PermissionsCheckerMock
 
 TASK_IDENT = "id0"
 WORKER_PID = 2222

--- a/pcs_test/tier0/daemon/test_env.py
+++ b/pcs_test/tier0/daemon/test_env.py
@@ -1,9 +1,6 @@
 import os.path
 from ssl import OP_NO_SSLv2
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
 from pcs.daemon import env

--- a/pcs_test/tier0/daemon/test_http_server.py
+++ b/pcs_test/tier0/daemon/test_http_server.py
@@ -1,9 +1,6 @@
 import logging
 from unittest import TestCase
-from unittest.mock import (
-    MagicMock,
-    Mock,
-)
+from unittest.mock import MagicMock, Mock
 
 from tornado.httpserver import HTTPServer
 

--- a/pcs_test/tier0/daemon/test_pcs_cfgsync.py
+++ b/pcs_test/tier0/daemon/test_pcs_cfgsync.py
@@ -18,12 +18,8 @@ from pcs.lib.host.config.types import KnownHosts
 from pcs.lib.permissions.config.exporter import (
     ExporterV2 as PcsSettingsExporter,
 )
-from pcs.lib.permissions.config.types import (
-    ClusterPermissions,
-)
-from pcs.lib.permissions.config.types import (
-    ConfigV2 as PcsSettingsConf,
-)
+from pcs.lib.permissions.config.types import ClusterPermissions
+from pcs.lib.permissions.config.types import ConfigV2 as PcsSettingsConf
 
 from pcs_test.tools.command_env import get_env_tools
 from pcs_test.tools.misc import read_test_resource

--- a/pcs_test/tier0/daemon/test_ruby_pcsd.py
+++ b/pcs_test/tier0/daemon/test_ruby_pcsd.py
@@ -1,20 +1,11 @@
 import json
 import logging
 from base64 import b64encode
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 from urllib.parse import urlencode
 
-from tornado.httputil import (
-    HTTPHeaders,
-    HTTPServerRequest,
-)
-from tornado.testing import (
-    AsyncTestCase,
-    gen_test,
-)
+from tornado.httputil import HTTPHeaders, HTTPServerRequest
+from tornado.testing import AsyncTestCase, gen_test
 from tornado.web import HTTPError
 
 from pcs.daemon import ruby_pcsd

--- a/pcs_test/tier0/daemon/test_ssl.py
+++ b/pcs_test/tier0/daemon/test_ssl.py
@@ -1,15 +1,8 @@
 import os
 import ssl
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
-from pcs.daemon.ssl import (
-    CertKeyPair,
-    PcsdSSL,
-    SSLCertKeyException,
-)
+from pcs.daemon.ssl import CertKeyPair, PcsdSSL, SSLCertKeyException
 
 from pcs_test.tools.misc import get_tmp_dir
 

--- a/pcs_test/tier0/lib/auth/config/test_facade.py
+++ b/pcs_test/tier0/lib/auth/config/test_facade.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.lib.auth.config.facade import Facade
 from pcs.lib.auth.config.types import TokenEntry

--- a/pcs_test/tier0/lib/auth/config/test_parser.py
+++ b/pcs_test/tier0/lib/auth/config/test_parser.py
@@ -2,10 +2,7 @@ import json
 from dataclasses import asdict
 from unittest import TestCase
 
-from pcs.lib.auth.config.parser import (
-    Parser,
-    ParserError,
-)
+from pcs.lib.auth.config.parser import Parser, ParserError
 from pcs.lib.auth.config.types import TokenEntry
 from pcs.lib.interface.config import ParserErrorException
 

--- a/pcs_test/tier0/lib/auth/test_provider.py
+++ b/pcs_test/tier0/lib/auth/test_provider.py
@@ -1,24 +1,14 @@
 from io import BytesIO
 from logging import Logger
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
-from pcs.common.file import (
-    FileMetadata,
-    RawFile,
-    RawFileError,
-)
+from pcs.common.file import FileMetadata, RawFile, RawFileError
 from pcs.common.file_type_codes import PCS_USERS_CONF
 from pcs.lib.auth import const
 from pcs.lib.auth.config.facade import Facade
 from pcs.lib.auth.config.parser import ParserError
 from pcs.lib.auth.config.types import TokenEntry
-from pcs.lib.auth.provider import (
-    AuthProvider,
-    _UpdateFacadeError,
-)
+from pcs.lib.auth.provider import AuthProvider, _UpdateFacadeError
 from pcs.lib.auth.types import AuthUser
 from pcs.lib.file.instance import FileInstance
 from pcs.lib.file.json import JsonParserException

--- a/pcs_test/tier0/lib/booth/test_config_facade.py
+++ b/pcs_test/tier0/lib/booth/test_config_facade.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.lib.booth import constants
 from pcs.lib.booth.config_facade import ConfigFacade

--- a/pcs_test/tier0/lib/booth/test_config_files.py
+++ b/pcs_test/tier0/lib/booth/test_config_files.py
@@ -1,8 +1,5 @@
 import os.path
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
 from pcs.common import file_type_codes

--- a/pcs_test/tier0/lib/booth/test_resource.py
+++ b/pcs_test/tier0/lib/booth/test_resource.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 

--- a/pcs_test/tier0/lib/booth/test_status.py
+++ b/pcs_test/tier0/lib/booth/test_status.py
@@ -1,16 +1,10 @@
 import os
 from textwrap import dedent
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 import pcs.lib.booth.status as lib
 from pcs import settings
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
+from pcs.common import file_type_codes, reports
 from pcs.common.reports import ReportItemSeverity as Severities
 from pcs.common.reports import codes as report_codes
 from pcs.lib.booth import constants

--- a/pcs_test/tier0/lib/cib/rule/test_cib_to_dto.py
+++ b/pcs_test/tier0/lib/cib/rule/test_cib_to_dto.py
@@ -2,18 +2,9 @@ from unittest import TestCase
 
 from lxml import etree
 
-from pcs.common.pacemaker.rule import (
-    CibRuleDateCommonDto,
-    CibRuleExpressionDto,
-)
-from pcs.common.types import (
-    CibRuleExpressionType,
-    CibRuleInEffectStatus,
-)
-from pcs.lib.cib.rule import (
-    RuleInEffectEval,
-    rule_element_to_dto,
-)
+from pcs.common.pacemaker.rule import CibRuleDateCommonDto, CibRuleExpressionDto
+from pcs.common.types import CibRuleExpressionType, CibRuleInEffectStatus
+from pcs.lib.cib.rule import RuleInEffectEval, rule_element_to_dto
 
 
 class RuleInEffectEvalMock(RuleInEffectEval):

--- a/pcs_test/tier0/lib/cib/rule/test_tools.py
+++ b/pcs_test/tier0/lib/cib/rule/test_tools.py
@@ -1,10 +1,7 @@
 from unittest import TestCase
 
 from pcs.common.pacemaker.rule import CibRuleExpressionDto
-from pcs.common.types import (
-    CibRuleExpressionType,
-    CibRuleInEffectStatus,
-)
+from pcs.common.types import CibRuleExpressionType, CibRuleInEffectStatus
 from pcs.lib.cib.rule import tools
 from pcs.lib.cib.rule.expression_part import (
     BOOL_AND,

--- a/pcs_test/tier0/lib/cib/test_acl.py
+++ b/pcs_test/tier0/lib/cib/test_acl.py
@@ -1,17 +1,11 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 
 from pcs.common.reports import ReportItemSeverity as severities
 from pcs.common.reports import codes as report_codes
 from pcs.lib.cib import acl as lib
-from pcs.lib.cib.tools import (
-    IdProvider,
-    get_acls,
-)
+from pcs.lib.cib.tools import IdProvider, get_acls
 from pcs.lib.errors import LibraryError
 
 from pcs_test.tools.assertions import (

--- a/pcs_test/tier0/lib/cib/test_constraint.py
+++ b/pcs_test/tier0/lib/cib/test_constraint.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 

--- a/pcs_test/tier0/lib/cib/test_constraint_colocation.py
+++ b/pcs_test/tier0/lib/cib/test_constraint_colocation.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 

--- a/pcs_test/tier0/lib/cib/test_constraint_location.py
+++ b/pcs_test/tier0/lib/cib/test_constraint_location.py
@@ -2,10 +2,7 @@ from unittest import TestCase
 
 from lxml import etree
 
-from pcs.common import (
-    const,
-    reports,
-)
+from pcs.common import const, reports
 from pcs.common.pacemaker.types import CibResourceDiscovery
 from pcs.common.types import CibRuleExpressionType
 from pcs.lib.cib import const as cib_const

--- a/pcs_test/tier0/lib/cib/test_fencing_topology.py
+++ b/pcs_test/tier0/lib/cib/test_fencing_topology.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 
@@ -25,10 +22,7 @@ from pcs.lib.cib import fencing_topology as lib
 from pcs.lib.errors import LibraryError
 from pcs.lib.pacemaker.state import ClusterState
 
-from pcs_test.tools import (
-    fixture,
-    fixture_crm_mon,
-)
+from pcs_test.tools import fixture, fixture_crm_mon
 from pcs_test.tools.assertions import (
     assert_report_item_list_equal,
     assert_xml_equal,

--- a/pcs_test/tier0/lib/cib/test_node.py
+++ b/pcs_test/tier0/lib/cib/test_node.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 
@@ -17,9 +14,7 @@ from pcs_test.tools.assertions import (
     assert_raise_library_error,
     assert_xml_equal,
 )
-from pcs_test.tools.custom_mock import (
-    RuleInEffectEvalMock,
-)
+from pcs_test.tools.custom_mock import RuleInEffectEvalMock
 from pcs_test.tools.misc import get_test_resource as rc
 from pcs_test.tools.nodes_dto import FIXTURE_NODES_CONFIG_XML, get_nodes_dto
 from pcs_test.tools.xml import etree_to_str

--- a/pcs_test/tier0/lib/cib/test_nvpair_multi.py
+++ b/pcs_test/tier0/lib/cib/test_nvpair_multi.py
@@ -3,19 +3,10 @@ from unittest import TestCase
 from lxml import etree
 
 from pcs.common import reports
-from pcs.common.pacemaker.nvset import (
-    CibNvpairDto,
-    CibNvsetDto,
-)
-from pcs.common.pacemaker.rule import (
-    CibRuleDateCommonDto,
-    CibRuleExpressionDto,
-)
+from pcs.common.pacemaker.nvset import CibNvpairDto, CibNvsetDto
+from pcs.common.pacemaker.rule import CibRuleDateCommonDto, CibRuleExpressionDto
 from pcs.common.tools import Version
-from pcs.common.types import (
-    CibRuleExpressionType,
-    CibRuleInEffectStatus,
-)
+from pcs.common.types import CibRuleExpressionType, CibRuleInEffectStatus
 from pcs.lib.cib import nvpair_multi
 from pcs.lib.cib.rule import RuleInEffectEval
 from pcs.lib.cib.rule.expression_part import (

--- a/pcs_test/tier0/lib/cib/test_remove_elements.py
+++ b/pcs_test/tier0/lib/cib/test_remove_elements.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 from lxml.etree import _Element

--- a/pcs_test/tier0/lib/cib/test_resource_clone.py
+++ b/pcs_test/tier0/lib/cib/test_resource_clone.py
@@ -1,6 +1,4 @@
-from unittest import (
-    TestCase,
-)
+from unittest import TestCase
 
 from lxml import etree
 

--- a/pcs_test/tier0/lib/cib/test_resource_guest_node.py
+++ b/pcs_test/tier0/lib/cib/test_resource_guest_node.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 

--- a/pcs_test/tier0/lib/cib/test_resource_primitive.py
+++ b/pcs_test/tier0/lib/cib/test_resource_primitive.py
@@ -1,8 +1,5 @@
 from functools import partial
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 

--- a/pcs_test/tier0/lib/cib/test_resource_remote_node.py
+++ b/pcs_test/tier0/lib/cib/test_resource_remote_node.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 

--- a/pcs_test/tier0/lib/cib/test_tools.py
+++ b/pcs_test/tier0/lib/cib/test_tools.py
@@ -1,8 +1,5 @@
 from functools import partial
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 

--- a/pcs_test/tier0/lib/commands/cluster/test_verify.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_verify.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
 from pcs.common.reports import codes as report_codes

--- a/pcs_test/tier0/lib/commands/constraint/test_location.py
+++ b/pcs_test/tier0/lib/commands/constraint/test_location.py
@@ -1,9 +1,6 @@
 from unittest import TestCase
 
-from pcs.common import (
-    const,
-    reports,
-)
+from pcs.common import const, reports
 from pcs.common.pacemaker.types import CibResourceDiscovery
 from pcs.lib.cib import const as cib_const
 from pcs.lib.commands.constraint import location

--- a/pcs_test/tier0/lib/commands/remote_node/test_node_add_guest.py
+++ b/pcs_test/tier0/lib/commands/remote_node/test_node_add_guest.py
@@ -1,8 +1,5 @@
 from functools import partial
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
 from pcs.common import reports

--- a/pcs_test/tier0/lib/commands/remote_node/test_node_add_remote.py
+++ b/pcs_test/tier0/lib/commands/remote_node/test_node_add_remote.py
@@ -1,14 +1,8 @@
 from functools import partial
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
+from pcs.common import file_type_codes, reports
 from pcs.common.file import RawFileError
 from pcs.common.host import Destination
 from pcs.lib.commands.remote_node import node_add_remote as node_add_remote_orig

--- a/pcs_test/tier0/lib/commands/resource/test_bundle_update.py
+++ b/pcs_test/tier0/lib/commands/resource/test_bundle_update.py
@@ -1,9 +1,6 @@
 from functools import partial
 from textwrap import dedent
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
 from pcs.common import reports

--- a/pcs_test/tier0/lib/commands/resource/test_group_add.py
+++ b/pcs_test/tier0/lib/commands/resource/test_group_add.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
 from pcs.common.reports import codes as report_codes

--- a/pcs_test/tier0/lib/commands/resource/test_resource_create.py
+++ b/pcs_test/tier0/lib/commands/resource/test_resource_create.py
@@ -1,13 +1,7 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
-from pcs.common import (
-    const,
-    reports,
-)
+from pcs.common import const, reports
 from pcs.lib.commands import resource
 from pcs.lib.errors import LibraryError
 from pcs.lib.resource_agent import ResourceAgentName

--- a/pcs_test/tier0/lib/commands/resource/test_resource_enable_disable.py
+++ b/pcs_test/tier0/lib/commands/resource/test_resource_enable_disable.py
@@ -1,8 +1,5 @@
 import json
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
 from pcs.common import reports
@@ -13,10 +10,7 @@ from pcs.lib.errors import LibraryError
 from pcs_test.tier0.lib.commands.tag.tag_common import fixture_tags_xml
 from pcs_test.tools import fixture
 from pcs_test.tools.command_env import get_env_tools
-from pcs_test.tools.custom_mock import (
-    TmpFileCall,
-    TmpFileMock,
-)
+from pcs_test.tools.custom_mock import TmpFileCall, TmpFileMock
 from pcs_test.tools.misc import get_test_resource as rc
 from pcs_test.tools.misc import outdent
 from pcs_test.tools.xml import XmlManipulation

--- a/pcs_test/tier0/lib/commands/resource/test_resource_move_autoclean.py
+++ b/pcs_test/tier0/lib/commands/resource/test_resource_move_autoclean.py
@@ -1,13 +1,7 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
+from pcs.common import file_type_codes, reports
 from pcs.common.tools import xml_fromstring
 from pcs.lib.commands.resource import move_autoclean
 from pcs.lib.xml_tools import etree_to_str
@@ -15,10 +9,7 @@ from pcs.lib.xml_tools import etree_to_str
 from pcs_test.tools import fixture
 from pcs_test.tools.assertions import assert_xml_equal
 from pcs_test.tools.command_env import get_env_tools
-from pcs_test.tools.custom_mock import (
-    TmpFileCall,
-    TmpFileMock,
-)
+from pcs_test.tools.custom_mock import TmpFileCall, TmpFileMock
 from pcs_test.tools.misc import get_test_resource as rc
 
 

--- a/pcs_test/tier0/lib/commands/resource/test_resource_move_ban.py
+++ b/pcs_test/tier0/lib/commands/resource/test_resource_move_ban.py
@@ -1,8 +1,5 @@
 from textwrap import dedent
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
 from pcs.common.reports import ReportItemSeverity as severities

--- a/pcs_test/tier0/lib/commands/resource/test_resource_update.py
+++ b/pcs_test/tier0/lib/commands/resource/test_resource_update.py
@@ -1,10 +1,6 @@
-from unittest import (
-    TestCase,
-)
+from unittest import TestCase
 
-from pcs.common import (
-    reports,
-)
+from pcs.common import reports
 from pcs.lib.commands import resource
 from pcs.lib.resource_agent.const import PRIMITIVE_META, STONITH_META
 from pcs.lib.resource_agent.types import ResourceAgentName

--- a/pcs_test/tier0/lib/commands/tag/test_tag_config.py
+++ b/pcs_test/tier0/lib/commands/tag/test_tag_config.py
@@ -1,9 +1,6 @@
 from unittest import TestCase
 
-from pcs.common.pacemaker.tag import (
-    CibTagDto,
-    CibTagListDto,
-)
+from pcs.common.pacemaker.tag import CibTagDto, CibTagListDto
 from pcs.lib.commands import tag as cmd_tag
 
 from pcs_test.tier0.lib.commands.tag.tag_common import (

--- a/pcs_test/tier0/lib/commands/test_acl.py
+++ b/pcs_test/tier0/lib/commands/test_acl.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 import pcs.lib.commands.acl as cmd_acl
 from pcs.common import reports

--- a/pcs_test/tier0/lib/commands/test_booth.py
+++ b/pcs_test/tier0/lib/commands/test_booth.py
@@ -5,10 +5,7 @@ from unittest import TestCase, mock
 
 from pcs import settings
 from pcs.common import file_type_codes, reports
-from pcs.common.booth_dto import (
-    BoothConfigAndAuthfileDto,
-    BoothConfigFileDto,
-)
+from pcs.common.booth_dto import BoothConfigAndAuthfileDto, BoothConfigFileDto
 from pcs.common.file import RawFileError
 from pcs.lib.booth import constants
 from pcs.lib.commands import booth as commands

--- a/pcs_test/tier0/lib/commands/test_cib_options.py
+++ b/pcs_test/tier0/lib/commands/test_cib_options.py
@@ -3,18 +3,9 @@ from unittest import TestCase
 from pcs import settings
 from pcs.common import reports
 from pcs.common.pacemaker.defaults import CibDefaultsDto
-from pcs.common.pacemaker.nvset import (
-    CibNvpairDto,
-    CibNvsetDto,
-)
-from pcs.common.pacemaker.rule import (
-    CibRuleDateCommonDto,
-    CibRuleExpressionDto,
-)
-from pcs.common.types import (
-    CibRuleExpressionType,
-    CibRuleInEffectStatus,
-)
+from pcs.common.pacemaker.nvset import CibNvpairDto, CibNvsetDto
+from pcs.common.pacemaker.rule import CibRuleDateCommonDto, CibRuleExpressionDto
+from pcs.common.types import CibRuleExpressionType, CibRuleInEffectStatus
 from pcs.lib.commands import cib_options
 from pcs.lib.resource_agent import const as ra_const
 

--- a/pcs_test/tier0/lib/commands/test_constraint_common.py
+++ b/pcs_test/tier0/lib/commands/test_constraint_common.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 

--- a/pcs_test/tier0/lib/commands/test_fencing_topology.py
+++ b/pcs_test/tier0/lib/commands/test_fencing_topology.py
@@ -1,9 +1,6 @@
 import logging
 from functools import partial
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.common.fencing_topology import (
     TARGET_TYPE_ATTRIBUTE,

--- a/pcs_test/tier0/lib/commands/test_node.py
+++ b/pcs_test/tier0/lib/commands/test_node.py
@@ -1,10 +1,7 @@
 import logging
 from contextlib import contextmanager
 from functools import partial
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 

--- a/pcs_test/tier0/lib/commands/test_pcsd.py
+++ b/pcs_test/tier0/lib/commands/test_pcsd.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
 from pcs.common.file import RawFileError

--- a/pcs_test/tier0/lib/commands/test_qdevice.py
+++ b/pcs_test/tier0/lib/commands/test_qdevice.py
@@ -1,17 +1,11 @@
 import base64
 import logging
 import os.path
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 import pcs.lib.commands.qdevice as lib
 from pcs import settings
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
+from pcs.common import file_type_codes, reports
 from pcs.common.file import RawFileError
 from pcs.common.reports import ReportItemSeverity as severity
 from pcs.common.reports import codes as report_codes

--- a/pcs_test/tier0/lib/commands/test_stonith.py
+++ b/pcs_test/tier0/lib/commands/test_stonith.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
 from pcs.common import reports

--- a/pcs_test/tier0/lib/commands/test_stonith_update_scsi_devices.py
+++ b/pcs_test/tier0/lib/commands/test_stonith_update_scsi_devices.py
@@ -1,14 +1,8 @@
 import json
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
-from pcs.common import (
-    communication,
-    reports,
-)
+from pcs.common import communication, reports
 from pcs.common.interface import dto
 from pcs.common.tools import timeout_to_seconds
 from pcs.lib.commands import stonith
@@ -20,11 +14,7 @@ from pcs_test.tools.command_env.config_http_corosync import (
 )
 from pcs_test.tools.misc import get_test_resource as rc
 
-from .cluster.common import (
-    corosync_conf_fixture,
-    get_two_node,
-    node_fixture,
-)
+from .cluster.common import corosync_conf_fixture, get_two_node, node_fixture
 
 STONITH_ID_SCSI = "scsi-fence-device"
 STONITH_ID_MPATH = "mpath-fence-device"

--- a/pcs_test/tier0/lib/communication/test_pcs_cfgsync.py
+++ b/pcs_test/tier0/lib/communication/test_pcs_cfgsync.py
@@ -19,10 +19,7 @@ from pcs.common.node_communicator import (
     Response,
 )
 from pcs.common.pcs_cfgsync_dto import SyncConfigsDto
-from pcs.lib.communication.pcs_cfgsync import (
-    ConfigInfo,
-    GetConfigs,
-)
+from pcs.lib.communication.pcs_cfgsync import ConfigInfo, GetConfigs
 
 from pcs_test.tools import fixture
 from pcs_test.tools.custom_mock import (

--- a/pcs_test/tier0/lib/corosync/test_config_facade_quorum_device.py
+++ b/pcs_test/tier0/lib/corosync/test_config_facade_quorum_device.py
@@ -8,10 +8,7 @@ from pcs.common.reports import codes as report_codes
 from pcs.lib.corosync.config_parser import Parser
 
 from pcs_test.tools import fixture
-from pcs_test.tools.assertions import (
-    ac,
-    assert_raise_library_error,
-)
+from pcs_test.tools.assertions import ac, assert_raise_library_error
 from pcs_test.tools.misc import get_test_resource as rc
 from pcs_test.tools.misc import outdent
 

--- a/pcs_test/tier0/lib/corosync/test_config_validators_links.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_links.py
@@ -3,11 +3,7 @@ from unittest import TestCase
 from pcs.common.corosync_conf import CorosyncNodeAddressType
 from pcs.common.reports import codes as report_codes
 from pcs.lib.cib.node import PacemakerNode
-from pcs.lib.corosync import (
-    config_validators,
-    constants,
-    node,
-)
+from pcs.lib.corosync import config_validators, constants, node
 
 from pcs_test.tools import fixture
 from pcs_test.tools.assertions import assert_report_item_list_equal

--- a/pcs_test/tier0/lib/corosync/test_node.py
+++ b/pcs_test/tier0/lib/corosync/test_node.py
@@ -2,10 +2,7 @@ from socket import gaierror
 from unittest import TestCase
 from unittest.mock import patch
 
-from pcs.common.corosync_conf import (
-    CorosyncNodeAddressDto,
-    CorosyncNodeDto,
-)
+from pcs.common.corosync_conf import CorosyncNodeAddressDto, CorosyncNodeDto
 from pcs.common.types import CorosyncNodeAddressType
 from pcs.lib.corosync.node import (
     CorosyncNode,

--- a/pcs_test/tier0/lib/corosync/test_qdevice_client.py
+++ b/pcs_test/tier0/lib/corosync/test_qdevice_client.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 import pcs.lib.corosync.qdevice_client as lib
 from pcs import settings

--- a/pcs_test/tier0/lib/pacemaker/test_api_result.py
+++ b/pcs_test/tier0/lib/pacemaker/test_api_result.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 

--- a/pcs_test/tier0/lib/pacemaker/test_state.py
+++ b/pcs_test/tier0/lib/pacemaker/test_state.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 
@@ -9,11 +6,7 @@ from pcs import settings
 from pcs.common.reports import ReportItemSeverity as severities
 from pcs.common.reports import codes as report_codes
 from pcs.lib.pacemaker import state
-from pcs.lib.pacemaker.state import (
-    ClusterState,
-    _Attrs,
-    _Children,
-)
+from pcs.lib.pacemaker.state import ClusterState, _Attrs, _Children
 
 from pcs_test.tools.assertions import assert_report_item_equal
 from pcs_test.tools.fixture_crm_mon import complete_state

--- a/pcs_test/tier0/lib/permissions/config/test_parser.py
+++ b/pcs_test/tier0/lib/permissions/config/test_parser.py
@@ -7,10 +7,7 @@ from pcs.common.permissions.types import (
     PermissionTargetType,
 )
 from pcs.lib.interface.config import ParserErrorException
-from pcs.lib.permissions.config.parser import (
-    ParserError,
-    ParserV2,
-)
+from pcs.lib.permissions.config.parser import ParserError, ParserV2
 from pcs.lib.permissions.config.types import (
     ClusterEntry,
     ClusterPermissions,

--- a/pcs_test/tier0/lib/resource_agent/test_facade.py
+++ b/pcs_test/tier0/lib/resource_agent/test_facade.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.common import reports
 from pcs.lib import resource_agent as ra

--- a/pcs_test/tier0/lib/resource_agent/test_list.py
+++ b/pcs_test/tier0/lib/resource_agent/test_list.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import settings
 from pcs.common.reports import codes as report_codes

--- a/pcs_test/tier0/lib/resource_agent/test_pcs_transform.py
+++ b/pcs_test/tier0/lib/resource_agent/test_pcs_transform.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.common import const
 from pcs.lib import resource_agent as ra

--- a/pcs_test/tier0/lib/resource_agent/test_xml.py
+++ b/pcs_test/tier0/lib/resource_agent/test_xml.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 

--- a/pcs_test/tier0/lib/test_env.py
+++ b/pcs_test/tier0/lib/test_env.py
@@ -1,9 +1,6 @@
 import logging
 from functools import partial
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.common import file_type_codes
 from pcs.common.reports import ReportItemSeverity as severity

--- a/pcs_test/tier0/lib/test_env_cib.py
+++ b/pcs_test/tier0/lib/test_env_cib.py
@@ -1,8 +1,5 @@
 from functools import partial
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from lxml import etree
 
@@ -13,10 +10,7 @@ from pcs.lib.env import LibraryEnvironment
 from pcs_test.tools import fixture
 from pcs_test.tools.assertions import assert_xml_equal
 from pcs_test.tools.command_env import get_env_tools
-from pcs_test.tools.custom_mock import (
-    TmpFileCall,
-    TmpFileMock,
-)
+from pcs_test.tools.custom_mock import TmpFileCall, TmpFileMock
 from pcs_test.tools.misc import create_setup_patch_mixin
 from pcs_test.tools.misc import get_test_resource as rc
 from pcs_test.tools.xml import etree_to_str

--- a/pcs_test/tier0/lib/test_env_corosync.py
+++ b/pcs_test/tier0/lib/test_env_corosync.py
@@ -1,10 +1,7 @@
 import json
 import re
 from textwrap import dedent
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.common import reports
 from pcs.common.reports import codes as report_codes

--- a/pcs_test/tier0/lib/test_external.py
+++ b/pcs_test/tier0/lib/test_external.py
@@ -1,9 +1,6 @@
 import logging
 from subprocess import DEVNULL
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 import pcs.lib.external as lib
 from pcs import settings

--- a/pcs_test/tier0/lib/test_node_communication.py
+++ b/pcs_test/tier0/lib/test_node_communication.py
@@ -3,10 +3,7 @@ from unittest import TestCase
 
 import pcs.lib.node_communication as lib
 from pcs.common import pcs_pycurl as pycurl
-from pcs.common.host import (
-    Destination,
-    PcsKnownHost,
-)
+from pcs.common.host import Destination, PcsKnownHost
 from pcs.common.node_communicator import (
     Request,
     RequestData,
@@ -21,10 +18,7 @@ from pcs_test.tools.assertions import (
     assert_raise_library_error,
     assert_report_item_equal,
 )
-from pcs_test.tools.custom_mock import (
-    MockCurl,
-    MockLibraryReportProcessor,
-)
+from pcs_test.tools.custom_mock import MockCurl, MockLibraryReportProcessor
 
 
 class NodeTargetLibFactory(TestCase):

--- a/pcs_test/tier0/lib/test_sbd.py
+++ b/pcs_test/tier0/lib/test_sbd.py
@@ -1,7 +1,4 @@
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 import pcs.lib.sbd as lib_sbd
 from pcs import settings

--- a/pcs_test/tier1/cib_resource/common.py
+++ b/pcs_test/tier1/cib_resource/common.py
@@ -11,10 +11,7 @@ from pcs_test.tools.metadata_dto import (
     FIXTURE_KNOWN_META_NAMES_STONITH_META,
 )
 from pcs_test.tools.misc import get_test_resource as rc
-from pcs_test.tools.misc import (
-    get_tmp_file,
-    write_file_to_tmpfile,
-)
+from pcs_test.tools.misc import get_tmp_file, write_file_to_tmpfile
 from pcs_test.tools.pcs_runner import PcsRunner
 
 

--- a/pcs_test/tier1/cib_resource/test_bundle.py
+++ b/pcs_test/tier1/cib_resource/test_bundle.py
@@ -7,10 +7,7 @@ from pcs_test.tools.assertions import AssertPcsMixin
 from pcs_test.tools.bin_mock import get_mock_settings
 from pcs_test.tools.cib import get_assert_pcs_effect_mixin
 from pcs_test.tools.misc import get_test_resource as rc
-from pcs_test.tools.misc import (
-    get_tmp_file,
-    write_file_to_tmpfile,
-)
+from pcs_test.tools.misc import get_tmp_file, write_file_to_tmpfile
 from pcs_test.tools.pcs_runner import PcsRunner
 
 ERRORS_HAVE_OCCURRED = (

--- a/pcs_test/tier1/cib_resource/test_clone_unclone.py
+++ b/pcs_test/tier1/cib_resource/test_clone_unclone.py
@@ -8,10 +8,7 @@ from pcs_test.tier1.cib_resource.common import (
 from pcs_test.tools.bin_mock import get_mock_settings
 from pcs_test.tools.cib import get_assert_pcs_effect_mixin
 from pcs_test.tools.misc import get_test_resource as rc
-from pcs_test.tools.misc import (
-    get_tmp_file,
-    write_data_to_tmpfile,
-)
+from pcs_test.tools.misc import get_tmp_file, write_data_to_tmpfile
 from pcs_test.tools.pcs_runner import PcsRunner
 from pcs_test.tools.xml import XmlManipulation
 

--- a/pcs_test/tier1/cib_resource/test_group_ungroup.py
+++ b/pcs_test/tier1/cib_resource/test_group_ungroup.py
@@ -5,10 +5,7 @@ from lxml import etree
 from pcs_test.tools.bin_mock import get_mock_settings
 from pcs_test.tools.cib import get_assert_pcs_effect_mixin
 from pcs_test.tools.misc import get_test_resource as rc
-from pcs_test.tools.misc import (
-    get_tmp_file,
-    write_data_to_tmpfile,
-)
+from pcs_test.tools.misc import get_tmp_file, write_data_to_tmpfile
 from pcs_test.tools.pcs_runner import PcsRunner
 from pcs_test.tools.xml import XmlManipulation
 

--- a/pcs_test/tier1/cib_resource/test_manage_unmanage.py
+++ b/pcs_test/tier1/cib_resource/test_manage_unmanage.py
@@ -5,10 +5,7 @@ from lxml import etree
 from pcs_test.tools.bin_mock import get_mock_settings
 from pcs_test.tools.cib import get_assert_pcs_effect_mixin
 from pcs_test.tools.misc import get_test_resource as rc
-from pcs_test.tools.misc import (
-    get_tmp_file,
-    write_file_to_tmpfile,
-)
+from pcs_test.tools.misc import get_tmp_file, write_file_to_tmpfile
 from pcs_test.tools.pcs_runner import PcsRunner
 
 

--- a/pcs_test/tier1/cib_resource/test_move.py
+++ b/pcs_test/tier1/cib_resource/test_move.py
@@ -4,10 +4,7 @@ from lxml import etree
 
 from pcs_test.tools.cib import get_assert_pcs_effect_mixin
 from pcs_test.tools.misc import get_test_resource as rc
-from pcs_test.tools.misc import (
-    get_tmp_file,
-    write_data_to_tmpfile,
-)
+from pcs_test.tools.misc import get_tmp_file, write_data_to_tmpfile
 from pcs_test.tools.pcs_runner import PcsRunner
 from pcs_test.tools.xml import XmlManipulation
 

--- a/pcs_test/tier1/cib_resource/test_resource_stonith_is_forbidden.py
+++ b/pcs_test/tier1/cib_resource/test_resource_stonith_is_forbidden.py
@@ -4,10 +4,7 @@ from lxml import etree
 
 from pcs_test.tools.cib import get_assert_pcs_effect_mixin
 from pcs_test.tools.misc import get_test_resource as rc
-from pcs_test.tools.misc import (
-    get_tmp_file,
-    write_data_to_tmpfile,
-)
+from pcs_test.tools.misc import get_tmp_file, write_data_to_tmpfile
 from pcs_test.tools.pcs_runner import PcsRunner
 from pcs_test.tools.xml import XmlManipulation
 

--- a/pcs_test/tier1/cib_resource/test_stonith_resource_is_forbidden.py
+++ b/pcs_test/tier1/cib_resource/test_stonith_resource_is_forbidden.py
@@ -4,10 +4,7 @@ from lxml import etree
 
 from pcs_test.tools.cib import get_assert_pcs_effect_mixin
 from pcs_test.tools.misc import get_test_resource as rc
-from pcs_test.tools.misc import (
-    get_tmp_file,
-    write_data_to_tmpfile,
-)
+from pcs_test.tools.misc import get_tmp_file, write_data_to_tmpfile
 from pcs_test.tools.pcs_runner import PcsRunner
 from pcs_test.tools.xml import XmlManipulation
 

--- a/pcs_test/tier1/cluster/test_config_show.py
+++ b/pcs_test/tier1/cluster/test_config_show.py
@@ -3,10 +3,7 @@ from textwrap import dedent
 from unittest import TestCase
 
 from pcs_test.tools.assertions import AssertPcsMixin
-from pcs_test.tools.misc import (
-    get_tmp_file,
-    write_data_to_tmpfile,
-)
+from pcs_test.tools.misc import get_tmp_file, write_data_to_tmpfile
 from pcs_test.tools.pcs_runner import PcsRunner
 
 from .common import fixture_corosync_conf_minimal

--- a/pcs_test/tier1/cluster/test_config_update.py
+++ b/pcs_test/tier1/cluster/test_config_update.py
@@ -2,10 +2,7 @@ from textwrap import dedent
 from unittest import TestCase
 
 from pcs_test.tools.assertions import AssertPcsMixin
-from pcs_test.tools.misc import (
-    get_tmp_file,
-    write_data_to_tmpfile,
-)
+from pcs_test.tools.misc import get_tmp_file, write_data_to_tmpfile
 from pcs_test.tools.pcs_runner import PcsRunner
 
 from .common import fixture_corosync_conf_minimal

--- a/pcs_test/tier1/cluster/test_config_uuid.py
+++ b/pcs_test/tier1/cluster/test_config_uuid.py
@@ -2,10 +2,7 @@ import json
 from unittest import TestCase
 
 from pcs_test.tools.assertions import AssertPcsMixin
-from pcs_test.tools.misc import (
-    get_tmp_file,
-    write_data_to_tmpfile,
-)
+from pcs_test.tools.misc import get_tmp_file, write_data_to_tmpfile
 from pcs_test.tools.pcs_runner import PcsRunner
 
 from .common import fixture_corosync_conf_minimal

--- a/pcs_test/tier1/cluster/test_setup_local.py
+++ b/pcs_test/tier1/cluster/test_setup_local.py
@@ -6,10 +6,7 @@ from pcs import settings
 from pcs.lib.corosync.constants import CLUSTER_NAME_LENGTH_MAX
 
 from pcs_test.tools.assertions import AssertPcsMixin
-from pcs_test.tools.misc import (
-    get_tmp_file,
-    skip_unless_root,
-)
+from pcs_test.tools.misc import get_tmp_file, skip_unless_root
 from pcs_test.tools.pcs_runner import PcsRunner
 
 

--- a/pcs_test/tier1/constraint/test_config.py
+++ b/pcs_test/tier1/constraint/test_config.py
@@ -16,10 +16,7 @@ from pcs_test.tools.misc import (
     write_data_to_tmpfile,
 )
 from pcs_test.tools.pcs_runner import PcsRunner
-from pcs_test.tools.xml import (
-    XmlManipulation,
-    etree_to_str,
-)
+from pcs_test.tools.xml import XmlManipulation, etree_to_str
 
 RULE_EVAL = RuleInEffectEvalMock(
     {

--- a/pcs_test/tier1/legacy/test_acl.py
+++ b/pcs_test/tier1/legacy/test_acl.py
@@ -3,10 +3,7 @@ from unittest import TestCase
 
 from pcs_test.tools.assertions import AssertPcsMixin
 from pcs_test.tools.misc import get_test_resource as rc
-from pcs_test.tools.misc import (
-    get_tmp_file,
-    write_file_to_tmpfile,
-)
+from pcs_test.tools.misc import get_tmp_file, write_file_to_tmpfile
 from pcs_test.tools.pcs_runner import PcsRunner
 
 empty_cib = rc("cib-empty.xml")

--- a/pcs_test/tier1/legacy/test_cluster.py
+++ b/pcs_test/tier1/legacy/test_cluster.py
@@ -14,10 +14,7 @@ from pcs_test.tools.misc import (
     write_file_to_tmpfile,
 )
 from pcs_test.tools.misc import get_test_resource as rc
-from pcs_test.tools.pcs_runner import (
-    PcsRunner,
-    pcs,
-)
+from pcs_test.tools.pcs_runner import PcsRunner, pcs
 from pcs_test.tools.xml import str_to_etree
 
 

--- a/pcs_test/tier1/legacy/test_resource.py
+++ b/pcs_test/tier1/legacy/test_resource.py
@@ -5,10 +5,7 @@ from lxml import etree
 
 from pcs import resource, utils
 from pcs.common import const
-from pcs.common.str_tools import (
-    format_list,
-    format_plural,
-)
+from pcs.common.str_tools import format_list, format_plural
 from pcs.constraint import LOCATION_NODE_VALIDATION_SKIP_MSG
 from pcs.lib.resource_agent import const as ra_const
 

--- a/pcs_test/tier1/legacy/test_utils.py
+++ b/pcs_test/tier1/legacy/test_utils.py
@@ -2,10 +2,7 @@ import sys
 import xml.dom.minidom
 from io import StringIO
 from time import sleep
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs import utils
 from pcs.common import const

--- a/pcs_test/tier1/test_booth.py
+++ b/pcs_test/tier1/test_booth.py
@@ -1,9 +1,6 @@
 import os
 from textwrap import dedent
-from unittest import (
-    TestCase,
-    mock,
-)
+from unittest import TestCase, mock
 
 from pcs.cli.booth import command as booth_cmd
 from pcs.lib.booth import constants

--- a/pcs_test/tier1/test_node.py
+++ b/pcs_test/tier1/test_node.py
@@ -8,9 +8,7 @@ from pcs.common.interface import dto
 from pcs.common.pacemaker.node import CibNodeDto, CibNodeListDto
 from pcs.common.pacemaker.nvset import CibNvpairDto, CibNvsetDto
 
-from pcs_test.tier1.legacy.common import (
-    FIXTURE_UTILIZATION_WARNING,
-)
+from pcs_test.tier1.legacy.common import FIXTURE_UTILIZATION_WARNING
 from pcs_test.tools.cib import get_assert_pcs_effect_mixin
 from pcs_test.tools.misc import (
     get_test_resource,

--- a/pcs_test/tier1/test_tag.py
+++ b/pcs_test/tier1/test_tag.py
@@ -6,10 +6,7 @@ from unittest import TestCase
 from lxml import etree
 
 from pcs.common.interface import dto
-from pcs.common.pacemaker.tag import (
-    CibTagDto,
-    CibTagListDto,
-)
+from pcs.common.pacemaker.tag import CibTagDto, CibTagListDto
 from pcs.common.types import StringSequence
 from pcs.lib.cib.tools import get_resources
 
@@ -23,10 +20,7 @@ from pcs_test.tools.misc import (
     write_file_to_tmpfile,
 )
 from pcs_test.tools.pcs_runner import PcsRunner
-from pcs_test.tools.xml import (
-    XmlManipulation,
-    etree_to_str,
-)
+from pcs_test.tools.xml import XmlManipulation, etree_to_str
 
 empty_cib = rc("cib-empty.xml")
 tags_cib = rc("cib-tags.xml")

--- a/pcs_test/tools/cib.py
+++ b/pcs_test/tools/cib.py
@@ -1,7 +1,4 @@
-from pcs_test.tools.assertions import (
-    AssertPcsMixin,
-    assert_xml_equal,
-)
+from pcs_test.tools.assertions import AssertPcsMixin, assert_xml_equal
 from pcs_test.tools.misc import write_data_to_tmpfile
 
 

--- a/pcs_test/tools/color_text_runner/result.py
+++ b/pcs_test/tools/color_text_runner/result.py
@@ -1,10 +1,6 @@
 import unittest
 
-from pcs_test.tools.color_text_runner.format import (
-    Format,
-    Output,
-    separator1,
-)
+from pcs_test.tools.color_text_runner.format import Format, Output, separator1
 from pcs_test.tools.color_text_runner.writer import (
     DotWriter,
     ImprovedVerboseWriter,

--- a/pcs_test/tools/command_env/config_corosync_conf.py
+++ b/pcs_test/tools/command_env/config_corosync_conf.py
@@ -1,8 +1,5 @@
 from pcs.lib.corosync.config_facade import ConfigFacade
-from pcs.lib.corosync.config_parser import (
-    Parser,
-    Section,
-)
+from pcs.lib.corosync.config_parser import Parser, Section
 
 from pcs_test.tools.command_env.mock_get_local_corosync_conf import Call
 from pcs_test.tools.misc import get_test_resource as rc

--- a/pcs_test/tools/command_env/config_env.py
+++ b/pcs_test/tools/command_env/config_env.py
@@ -1,8 +1,5 @@
 from pcs import settings
-from pcs.common.host import (
-    Destination,
-    PcsKnownHost,
-)
+from pcs.common.host import Destination, PcsKnownHost
 
 from pcs_test.tools.command_env.mock_push_cib import Call as PushCibCall
 from pcs_test.tools.command_env.mock_push_corosync_conf import (

--- a/pcs_test/tools/command_env/mock_get_local_corosync_conf.py
+++ b/pcs_test/tools/command_env/mock_get_local_corosync_conf.py
@@ -1,8 +1,5 @@
 from pcs import settings
-from pcs.common import (
-    file_type_codes,
-    reports,
-)
+from pcs.common import file_type_codes, reports
 from pcs.common.file import RawFileError
 from pcs.common.reports.item import ReportItem
 from pcs.lib.errors import LibraryError

--- a/pcs_test/tools/command_env/mock_raw_file.py
+++ b/pcs_test/tools/command_env/mock_raw_file.py
@@ -1,9 +1,5 @@
 from pcs import settings
-from pcs.common.file import (
-    FileAlreadyExists,
-    RawFileError,
-    RawFileInterface,
-)
+from pcs.common.file import FileAlreadyExists, RawFileError, RawFileInterface
 
 CALL_TYPE_RAW_FILE_BACKUP = "CALL_TYPE_RAW_FILE_BACKUP"
 CALL_TYPE_RAW_FILE_EXISTS = "CALL_TYPE_RAW_FILE_EXISTS"

--- a/pcs_test/tools/constraints_dto.py
+++ b/pcs_test/tools/constraints_dto.py
@@ -1,7 +1,4 @@
-from pcs.common.const import (
-    PcmkAction,
-    PcmkRoleType,
-)
+from pcs.common.const import PcmkAction, PcmkRoleType
 from pcs.common.pacemaker.constraint import (
     CibConstraintColocationAttributesDto,
     CibConstraintColocationDto,
@@ -23,10 +20,7 @@ from pcs.common.pacemaker.types import (
     CibResourceSetOrderType,
     CibTicketLossPolicy,
 )
-from pcs.common.types import (
-    CibRuleExpressionType,
-    CibRuleInEffectStatus,
-)
+from pcs.common.types import CibRuleExpressionType, CibRuleInEffectStatus
 from pcs.lib.cib.rule.in_effect import RuleInEffectEval
 
 

--- a/pcs_test/tools/custom_mock.py
+++ b/pcs_test/tools/custom_mock.py
@@ -9,10 +9,7 @@ from unittest import mock
 
 import pcs.common.pcs_pycurl as pycurl
 from pcs import settings
-from pcs.common.reports import (
-    ReportItemSeverity,
-    ReportProcessor,
-)
+from pcs.common.reports import ReportItemSeverity, ReportProcessor
 from pcs.common.types import CibRuleInEffectStatus
 from pcs.lib.cib.rule.in_effect import RuleInEffectEval
 from pcs.lib.external import CommandRunner

--- a/pcs_test/tools/misc.py
+++ b/pcs_test/tools/misc.py
@@ -3,10 +3,7 @@ import os
 import re
 import tempfile
 from functools import lru_cache
-from unittest import (
-    mock,
-    skipUnless,
-)
+from unittest import mock, skipUnless
 
 from lxml import etree
 

--- a/pcs_test/tools/nodes_dto.py
+++ b/pcs_test/tools/nodes_dto.py
@@ -1,8 +1,5 @@
 from pcs.common.pacemaker.node import CibNodeDto, CibNodeListDto
-from pcs.common.pacemaker.nvset import (
-    CibNvpairDto,
-    CibNvsetDto,
-)
+from pcs.common.pacemaker.nvset import CibNvpairDto, CibNvsetDto
 from pcs.common.pacemaker.rule import CibRuleExpressionDto
 from pcs.common.types import CibRuleExpressionType, CibRuleInEffectStatus
 from pcs.lib.cib.rule.in_effect import RuleInEffectEval

--- a/pcs_test/tools/resources_dto.py
+++ b/pcs_test/tools/resources_dto.py
@@ -3,10 +3,7 @@ Data structures in this file correspond to resources configured in
 pcs_test/resources/cib-all.xml
 """
 
-from pcs.common.pacemaker.nvset import (
-    CibNvpairDto,
-    CibNvsetDto,
-)
+from pcs.common.pacemaker.nvset import CibNvpairDto, CibNvsetDto
 from pcs.common.pacemaker.resource.bundle import (
     CONTAINER_TYPE_DOCKER,
     CibResourceBundleContainerRuntimeOptionsDto,


### PR DESCRIPTION
Following upgrades linters, I am updating the imports at the top of the file from multiline to oneline.

<!-- testing-farm = {"lock":"false","comment-id":"5044402158","data":[{"id":"0fbacf34-d59e-485d-a9f2-c12f17c3b9ae","name":"CentOS-Stream-10","runTime":492.72954,"created":"2026-07-22T09:43:23.558894","updated":"2026-07-22T09:43:23.558900","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/0fbacf34-d59e-485d-a9f2-c12f17c3b9ae\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0fbacf34-d59e-485d-a9f2-c12f17c3b9ae/pipeline.log\">pipeline</a>"]}]} -->