### PR TITLE
remove deprecated --force flag from commands using --yes or --overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Removed
+- The deprecated `--force` flag is no longer accepted as an alternative to
+  `--yes` in commands `pcs cluster destroy`, `pcs quorum unblock`,
+  `pcs stonith confirm`, `pcs stonith sbd device setup`, and
+  `pcs stonith sbd watchdog test`. Use `--yes` instead.
+- The deprecated `--force` flag is no longer accepted as an alternative to
+  `--overwrite` in command `pcs cluster report`. Use `--overwrite` instead.
+
 ### Fixed
 - Command `pcs stonith update-scsi-devices` no longer triggers unnecessary
   resource restarts when updating SCSI devices. ([RHEL-214140])

--- a/pcs/cluster.py
+++ b/pcs/cluster.py
@@ -30,7 +30,7 @@ from pcs.cli.common.tools import print_to_stderr
 from pcs.cli.file import metadata as file_metadata
 from pcs.cli.reports import process_library_reports
 from pcs.cli.reports.messages import report_item_msg_from_dto
-from pcs.cli.reports.output import deprecation_warning, warn
+from pcs.cli.reports.output import warn
 from pcs.common import file as pcs_file
 from pcs.common import file_type_codes, reports
 from pcs.common.auth import HostAuthData
