### PR TITLE
fix `pcs stonith update-scsi-devices` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## Unreleased
+
+### Fixed
+- Command `pcs stonith update-scsi-devices` no longer triggers unnecessary
+  resource restarts when updating SCSI devices. ([RHEL-214140])
+
+[RHEL-214140]: https://redhat.atlassian.net/browse/RHEL-214140
+
+
 ## [0.12.3] - 2026-07-01
 
 ### Added

--- a/pcs/lib/commands/stonith.py
+++ b/pcs/lib/commands/stonith.py
@@ -26,6 +26,7 @@ from pcs.lib.pacemaker.live import (
     fence_history_cleanup,
     fence_history_text,
     fence_history_update,
+    is_cibadmin_update_status_supported,
     is_fence_history_supported_management,
     is_getting_resource_digest_supported,
 )
@@ -254,7 +255,9 @@ def _update_scsi_devices_get_element_and_devices(
     cib -- cib element
     stonith_id -- id of stonith resource
     """
-    if not is_getting_resource_digest_supported(runner):
+    if not is_getting_resource_digest_supported(
+        runner
+    ) or not is_cibadmin_update_status_supported(runner):
         raise LibraryError(
             ReportItem.error(
                 reports.messages.StonithRestartlessUpdateOfScsiDevicesNotSupported()
@@ -381,7 +384,7 @@ def update_scsi_devices(
     _unfencing_scsi_devices(
         env, stonith_el, current_device_list, set_device_list, force_flags
     )
-    env.push_cib()
+    env.push_cib(with_status=True)
 
 
 def update_scsi_devices_add_remove(
@@ -435,4 +438,4 @@ def update_scsi_devices_add_remove(
     _unfencing_scsi_devices(
         env, stonith_el, current_device_list, updated_device_set, force_flags
     )
-    env.push_cib()
+    env.push_cib(with_status=True)

--- a/pcs/lib/env.py
+++ b/pcs/lib/env.py
@@ -226,15 +226,21 @@ class LibraryEnvironment:
                 ReportItem.error(reports.messages.WaitForIdleNotLiveCluster())
             )
 
-    def push_cib(self, custom_cib=None, wait_timeout: int = -1) -> None:
+    def push_cib(
+        self,
+        custom_cib: _Element | None = None,
+        wait_timeout: int = -1,
+        with_status: bool = False,
+    ) -> None:
         """
         Push previously loaded instance of CIB or a custom CIB
 
-        etree custom_cib -- push a custom CIB instead of a loaded instance
+        custom_cib -- push a custom CIB instead of a loaded instance
             (allows to push an externally provided CIB and replace the one in
             the cluster completely)
         wait_timeout -- wait timeout in seconds, if less than 0 wait will be
             skipped, if 0 wait indefinitely
+        with_status -- push also status section of a CIB
         """
         self._ensure_wait_satisfiable(wait_timeout)
         if custom_cib is not None:
@@ -242,10 +248,14 @@ class LibraryEnvironment:
                 raise AssertionError(
                     "CIB has been loaded, cannot push custom CIB"
                 )
+            if with_status:
+                raise AssertionError(
+                    "Cannot push status section of a custom CIB"
+                )
             return self.__push_cib_full(custom_cib, wait_timeout)
         if self.__loaded_cib_diff_source is None:
             raise AssertionError("CIB has not been loaded")
-        return self.__push_cib_diff(wait_timeout)
+        return self.__push_cib_diff(wait_timeout, with_status)
 
     def __push_cib_full(self, cib_to_push, wait_timeout: int):
         self.__do_push_cib(
@@ -253,20 +263,23 @@ class LibraryEnvironment:
             wait_timeout,
         )
 
-    def __push_cib_diff(self, wait_timeout: int):
+    def __push_cib_diff(self, wait_timeout: int, with_status: bool = False):
         self.__do_push_cib(
-            lambda: self.__main_push_cib_diff(self.cmd_runner()), wait_timeout
+            lambda: self.__main_push_cib_diff(self.cmd_runner(), with_status),
+            wait_timeout,
         )
 
-    def __main_push_cib_diff(self, cmd_runner):
+    def __main_push_cib_diff(
+        self, cmd_runner: CommandRunner, with_status: bool = False
+    ):
         cib_diff_xml = diff_cibs_xml(
             cmd_runner,
             self.report_processor,
-            self.__loaded_cib_diff_source,
-            etree_to_str(self.__loaded_cib_to_modify),
+            cast(str, self.__loaded_cib_diff_source),
+            etree_to_str(cast(_Element, self.__loaded_cib_to_modify)),
         )
         if cib_diff_xml:
-            push_cib_diff_xml(cmd_runner, cib_diff_xml)
+            push_cib_diff_xml(cmd_runner, cib_diff_xml, with_status)
 
     def __do_push_cib(self, push_strategy, wait_timeout: int) -> None:
         push_strategy()

--- a/pcs/lib/pacemaker/live.py
+++ b/pcs/lib/pacemaker/live.py
@@ -298,13 +298,17 @@ def replace_cib_configuration(runner: CommandRunner, tree: _Element) -> None:
     return replace_cib_configuration_xml(runner, etree_to_str(tree))
 
 
-def push_cib_diff_xml(runner: CommandRunner, cib_diff_xml: str) -> None:
+def push_cib_diff_xml(
+    runner: CommandRunner, cib_diff_xml: str, with_status: bool = False
+) -> None:
     cmd = [
         settings.cibadmin_exec,
         "--patch",
         "--verbose",
         "--xml-pipe",
     ]
+    if with_status:
+        cmd.append("--update-status")
     stdout, stderr, retval = runner.run(cmd, stdin_string=cib_diff_xml)
     if retval != 0:
         raise LibraryError(
@@ -949,6 +953,12 @@ def is_crm_attribute_list_options_supported(runner: CommandRunner) -> bool:
 def is_getting_resource_digest_supported(runner: CommandRunner) -> bool:
     return _is_in_pcmk_tool_help(
         runner, settings.crm_resource_exec, ["--digests"]
+    )
+
+
+def is_cibadmin_update_status_supported(runner: CommandRunner) -> bool:
+    return _is_in_pcmk_tool_help(
+        runner, settings.cibadmin_exec, ["--update-status"]
     )
 
 

--- a/pcs_test/tier0/lib/commands/test_stonith_update_scsi_devices.py
+++ b/pcs_test/tier0/lib/commands/test_stonith_update_scsi_devices.py
@@ -404,6 +404,7 @@ class UpdateScsiDevicesMixin:
             ),
         )
         self.config.runner.pcmk.is_resource_digests_supported()
+        self.config.runner.pcmk.is_cibadmin_update_status_supported()
         self.config.runner.pcmk.load_state(
             resources=fixture_crm_mon_res_running(
                 self.stonith_id,
@@ -504,6 +505,7 @@ class UpdateScsiDevicesMixin:
                 lrm_monitor_ops=lrm_monitor_ops_updated,
                 digests_attrs_list=digests_attrs_list_updated,
             ),
+            with_status=True,
         )
         kwargs = dict(devices_updated=devices_updated)
         if devices_add is not None:
@@ -546,6 +548,26 @@ class UpdateScsiDevicesFailuresMixin(UpdateScsiDevicesMixin):
             expected_in_processor=False,
         )
 
+    def test_cibadmin_doesnt_support_update_status(self):
+        self.config.runner.cib.load(
+            resources=fixture_scsi(
+                stonith_id=self.stonith_id, stonith_type=self.stonith_type
+            )
+        )
+        self.config.runner.pcmk.is_resource_digests_supported()
+        self.config.runner.pcmk.is_cibadmin_update_status_supported(
+            is_supported=False
+        )
+        self.env_assist.assert_raise_library_error(
+            self.command(),
+            [
+                fixture.error(
+                    reports.codes.STONITH_RESTARTLESS_UPDATE_OF_SCSI_DEVICES_NOT_SUPPORTED,
+                )
+            ],
+            expected_in_processor=False,
+        )
+
     def test_nonexistent_id(self):
         """
         lower level tested in
@@ -558,6 +580,7 @@ class UpdateScsiDevicesFailuresMixin(UpdateScsiDevicesMixin):
             )
         )
         self.config.runner.pcmk.is_resource_digests_supported()
