### PR TITLE
replace python-dateutil with python stdlib datetime module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Command `pcs stonith update-scsi-devices` no longer triggers unnecessary
   resource restarts when updating SCSI devices. ([RHEL-214140])
 
+### Changed
+- Dropped dependency on `python-dateutil` in favor of the Python standard
+  library `datetime` module. Ordinal date format (`YYYY-DDD`) is no longer
+  accepted in rule date expressions.
+
 ### Deprecated
 - Disabling cluster traffic encryption (setting knet transport crypto options
   `cipher` or `hash` to `none`) ([RHEL-218000])

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ daemon, which operates as a remote server for pcs.
 These are the runtime dependencies of pcs and pcsd:
 * python 3.12+
 * python3-cryptography
-* python3-dateutil 2.7.0+
 * python3-lxml
 * python3-pycurl
 * python3-pyparsing 3.0.0+

--- a/configure.ac
+++ b/configure.ac
@@ -381,13 +381,6 @@ if test "x$tests_only" != "xyes"; then
 	# use them all from the BaseOS or embedded them all as necessary (--enable-local-build)
 	PCS_CHECK_PYMOD([dacite], [], [yes])
 	PCS_CHECK_PYMOD([tornado], [>= 6.0.0], [yes])
-	PCS_CHECK_PYMOD([python-dateutil], [>= 2.7.0], [yes])
-	# setuptoools_scm is needed for bundling dateutil, this uses variables
-	# set by the PCS_CHECK_PYMOD macro, so it must be executed right after it
-	if test "x$bundle_module" = "xyes" && test "x$local_build" = "xyes"; then
-		PCS_CHECK_PYMOD([setuptools-scm])
-		PCS_CHECK_PYMOD([six])
-	fi
 	# Pycurl-7.46.0 requires setuptools => 77. However, if pycurl is already
 	# installed on the system, use whatever pycurl is installed and don't limit
 	# its version based on setuptools version.

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -8,4 +8,3 @@ types-dataclasses
 # error: Call to untyped function "getinfo" in typed context  [no-untyped-call]
 # so we are stuck with this version until there's a fix
 types-pycurl==7.45.2.20240311
-types-python-dateutil

--- a/pcs/lib/cib/rule/validator.py
+++ b/pcs/lib/cib/rule/validator.py
@@ -1,7 +1,6 @@
 import dataclasses
+import datetime as dt
 from collections import Counter, OrderedDict
-
-from dateutil import parser as dateutil_parser
 
 from pcs.common import reports
 from pcs.common.types import CibRuleExpressionType