@@ -1256,13 +1256,15 @@ def cluster_destroy(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:  #
     """
     Options:
       * --all - destroy cluster on all cluster nodes => destroy whole cluster
-      * --force - required for destroying the cluster - DEPRECATED
       * --request-timeout - timeout of HTTP requests, effective only with --all
       * --yes - required for destroying the cluster
     """
     del lib
     modifiers.ensure_only_supported(
-        "--all", "--force", "--request-timeout", "--yes"
+        "--all",
+        "--request-timeout",
+        "--yes",
+        hint_syntax_changed="1.0",
     )
     if argv:
         raise CmdLineInputError()
@@ -1275,7 +1277,6 @@ def cluster_destroy(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:  #
             "This would kill all cluster processes and then PERMANENTLY remove "
             "cluster state and configuration",
             bool(modifiers.get("--yes")),
-            bool(modifiers.get("--force")),
         ):
             return
     if modifiers.get("--all"):
@@ -1396,7 +1397,6 @@ def cluster_verify(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:
 def cluster_report(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:  # noqa: PLR0912
     """
     Options:
-      * --force - allow overwriting existing files - DEPRECATED
       * --from - timestamp
       * --to - timestamp
       * --overwrite - allow overwriting existing files
@@ -1406,24 +1406,23 @@ def cluster_report(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:  # 
     """
 
     del lib
-    modifiers.ensure_only_supported("--force", "--from", "--overwrite", "--to")
+    modifiers.ensure_only_supported(
+        "--from",
+        "--overwrite",
+        "--to",
+        hint_syntax_changed="1.0",
+    )
     if len(argv) != 1:
         raise CmdLineInputError()
 
     outfile = argv[0]
     dest_outfile = outfile + ".tar.bz2"
     if os.path.exists(dest_outfile):
-        if not (modifiers.get("--overwrite") or modifiers.get("--force")):
+        if not modifiers.get("--overwrite"):
             utils.err(
                 dest_outfile + " already exists, use --overwrite to overwrite"
             )
             return
-        if modifiers.get("--force"):
-            # deprecated in the first pcs-0.12 version, replaced by --overwrite
-            deprecation_warning(
-                "Using --force to confirm this action is deprecated and might "
-                "be removed in a future release, use --overwrite instead"
-            )
         try:
             os.remove(dest_outfile)
         except OSError as e:

--- a/pcs/pcs.8.in
+++ b/pcs/pcs.8.in
@@ -1736,6 +1736,10 @@ EDITOR
 .TP
 no_proxy, https_proxy, all_proxy, NO_PROXY, HTTPS_PROXY, ALL_PROXY
  These environment variables (listed according to their priorities) control how pcs handles proxy servers when connecting to cluster nodes. See curl(1) man page for details.
+.SH CHANGES IN PCS\-1.0
+This section summarizes the most important changes in commands done in pcs\-1.0.x compared to pcs\-0.12.x. For detailed description of current commands see above.
+.SS "\-\-force no longer accepted as an alternative to \-\-yes or \-\-overwrite"
+The \fB\-\-force\fR flag is no longer accepted as an alternative to interactive confirmation or file overwriting in the following commands. Use \fB\-\-yes\fR or \fB\-\-overwrite\fR instead. Affected commands are: 'pcs cluster destroy', 'pcs quorum unblock', 'pcs stonith confirm', 'pcs stonith sbd device setup', 'pcs stonith sbd watchdog test' (\fB\-\-yes\fR) and 'pcs cluster report' (\fB\-\-overwrite\fR).
 .SH CHANGES IN PCS\-0.12
 This section summarizes the most important changes in commands done in pcs\-0.12.x compared to pcs\-0.11.x. For detailed description of current commands see above.
 .SS "Pacemaker 3 changes"

--- a/pcs/quorum.py
+++ b/pcs/quorum.py
@@ -286,10 +286,9 @@ def quorum_device_heuristics_remove_cmd(
 def quorum_unblock_cmd(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:
     """
     Options:
-      * --force - required for unblocking the quorum - DEPRECATED
       * --yes - required for unblocking the quorum
     """
-    modifiers.ensure_only_supported("--force", "--yes")
+    modifiers.ensure_only_supported("--yes", hint_syntax_changed="1.0")
     if argv:
         raise CmdLineInputError()
 
@@ -317,7 +316,6 @@ def quorum_unblock_cmd(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:
         "do have access to shared resources, data corruption and/or cluster "
         "failure may occur",
         bool(modifiers.get("--yes")),
-        bool(modifiers.get("--force")),
     ):
         return
     for node in unjoined_nodes:

--- a/pcs/stonith.py
+++ b/pcs/stonith.py
@@ -328,11 +328,10 @@ def stonith_fence(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:
 def stonith_confirm(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:
     """
     Options:
-      * --force - required for confirming that fencing happened - DEPRECATED
       * --yes - required for confirming that fencing happened
     """
     del lib
-    modifiers.ensure_only_supported("--force", "--yes")
+    modifiers.ensure_only_supported("--yes", hint_syntax_changed="1.0")
     if len(argv) != 1:
         utils.err("must specify one (and only one) node to confirm fenced")
 
@@ -341,7 +340,6 @@ def stonith_confirm(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:
         f"If node '{node}' is not powered off or it does have access to shared "
         "resources, data corruption and/or cluster failure may occur",
         bool(modifiers.get("--yes")),
-        bool(modifiers.get("--force")),
     ):
         return
     args = ["stonith_admin", "-C", node]
@@ -383,17 +381,15 @@ def sbd_watchdog_list(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:
 def sbd_watchdog_test(lib: Any, argv: Argv, modifiers: InputModifiers) -> None:
     """
     Options:
-      * --force - required for testing the watchdog - DEPRECATED
       * --yes - required for testing the watchdog
     """
-    modifiers.ensure_only_supported("--force", "--yes")
+    modifiers.ensure_only_supported("--yes", hint_syntax_changed="1.0")
     if len(argv) > 1:
         raise CmdLineInputError()
     if not utils.get_continue_confirmation(
         "This operation is expected to force-reboot this system without "
         "following any shutdown procedures",
         bool(modifiers.get("--yes")),
-        bool(modifiers.get("--force")),
     ):
         return
     watchdog = None
@@ -627,10 +623,9 @@ def sbd_setup_block_device(
 ) -> None:
     """
     Options:
-      * --force - required for wiping specified storage devices - DEPRECATED
       * --yes - required for wiping specified storage devices
     """
-    modifiers.ensure_only_supported("--force", "--yes")
+    modifiers.ensure_only_supported("--yes", hint_syntax_changed="1.0")
     parser = KeyValueParser(argv, repeatable=("device",))
     repeatable_options = parser.get_repeatable()
     device_list = repeatable_options.get("device", [])
@@ -641,7 +636,6 @@ def sbd_setup_block_device(
         f"All current content on device(s) {format_list(device_list)} will be "
         "overwritten",
         bool(modifiers.get("--yes")),
-        bool(modifiers.get("--force")),
     ):
         return
 

--- a/pcs/utils.py
+++ b/pcs/utils.py
@@ -1801,9 +1801,7 @@ def is_run_interactive() -> bool:
     )
 
 
-def get_continue_confirmation(
-    warning_text: str, yes: bool, force: bool
-) -> bool:
+def get_continue_confirmation(warning_text: str, yes: bool) -> bool:
     """
     Either asks user to confirm continuation interactively or use --yes to
     override when running from a script. Returns True if user wants to continue.
@@ -1812,17 +1810,8 @@ def get_continue_confirmation(
 
     warning_text -- describes action that we want the user to confirm
     yes -- was --yes flag provided?
-    force -- was --force flag provided? (deprecated)
     """
-    if force and not yes:
-        # Force may be specified for overriding library errors. We don't want
-        # to report an issue in that case.
-        # deprecated in the first pcs-0.12 version
-        reports_output.deprecation_warning(
-            "Using --force to confirm this action is deprecated and might be "
-            "removed in a future release, use --yes instead"
-        )
-    if yes or force:
+    if yes:
         reports_output.warn(warning_text)
         return True
     if not is_run_interactive():

--- a/pcs_test/smoke.sh.in
+++ b/pcs_test/smoke.sh.in
@@ -112,6 +112,6 @@ rm "${token_file}"
 rm "${output_file}"
 rm "${cookie_file}"
 rm "${pcsd_settings_conf_path}"
-pcs cluster destroy --force
+pcs cluster destroy --yes
 userdel -rf testuser
 exit 0

--- a/pcs_test/tier1/legacy/test_utils.py
+++ b/pcs_test/tier1/legacy/test_utils.py
@@ -1665,33 +1665,13 @@ class GetContinueConfirmation(TestCase):
         self.addCleanup(patcher_output.stop)
         self.mock_output = patcher_output.start()
 
-    def test_yes_force(self):
-        self.assertTrue(utils.get_continue_confirmation(self.text, True, True))
-        self.mock_output.assert_called_once_with(f"Warning: {self.text}")
-
     def test_yes(self):
-        self.assertTrue(utils.get_continue_confirmation(self.text, True, False))
+        self.assertTrue(utils.get_continue_confirmation(self.text, True))
         self.mock_output.assert_called_once_with(f"Warning: {self.text}")
-
-    def test_force(self):
-        self.assertTrue(utils.get_continue_confirmation(self.text, False, True))
-        self.assertEqual(
-            self.mock_output.mock_calls,
-            [
-                mock.call(
-                    "Deprecation Warning: Using --force to confirm this action "
-                    "is deprecated and might be removed in a future release, "
-                    "use --yes instead"
-                ),
-                mock.call(f"Warning: {self.text}"),
-            ],
-        )
 
     def test_nothing(self):
         with self.assertRaises(SystemExit) as cm:
-            self.assertFalse(
-                utils.get_continue_confirmation(self.text, False, False)
-            )
+            self.assertFalse(utils.get_continue_confirmation(self.text, False))
         self.assertEqual(cm.exception.code, 1)
         self.mock_output.assert_called_once_with(
             f"Error: {self.text}, use --yes to override"

--- a/pcsd/capabilities.xml.in
+++ b/pcsd/capabilities.xml.in
@@ -2784,6 +2784,14 @@
         pcs commands: --yes
       </description>
     </capability>
+    <capability id="pcs.overwrite-to-confirm-commands" in-pcs="1" in-pcsd="0">
+      <description>
+        Interactive confirmation required by some of pcs commands can be
+        overridden by specifying --overwrite flag.
+
+        pcs commands: --overwrite
+      </description>
+    </capability>
     <capability id="pcs.daemon-ssl-cert.set" in-pcs="1" in-pcsd="1">
       <description>
         Set a SSL certificate (a certificate-key pair) to be used by pcsd on the


### PR DESCRIPTION
Assisted-by: Claude Code (Claude Opus 4.6)

<!-- testing-farm = {"lock":"false","comment-id":"5328594519","data":[{"id":"3b4ca89b-4ad7-4fb9-ac85-7fb3f6f7188a","name":"CentOS-Stream-10","runTime":578.626519,"created":"2026-08-18T13:35:40.025390","updated":"2026-08-18T13:35:40.025397","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/3b4ca89b-4ad7-4fb9-ac85-7fb3f6f7188a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3b4ca89b-4ad7-4fb9-ac85-7fb3f6f7188a/pipeline.log\">pipeline</a>"]}]} -->