+        self.config.runner.pcmk.is_cibadmin_update_status_supported()
         self.env_assist.assert_raise_library_error(self.command())
         self.env_assist.assert_reports(
             [
@@ -583,6 +606,7 @@ class UpdateScsiDevicesFailuresMixin(UpdateScsiDevicesMixin):
             )
         )
         self.config.runner.pcmk.is_resource_digests_supported()
+        self.config.runner.pcmk.is_cibadmin_update_status_supported()
         self.env_assist.assert_raise_library_error(
             self.command(devices_add=[DEV_2], devices_remove=[DEV_1])
         )
@@ -935,6 +959,7 @@ class UpdateScsiDevicesFailuresMixin(UpdateScsiDevicesMixin):
                 lrm_start_ops=DEFAULT_LRM_START_OPS_UPDATED,
                 lrm_monitor_ops=DEFAULT_LRM_MONITOR_OPS_UPDATED,
             ),
+            with_status=True,
         )
         self.command(force_flags=[reports.codes.SKIP_OFFLINE_NODES])()
         self.env_assist.assert_reports(
@@ -1226,6 +1251,7 @@ class UpdateScsiDevicesSetFailuresBaseMixin(
             )
         )
         self.config.runner.pcmk.is_resource_digests_supported()
+        self.config.runner.pcmk.is_cibadmin_update_status_supported()
         self.env_assist.assert_raise_library_error(
             self.command(devices_updated=())
         )