@@ -23,6 +22,16 @@ from .expression_part import (
 
 
 class Validator:
+    """
+    This validator uses datetime's fromisoformat() for datetime validation.
+    Currently (up to Python 3.14), fromisoformat() does not support:
+        1. Reduced precision dates (YYYY-MM, YYYY)
+        2. Extended date representation (+-YYYYYY-MM-DD)
+        3. Ordinal dates (YYYY-DDD)
+    Pacemaker only supports ordinal dates (3). If needed, create a wrapper
+    around fromisoformat() to handle them.
+    """
+
     def __init__(
         self,
         parsed_rule: BoolExpr,
@@ -93,7 +102,7 @@ class Validator:
 
         if expr.date_start is not None:
             try:
-                start_date = dateutil_parser.isoparse(expr.date_start)
+                start_date = dt.datetime.fromisoformat(expr.date_start)
             except ValueError:
                 report_list.append(
                     reports.item.ReportItem.error(
@@ -104,7 +113,7 @@ class Validator:
                 )
         if expr.date_end is not None:
             try:
-                end_date = dateutil_parser.isoparse(expr.date_end)
+                end_date = dt.datetime.fromisoformat(expr.date_end)
             except ValueError:
                 report_list.append(
                     reports.item.ReportItem.error(
@@ -208,7 +217,7 @@ class Validator:
     ) -> reports.ReportItemList:
         report_list: reports.ReportItemList = []
         try:
-            dateutil_parser.isoparse(expr.date)
+            dt.datetime.fromisoformat(expr.date)
         except ValueError:
             report_list.append(
                 reports.item.ReportItem.error(

--- a/pcs_test/tier0/lib/cib/rule/test_validator.py
+++ b/pcs_test/tier0/lib/cib/rule/test_validator.py
@@ -244,6 +244,29 @@ class DateUnaryExpression(TestCase):
             ],
         )
 
+    def test_date_ordinal_not_supported(self):
+        """
+        Ordinal dates (YYYY-DDD) are valid ISO 8601 and supported by
+        Pacemaker, but datetime's fromisoformat() cannot parse them.
+        This is not intentional and support should be added once the
+        underlying standard library gains this capability.
+        """
+        assert_report_item_list_equal(
+            Validator(
+                BoolExpr(BOOL_AND, [DateUnaryExpr(DATE_OP_GT, "2020-060")])
+            ).get_reports(),
+            [
+                fixture.error(
+                    reports.codes.INVALID_OPTION_VALUE,
+                    option_name="date",
+                    option_value="2020-060",
+                    allowed_values="ISO 8601 date",
+                    cannot_be_empty=False,
+                    forbidden_characters=None,
+                )
+            ],
+        )
+
 
 class DateInrangeExpression(TestCase):
     part_list = {

--- a/plans.fmf
+++ b/plans.fmf
@@ -65,7 +65,6 @@ prepare:
       - python3-wheel
       # pcs python development requirements
       - python3-cryptography
-      - python3-dateutil
       - python3-devel
       - python3-lxml
       - python3-pip
@@ -83,7 +82,6 @@ prepare:
       - rubygem-test-unit
       - rubygems
       # packages required for rpm build
-      - python3-setuptools_scm
       - redhat-rpm-config
       - rpm-build
       - rpmdevtools

--- a/rpm/pcs.spec.in
+++ b/rpm/pcs.spec.in
@@ -15,7 +15,6 @@ Release: 99+git%{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty
 # https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing#Good_Licenses
 # GPL-2.0-only: pcs
 # Apache-2.0: dataclasses, tornado
-# Apache-2.0 OR BSD-3-Clause: dateutil
 # MIT: backports, childprocess, dacite, mustermann, rack, rackup,
 #      rack-protection, rack-session, rack-test, sinatra, tilt
 # MIT AND (BSD-2-Clause OR GPL-2.0-or-later): nio4r
@@ -41,7 +40,7 @@ Release: 99+git%{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty
 #   base64
 # rexml:
 #   strscan (might be included with Ruby)
-License: GPL-2.0-only AND Apache-2.0 AND MIT AND BSD-2-Clause AND BSD-3-Clause AND Ruby AND (BSD-2-Clause OR GPL-2.0-or-later) AND (Apache-2.0 OR BSD-3-Clause) AND (BSD-2-Clause OR Ruby) AND (curl OR LGPL-2.1-or-later)
+License: GPL-2.0-only AND Apache-2.0 AND MIT AND BSD-2-Clause AND BSD-3-Clause AND Ruby AND (BSD-2-Clause OR GPL-2.0-or-later) AND (BSD-2-Clause OR Ruby) AND (curl OR LGPL-2.1-or-later)
 URL: https://github.com/ClusterLabs/pcs
 Summary: Pacemaker/Corosync Configuration System
 
@@ -85,11 +84,6 @@ BuildRequires: python%{python3_version}-setuptools >= 66.1
 
 # for building wheel during make install
 BuildRequires: (python%{python3_version}-wheel if python%{python3_version}-setuptools < 71)
-
-# for bundling dateutil
-%if "@cirpmworkarounds@" != "yes"
-BuildRequires: python%{python3_version}-setuptools_scm
-%endif
 
 # for tier0 tests
 BuildRequires: python%{python3_version}-cryptography


### PR DESCRIPTION
Assisted-by: Claude Code (Claude Opus 4.6)

<!-- testing-farm = {"lock":"false","comment-id":"5328481528","data":[{"id":"ea0055f2-b002-4447-9d7b-6f0098ebc6f4","name":"CentOS-Stream-10","runTime":597.785029,"created":"2026-08-18T12:47:20.101031","updated":"2026-08-18T12:47:20.101037","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/ea0055f2-b002-4447-9d7b-6f0098ebc6f4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ea0055f2-b002-4447-9d7b-6f0098ebc6f4/pipeline.log\">pipeline</a>"]}]} -->