### PR TITLE
Add ClaudeCode formating hook 

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+    "hooks": {
+        "PostToolUse": [
+            {
+                "matcher": "Edit|Write",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "scripts/claude-format-file.sh"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/scripts/claude-format-file.sh
+++ b/scripts/claude-format-file.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+file_path="$(python3 -c \
+    "import json, sys; print(json.load(sys.stdin).get('tool_input', {}).get('file_path', ''))" \
+    2>/dev/null)" || true
+
+if [ -z "$file_path" ]; then
+    exit 0
+fi
+
+case "$file_path" in
+    *.py) ;;
+    *) exit 0 ;;
+esac
+
+if ! command -v ruff > /dev/null 2>&1; then
+    echo "claude-format-file: ruff not found, skipping format" >&2
+    exit 0
+fi
+
+if [ -f "$repo_root/pyproject.toml" ]; then
+    ruff check --select I --fix --config "$repo_root/pyproject.toml" "$file_path" || true
+    ruff format --config "$repo_root/pyproject.toml" "$file_path"
+else
+    ruff check --select I --fix "$file_path" || true
+    ruff format "$file_path"
+fi


### PR DESCRIPTION
Add hook for code formatting after every edit or write done by ClaudeCode. Hooks make sure it runs, while if it is in his instructions, he may ignore it.

Assissted-by: ClaudeCode

<!-- testing-farm = {"lock":"false","comment-id":"5127158925","data":[{"id":"73d99502-9d0d-4f47-a945-7501eead47ea","name":"CentOS-Stream-10","runTime":553.330501,"created":"2026-07-30T05:46:24.060600","updated":"2026-07-30T05:46:24.060606","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/73d99502-9d0d-4f47-a945-7501eead47ea\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/73d99502-9d0d-4f47-a945-7501eead47ea/pipeline.log\">pipeline</a>"]}]} -->