@@ -1257,6 +1283,7 @@ class UpdateScsiDevicesAddRemoveFailuresBaseMixin(
             )
         )
         self.config.runner.pcmk.is_resource_digests_supported()
+        self.config.runner.pcmk.is_cibadmin_update_status_supported()
         self.env_assist.assert_raise_library_error(
             self.command(devices_add=(), devices_remove=())
         )

--- a/pcs_test/tier0/lib/test_env_cib.py
+++ b/pcs_test/tier0/lib/test_env_cib.py
@@ -46,6 +46,11 @@ class ManageCibAssertionMixin:
             callable_obj, "CIB has been loaded, cannot push custom CIB"
         )
 
+    def assert_raises_cannot_push_status_custom(self, callable_obj):
+        self.assert_raises_cib_error(
+            callable_obj, "Cannot push status section of a custom CIB"
+        )
+
 
 class IsCibLive(TestCase):
     def test_is_live_when_no_cib_data_specified(self):
@@ -379,6 +384,16 @@ class PushLoadedCib(TestCase, ManageCibAssertionMixin):
             ]
         )
 
+    def test_with_status(self):
+        self.config_load_cib_files()
+        self.config.runner.cib.diff(self.tmpfile_old, self.tmpfile_new)
+        self.config.runner.cib.push_diff(with_status=True)
+        env = self.env_assist.get_env()
+
+        env.get_cib()
+        env.push_cib(with_status=True)
+        self.env_assist.assert_reports(self.push_reports())
+
 
 class PushCustomCib(TestCase, ManageCibAssertionMixin):
     custom_cib = "<custom_cib />"
@@ -416,6 +431,12 @@ class PushCustomCib(TestCase, ManageCibAssertionMixin):
                     timeout=self.wait_timeout,
                 )
             ]
+        )
+
+    def test_with_status(self):
+        env = self.env_assist.get_env()
+        self.assert_raises_cannot_push_status_custom(
+            partial(env.push_cib, etree.XML(self.custom_cib), with_status=True)
         )
 
 

--- a/pcs_test/tools/command_env/config_env.py
+++ b/pcs_test/tools/command_env/config_env.py
@@ -86,6 +86,7 @@ class EnvConfig:
         wait=-1,
         exception=None,
         instead=None,
+        with_status=False,
         **modifier_shortcuts,
     ):
         """
@@ -112,7 +113,12 @@ class EnvConfig:
         )
         self.__calls.place(
             name,
-            PushCibCall(cib_xml, wait_timeout=wait, exception=exception),
+            PushCibCall(
+                cib_xml,
+                wait_timeout=wait,
+                exception=exception,
+                with_status=with_status,
+            ),
             instead=instead,
         )
 

--- a/pcs_test/tools/command_env/config_runner_cib.py
+++ b/pcs_test/tools/command_env/config_runner_cib.py
@@ -226,17 +226,22 @@ class CibShortcuts:
         stderr="",
         returncode=0,
         env=None,
+        with_status=False,
     ):
         """
         Create a call for pushing a diff of CIBs
         string name -- key of the call
         string cib_diff -- the diff of CIBs
         dict env -- CommandRunner environment variables
+        bool with_status -- if True, expect --update-status flag
         """
+        cmd = ["cibadmin", "--patch", "--verbose", "--xml-pipe"]
+        if with_status:
+            cmd.append("--update-status")
         self.__calls.place(
             name,
             RunnerCall(
-                ["cibadmin", "--patch", "--verbose", "--xml-pipe"],
+                cmd,
                 check_stdin=CheckStdinEqualXml(cib_diff),
                 stdout=stdout,
                 stderr=stderr,

--- a/pcs_test/tools/command_env/config_runner_pcmk.py
+++ b/pcs_test/tools/command_env/config_runner_pcmk.py
@@ -1006,6 +1006,21 @@ class PcmkShortcuts:
             ),
         )
 
+    def is_cibadmin_update_status_supported(
+        self,
+        name="runner.pcmk.is_cibadmin_update_status_supported",
+        is_supported=True,
+    ):
+        self.__calls.place(
+            name,
+            RunnerCall(
+                ["cibadmin", "--help-all"],
+                stdout="--update-status" if is_supported else "",
+                stderr="",
+                returncode=0,
+            ),
+        )
+
     def resource_digests(
         self,
         resource_id,

--- a/pcs_test/tools/command_env/mock_push_cib.py
+++ b/pcs_test/tools/command_env/mock_push_cib.py
@@ -8,19 +8,28 @@ class Call:
     type = CALL_TYPE_PUSH_CIB
 
     def __init__(
-        self, cib_xml, custom_cib=False, wait_timeout=-1, exception=None
+        self,
+        cib_xml,
+        custom_cib=False,
+        wait_timeout=-1,
+        exception=None,
+        with_status=False,
     ):
         self.cib_xml = cib_xml
         self.custom_cib = custom_cib
         self.wait_timeout = wait_timeout
         self.exception = exception
+        self.with_status = with_status
 
     def __repr__(self):
-        return "<CibPush wait_timeout='{0}'>".format(self.wait_timeout)
+        return (
+            f"<CibPush wait_timeout='{self.wait_timeout}' "
+            f"with_status='{self.with_status}'>"
+        )
 
 
 def get_push_cib(call_queue):
-    def push_cib(lib_env, custom_cib=None, wait_timeout=-1):
+    def push_cib(lib_env, custom_cib=None, wait_timeout=-1, with_status=False):
         i, expected_call = call_queue.take(CALL_TYPE_PUSH_CIB)
 
         if custom_cib is None and expected_call.custom_cib:
@@ -60,6 +69,21 @@ def get_push_cib(call_queue):
                     real_type=type(wait_timeout),
                     expected_value=expected_call.wait_timeout,
                     expected_type=type(expected_call.wait_timeout),
+                )
+            )
+        if with_status != expected_call.with_status:
+            raise AssertionError(
+                (
+                    "Trying to call env.push_cib (call no. {index}) with "
+                    "'with_status' == {real_value} ({real_type}) but it was "
+                    "expected 'with_status' == {expected_value} "
+                    "({expected_type})"
+                ).format(
+                    index=i,
+                    real_value=with_status,
+                    real_type=type(with_status),
+                    expected_value=expected_call.with_status,
+                    expected_type=type(expected_call.with_status),
                 )
             )
 


### PR DESCRIPTION
* use new cibadmin option `--update-status` when updating scsi devices

<!-- testing-farm = {"lock":"false","comment-id":"5060446371","data":[{"id":"96506cfd-95ff-4ad7-8aa2-392c58410c16","name":"CentOS-Stream-10","runTime":477.649744,"created":"2026-07-23T15:38:20.308256","updated":"2026-07-23T15:38:20.308261","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/96506cfd-95ff-4ad7-8aa2-392c58410c16\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/96506cfd-95ff-4ad7-8aa2-392c58410c16/pipeline.log\">pipeline</a>"]}]} -->