### PR TITLE
remove support for sctp knet transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   sync-certificates`
 - Automatic synchronization of pcsd SSL certificates during `pcs cluster setup`
   and `pcs cluster node add`
+- Value `sctp` of the knet link option `transport`, following corosync / knet
+  (TODO rhel jira link)
 
 ### Fixed
 - Command `pcs stonith update-scsi-devices` no longer triggers unnecessary

--- a/pcs/lib/corosync/config_validators.py
+++ b/pcs/lib/corosync/config_validators.py
@@ -834,9 +834,7 @@ def _get_link_options_validators_knet(
         validate.ValueNonnegativeInteger("ping_precision"),
         validate.ValueInteger("ping_timeout", knet_thread_timer_res_ms, None),
         validate.ValueNonnegativeInteger("pong_count"),
-        validate.ValueIn("transport", ("sctp", "udp")),
-        # DEPRECATED in knet 1, to be removed in knet 2.0
-        validate.ValueDeprecated("transport", {"sctp": None}),
+        validate.ValueIn("transport", ("udp",)),
     ]
 
     if including_linknumber:

--- a/pcs/pcs.8.in
+++ b/pcs/pcs.8.in
@@ -480,7 +480,7 @@ This is the default transport. It allows configuring traffic encryption and comp
 .br
 Transport options are: ip_version, knet_pmtud_interval, link_mode
 .br
-Link options are: link_priority, linknumber, mcastport, ping_interval, ping_precision, ping_timeout, pong_count, transport (udp or sctp)
+Link options are: link_priority, linknumber, mcastport, ping_interval, ping_precision, ping_timeout, pong_count, transport
 .br
 Each 'link' followed by options sets options for one link in the order the links are defined by nodes' addresses. You can set link options for a subset of links using a linknumber. See examples below.
 .br
@@ -530,11 +530,11 @@ Create a cluster with default settings:
 Create a cluster using two links:
     pcs cluster setup newcluster node1 addr=10.0.1.11 addr=10.0.2.11 node2 addr=10.0.1.12 addr=10.0.2.12
 .br
-Set link options for all links. Link options are matched to the links in order. The first link (link 0) has sctp transport, the second link (link 1) has mcastport 55405:
-    pcs cluster setup newcluster node1 addr=10.0.1.11 addr=10.0.2.11 node2 addr=10.0.1.12 addr=10.0.2.12 transport knet link transport=sctp link mcastport=55405
+Set link options for all links. Link options are matched to the links in order. The first link (link 0) has pong_count 4, the second link (link 1) has mcastport 55405:
+    pcs cluster setup newcluster node1 addr=10.0.1.11 addr=10.0.2.11 node2 addr=10.0.1.12 addr=10.0.2.12 transport knet link pong_count=4 link mcastport=55405
 .br
 Set link options for the second and fourth links only. Link options are matched to the links based on the linknumber option (the first link is link 0):
-    pcs cluster setup newcluster node1 addr=10.0.1.11 addr=10.0.2.11 addr=10.0.3.11 addr=10.0.4.11 node2 addr=10.0.1.12 addr=10.0.2.12 addr=10.0.3.12 addr=10.0.4.12 transport knet link linknumber=3 mcastport=55405 link linknumber=1 transport=sctp
+    pcs cluster setup newcluster node1 addr=10.0.1.11 addr=10.0.2.11 addr=10.0.3.11 addr=10.0.4.11 node2 addr=10.0.1.12 addr=10.0.2.12 addr=10.0.3.12 addr=10.0.4.12 transport knet link linknumber=3 mcastport=55405 link linknumber=1 pong_count=4
 .br
 Create a cluster using udp transport with a non\-default port:
     pcs cluster setup newcluster node1 node2 transport udp link mcastport=55405
@@ -738,7 +738,7 @@ optionally, you can deauthenticate old node names.
 link add <node_name>=<node_address>... [options <link options>]
 Add a corosync link. One address must be specified for each cluster node. If no linknumber is specified, pcs will use the lowest available linknumber.
 .br
-Link options (documented in corosync.conf(5) man page) are: link_priority, linknumber, mcastport, ping_interval, ping_precision, ping_timeout, pong_count, transport (udp or sctp)
+Link options (documented in corosync.conf(5) man page) are: link_priority, linknumber, mcastport, ping_interval, ping_precision, ping_timeout, pong_count, transport
 .TP
 link delete <linknumber> [<linknumber>]...
 Remove specified corosync links.
@@ -751,7 +751,7 @@ Add, remove or change node addresses / link options of an existing corosync link
 .br
 Link options (documented in corosync.conf(5) man page) are:
 .br
-for knet transport: link_priority, mcastport, ping_interval, ping_precision, ping_timeout, pong_count, transport (udp or sctp)
+for knet transport: link_priority, mcastport, ping_interval, ping_precision, ping_timeout, pong_count, transport
 .br
 for udp and udpu transports: bindnetaddr, broadcast, mcastaddr, mcastport, ttl
 .TP
@@ -1730,6 +1730,11 @@ no_proxy, https_proxy, all_proxy, NO_PROXY, HTTPS_PROXY, ALL_PROXY
  These environment variables (listed according to their priorities) control how pcs handles proxy servers when connecting to cluster nodes. See curl(1) man page for details.
 .SH CHANGES IN PCS\-1.0
 This section summarizes the most important changes in commands done in pcs\-1.0.x compared to pcs\-0.12.x. For detailed description of current commands see above.
+.SS "Corosync / kronosnet changes"
+.TP
+Following Corosync / Kronosnet, pcs has dropped support for:
+.br
+SCTP transport in knet links
 .SS "\-\-force no longer accepted as an alternative to \-\-yes or \-\-overwrite"
 The \fB\-\-force\fR flag is no longer accepted as an alternative to interactive confirmation or file overwriting in the following commands. Use \fB\-\-yes\fR or \fB\-\-overwrite\fR instead. Affected commands are: 'pcs cluster destroy', 'pcs quorum unblock', 'pcs stonith confirm', 'pcs stonith sbd device setup', 'pcs stonith sbd watchdog test' (\fB\-\-yes\fR) and 'pcs cluster report' (\fB\-\-overwrite\fR).
 .SS "pcsd"

--- a/pcs/usage.py
+++ b/pcs/usage.py
@@ -1522,7 +1522,7 @@ Commands:
             ip_version, knet_pmtud_interval, link_mode
         Link options are:
             link_priority, linknumber, mcastport, ping_interval,
-            ping_precision, ping_timeout, pong_count, transport (udp or sctp)
+            ping_precision, ping_timeout, pong_count, transport
             Each 'link' followed by options sets options for one link in the
             order the links are defined by nodes' addresses. You can set link
             options for a subset of links using a linknumber. See examples
@@ -1592,12 +1592,12 @@ Commands:
                 node1 addr=10.0.1.11 addr=10.0.2.11 \\
                 node2 addr=10.0.1.12 addr=10.0.2.12
         Set link options for all links. Link options are matched to the links
-            in order. The first link (link 0) has sctp transport, the second
-            link (link 1) has mcastport 55405:
+            in order. The first link (link 0) has pong_count 4, the second link
+            (link 1) has mcastport 55405:
             pcs cluster setup newcluster \\
                 node1 addr=10.0.1.11 addr=10.0.2.11 \\
                 node2 addr=10.0.1.12 addr=10.0.2.12 \\
-                transport knet link transport=sctp link mcastport=55405
+                transport knet link pong_count=4 link mcastport=55405
         Set link options for the second and fourth links only. Link options are
             matched to the links based on the linknumber option (the first link
             is link 0):
@@ -1608,7 +1608,7 @@ Commands:
                 addr=10.0.1.12 addr=10.0.2.12 addr=10.0.3.12 addr=10.0.4.12 \\
                 transport knet \\
                 link linknumber=3 mcastport=55405 \\
-                link linknumber=1 transport=sctp
+                link linknumber=1 pong_count=4
         Create a cluster using udp transport with a non-default port:
             pcs cluster setup newcluster node1 node2 \\
                 transport udp link mcastport=55405
@@ -1909,7 +1909,7 @@ Commands:
         linknumber.
         Link options (documented in corosync.conf(5) man page) are:
             link_priority, linknumber, mcastport, ping_interval,
-            ping_precision, ping_timeout, pong_count, transport (udp or sctp)
+            ping_precision, ping_timeout, pong_count, transport
 
     link delete <linknumber> [<linknumber>]...
         Remove specified corosync links.
@@ -1927,7 +1927,7 @@ Commands:
         Link options (documented in corosync.conf(5) man page) are:
         for knet transport:
             link_priority, mcastport, ping_interval, ping_precision,
-            ping_timeout, pong_count, transport (udp or sctp)
+            ping_timeout, pong_count, transport
         for udp and udpu transports:
             bindnetaddr, broadcast, mcastaddr, mcastport, ttl
 

--- a/pcs_test/tier0/lib/commands/cluster/test_add_link.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_add_link.py
@@ -96,32 +96,6 @@ class AddLink(TestCase):
         # hidden in self.config.env.push_corosync_conf.
         self.env_assist.assert_reports([])
 
-    def test_success_deprecated_sctp(self):
-        after = self.after.replace(
-            "knet_transport: udp", "knet_transport: sctp"
-        )
-        self.config.corosync_conf.load_content(self.before)
-        self.config.runner.cib.load()
-        self.config.env.push_corosync_conf(corosync_conf_text=after)
-
-        cluster.add_link(
-            self.env_assist.get_env(),
-            self.node_addr_map,
-            {"transport": "sctp"},
-        )
-        # Reports from pushing corosync.conf are produced in env. That code is
-        # hidden in self.config.env.push_corosync_conf.
-        self.env_assist.assert_reports(
-            [
-                fixture.deprecation(
-                    report_codes.DEPRECATED_OPTION_VALUE,
-                    option_name="transport",
-                    deprecated_value="sctp",
-                    replaced_by=None,
-                )
-            ]
-        )
-
     def test_not_live(self):
         self.config.env.set_corosync_conf_data(self.before)
 

--- a/pcs_test/tier0/lib/commands/cluster/test_get_corosync_conf_struct.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_get_corosync_conf_struct.py
@@ -161,9 +161,9 @@ class GetCorosyncConfStruct(TestCase):
                     interface {
                         linknumber: 1
                         knet_link_priority: 200
-                        knet_ping_interval: 750
-                        knet_ping_timeout: 1500
-                        knet_transport: sctp
+                        knet_ping_interval: 751
+                        knet_ping_timeout: 1502
+                        knet_transport: udp
                     }
                 }
 
@@ -276,9 +276,9 @@ class GetCorosyncConfStruct(TestCase):
                     "1": {
                         "linknumber": "1",
                         "link_priority": "200",
-                        "ping_interval": "750",
-                        "ping_timeout": "1500",
-                        "transport": "sctp",
+                        "ping_interval": "751",
+                        "ping_timeout": "1502",
+                        "transport": "udp",
                     },
                 },
                 quorum_options={"wait_for_all": "1"},

--- a/pcs_test/tier0/lib/commands/cluster/test_setup.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_setup.py
@@ -1864,7 +1864,7 @@ class TransportKnetSuccess(TestCase):
                 ping_precision="2",
                 ping_timeout="203",
                 pong_count="4",
-                transport="sctp",
+                transport="udp",
             ),
             dict(mcastport="23456"),
             dict(
@@ -1876,7 +1876,7 @@ class TransportKnetSuccess(TestCase):
                 link_priority="20",
             ),
             dict(mcastport="34567"),
-            dict(transport="sctp"),
+            dict(transport="udp"),
         ]
         links_linknumber = [1, 0, 7, 3, 2, 4]
         transport_options = dict(
@@ -1926,21 +1926,7 @@ class TransportKnetSuccess(TestCase):
             quorum_options=QUORUM_OPTIONS,
         )
         self.env_assist.assert_reports(
-            [
-                fixture.deprecation(
-                    reports.codes.DEPRECATED_OPTION_VALUE,
-                    option_name="transport",
-                    deprecated_value="sctp",
-                    replaced_by=None,
-                ),
-                fixture.deprecation(
-                    reports.codes.DEPRECATED_OPTION_VALUE,
-                    option_name="transport",
-                    deprecated_value="sctp",
-                    replaced_by=None,
-                ),
-            ]
-            + reports_success_minimal_fixture(using_known_hosts_addresses=False)
+            reports_success_minimal_fixture(using_known_hosts_addresses=False)
         )
 
     def test_disable_crypto(self):

--- a/pcs_test/tier0/lib/commands/cluster/test_update_link.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_update_link.py
@@ -249,86 +249,6 @@ class UpdateLinkKnet(TestCase):
         # hidden in self.config.env.push_corosync_conf.
         self.env_assist.assert_reports([])
 
-    def test_success_deprecated_sctp(self):
-        before = """\
-            totem {
-                transport: knet
-
-                interface {
-                    linknumber: 2
-                    knet_transport: udp
-                }
-            }
-
-            nodelist {
-                node {
-                    ring0_addr: node1-addr0
-                    ring2_addr: node1-addr2
-                    name: node1
-                    nodeid: 1
-                }
-
-                node {
-                    ring0_addr: node2-addr0
-                    ring2_addr: node2-addr2a
-                    name: node2
-                    nodeid: 2
-                }
-            }
-        """
-
-        after = """\
-            totem {
-                transport: knet
-
-                interface {
-                    linknumber: 2
-                    knet_transport: sctp
-                }
-            }
-
-            nodelist {
-                node {
-                    ring0_addr: node1-addr0
-                    ring2_addr: node1-addr2
-                    name: node1
-                    nodeid: 1
-                }
-
-                node {
-                    ring0_addr: node2-addr0
-                    ring2_addr: node2-addr2a
-                    name: node2
-                    nodeid: 2
-                }
-            }
-        """
-
-        patch_getaddrinfo(self, self.existing_addrs + ["node2-addr2a"])
-        self.config.corosync_conf.load_content(before)
-        self.config.env.push_corosync_conf(
-            corosync_conf_text=after, need_stopped_cluster=True
-        )
-
-        cluster.update_link(
-            self.env_assist.get_env(),
-            "2",
-            {"node2": "node2-addr2a"},
-            {"transport": "sctp"},
-        )
-        # Reports from pushing corosync.conf are produced in env. That code is
-        # hidden in self.config.env.push_corosync_conf.
-        self.env_assist.assert_reports(
-            [
-                fixture.deprecation(
-                    report_codes.DEPRECATED_OPTION_VALUE,
-                    option_name="transport",
-                    deprecated_value="sctp",
-                    replaced_by=None,
-                )
-            ]
-        )
-
     def test_validation(self):
         patch_getaddrinfo(self, self.existing_addrs + ["node2-addr0"])
         self.config.corosync_conf.load_content(self.before)
@@ -344,7 +264,7 @@ class UpdateLinkKnet(TestCase):
                 },
                 {
                     "wrong": "option",
-                    "transport": "unknown",
+                    "transport": "sctp",
                     "link_priority": 10,
                 },
             ),
@@ -354,9 +274,9 @@ class UpdateLinkKnet(TestCase):
             [
                 fixture.error(
                     report_codes.INVALID_OPTION_VALUE,
-                    option_value="unknown",
+                    option_value="sctp",
                     option_name="transport",
-                    allowed_values=("sctp", "udp"),
+                    allowed_values=("udp",),
                     cannot_be_empty=False,
                     forbidden_characters=None,
                 ),

--- a/pcs_test/tier0/lib/corosync/test_config_facade_links.py
+++ b/pcs_test/tier0/lib/corosync/test_config_facade_links.py
@@ -83,7 +83,7 @@ class GetLinkOptions(TestCase):
                         knet_ping_precision: 4
                         knet_ping_timeout: 5
                         knet_pong_count: 6
-                        knet_transport: sctp
+                        knet_transport: udp
                         unknown: option
                     }
                 }
@@ -98,7 +98,7 @@ class GetLinkOptions(TestCase):
                     "ping_precision": "4",
                     "ping_timeout": "5",
                     "pong_count": "6",
-                    "transport": "sctp",
+                    "transport": "udp",
                 },
             },
         )
@@ -284,7 +284,7 @@ class AddLink(TestCase):
                 "ping_precision": "10",
                 "ping_timeout": "20",
                 "pong_count": "5",
-                "transport": "sctp",
+                "transport": "udp",
             },
             self.before,
             dedent(
@@ -303,7 +303,7 @@ class AddLink(TestCase):
                         knet_ping_precision: 10
                         knet_ping_timeout: 20
                         knet_pong_count: 5
-                        knet_transport: sctp
+                        knet_transport: udp
                         linknumber: 2
                         mcastport: 5405
                     }
@@ -370,7 +370,7 @@ class AddLink(TestCase):
     def test_custom_link_number_options(self):
         self._assert_add(
             {"node1": "node1-addr2", "node2": "node2-addr2"},
-            {"linknumber": "4", "transport": "sctp"},
+            {"linknumber": "4", "transport": "udp"},
             self.before,
             dedent(
                 """\
@@ -383,7 +383,7 @@ class AddLink(TestCase):
                     }
 
                     interface {
-                        knet_transport: sctp
+                        knet_transport: udp
                         linknumber: 4
                     }
                 }
@@ -449,7 +449,7 @@ class AddLink(TestCase):
                 }
 
                 interface {
-                    knet_transport: sctp
+                    knet_transport: udp
                     linknumber: 0
                 }
             }
@@ -475,7 +475,7 @@ class AddLink(TestCase):
         )
         self._assert_add(
             {"node1": "node1-addr0", "node2": "node2-addr0"},
-            {"transport": "sctp"},
+            {"transport": "udp"},
             before,
             after,
         )
@@ -623,7 +623,7 @@ class AddLink(TestCase):
         )
         self._assert_add(
             {"node1": "node1-addr4", "node2": "node2-addr4"},
-            {"linknumber": "4", "transport": "sctp"},
+            {"linknumber": "4", "transport": "udp"},
             before,
             dedent(
                 """\
@@ -638,7 +638,7 @@ class AddLink(TestCase):
                     transport: knet
 
                     interface {
-                        knet_transport: sctp
+                        knet_transport: udp
                         linknumber: 4
                     }
                 }
@@ -685,7 +685,7 @@ class RemoveLinks(TestCase):
 
                 interface {
                     linknumber: 2
-                    knet_transport: sctp
+                    knet_transport: udp
                 }
             }
 
@@ -910,7 +910,7 @@ class RemoveLinks(TestCase):
 
                 interface {
                     linknumber: 2
-                    knet_transport: sctp
+                    knet_transport: udp
                 }
 
                 interface {
@@ -964,7 +964,7 @@ class RemoveLinks(TestCase):
             totem {
                 interface {
                     linknumber: 2
-                    knet_transport: sctp
+                    knet_transport: udp
                 }
             }
 
@@ -1011,7 +1011,7 @@ class RemoveLinks(TestCase):
 
                 interface {
                     linknumber: 1
-                    knet_transport: sctp
+                    knet_transport: udp
                 }
             }
 
@@ -1037,7 +1037,7 @@ class RemoveLinks(TestCase):
             totem {
                 interface {
                     linknumber: 1
-                    knet_transport: sctp
+                    knet_transport: udp
                 }
             }
 
@@ -1194,7 +1194,7 @@ class UpdateLink(TestCase):
 
                 interface {
                     linknumber: 2
-                    knet_transport: sctp
+                    knet_transport: udp
                 }
             }
 
@@ -1217,7 +1217,7 @@ class UpdateLink(TestCase):
         """
         )
         self._assert_update(
-            before, after, "2", {"transport": "sctp"}, {"node1": "new-addr"}
+            before, after, "2", {"transport": "udp"}, {"node1": "new-addr"}
         )
 
     def test_do_not_allow_linknumber_change(self):
@@ -1256,7 +1256,7 @@ class UpdateLink(TestCase):
 
                 interface {
                     linknumber: 1
-                    knet_transport: sctp
+                    knet_transport: udp
                 }
             }
 
@@ -1281,7 +1281,7 @@ class UpdateLink(TestCase):
             before,
             after,
             "1",
-            {"linknumber": "2", "transport": "sctp"},
+            {"linknumber": "2", "transport": "udp"},
             {"node1": "new-addr"},
         )
 
@@ -1410,7 +1410,7 @@ class UpdateLink(TestCase):
 
                 interface {
                     linknumber: 0
-                    knet_transport: sctp
+                    knet_transport: udp
                 }
 
                 interface {
@@ -1428,12 +1428,12 @@ class UpdateLink(TestCase):
 
                 interface {
                     linknumber: 0
-                    knet_transport: sctp
+                    knet_transport: udp
                 }
 
                 interface {
                     linknumber: 1
-                    knet_transport: sctp
+                    knet_transport: udp
                     knet_pong_count: 10
                 }
             }
@@ -1443,7 +1443,7 @@ class UpdateLink(TestCase):
             before,
             after,
             "1",
-            {"transport": "sctp", "mcastport": "", "pong_count": "10"},
+            {"transport": "udp", "mcastport": "", "pong_count": "10"},
             {},
         )
 
@@ -1461,7 +1461,7 @@ class UpdateLink(TestCase):
 
                 interface {
                     linknumber: 0
-                    knet_transport: sctp
+                    knet_transport: udp
                 }
 
                 interface {
@@ -1490,7 +1490,7 @@ class UpdateLink(TestCase):
 
                 interface {
                     linknumber: 0
-                    knet_transport: sctp
+                    knet_transport: udp
                 }
             }
 
@@ -1561,12 +1561,12 @@ class UpdateLink(TestCase):
 
                 interface {
                     linknumber: 1
-                    knet_transport: sctp
+                    knet_transport: udp
                 }
             }
         """
         )
-        self._assert_update(before, after, "1", {"transport": "sctp"}, {})
+        self._assert_update(before, after, "1", {"transport": "udp"}, {})
 
     def test_enable_broadcast(self):
         before = dedent(

--- a/pcs_test/tier0/lib/corosync/test_config_validators_create.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_create.py
@@ -1189,7 +1189,7 @@ class CreateLinkListKnet(CreateLinkListCommonMixin, TestCase):
                         "ping_precision": "15",
                         "ping_timeout": "750",
                         "pong_count": "10",
-                        "transport": "sctp",
+                        "transport": "udp",
                     },
                     {
                         "linknumber": "1",
@@ -1204,14 +1204,7 @@ class CreateLinkListKnet(CreateLinkListCommonMixin, TestCase):
                 ],
                 2,
             ),
-            [
-                fixture.deprecation(
-                    report_codes.DEPRECATED_OPTION_VALUE,
-                    option_name="transport",
-                    deprecated_value="sctp",
-                    replaced_by=None,
-                )
-            ],
+            [],
         )
 
     def test_invalid_all_values(self):
@@ -1263,7 +1256,7 @@ class CreateLinkListKnet(CreateLinkListCommonMixin, TestCase):
                     report_codes.INVALID_OPTION_VALUE,
                     option_value="tcp",
                     option_name="transport",
-                    allowed_values=("sctp", "udp"),
+                    allowed_values=("udp",),
                     cannot_be_empty=False,
                     forbidden_characters=None,
                 ),
@@ -1303,7 +1296,7 @@ class CreateLinkListKnet(CreateLinkListCommonMixin, TestCase):
                     report_codes.INVALID_OPTION_VALUE,
                     option_value="udpu",
                     option_name="transport",
-                    allowed_values=("sctp", "udp"),
+                    allowed_values=("udp",),
                     cannot_be_empty=False,
                     forbidden_characters=None,
                 ),
@@ -1505,7 +1498,7 @@ class CreateLinkListKnet(CreateLinkListCommonMixin, TestCase):
                         "ping_precision": "{}15",
                         "ping_timeout": "\r\n750",
                         "pong_count": "{10}",
-                        "transport": "\rsctp\n",
+                        "transport": "\rudp\n",
                         "op:.tion": "va}l{ue",
                     },
                 ],
@@ -1578,7 +1571,7 @@ class CreateLinkListKnet(CreateLinkListCommonMixin, TestCase):
                 ),
                 fixture.error(
                     report_codes.INVALID_OPTION_VALUE,
-                    option_value="\rsctp\n",
+                    option_value="\rudp\n",
                     option_name="transport",
                     **forbidden_characters_kwargs,
                 ),
@@ -1638,9 +1631,9 @@ class CreateLinkListKnet(CreateLinkListCommonMixin, TestCase):
                 ),
                 fixture.error(
                     report_codes.INVALID_OPTION_VALUE,
-                    option_value="\rsctp\n",
+                    option_value="\rudp\n",
                     option_name="transport",
-                    allowed_values=("sctp", "udp"),
+                    allowed_values=("udp",),
                     cannot_be_empty=False,
                     forbidden_characters=None,
                 ),

--- a/pcs_test/tier0/lib/corosync/test_config_validators_links.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_links.py
@@ -555,7 +555,7 @@ class AddLink(TestCase):
                     report_codes.INVALID_OPTION_VALUE,
                     option_name="transport",
                     option_value="t",
-                    allowed_values=("sctp", "udp"),
+                    allowed_values=("udp",),
                     cannot_be_empty=False,
                     forbidden_characters=None,
                 ),
@@ -749,7 +749,7 @@ class AddLink(TestCase):
                     report_codes.INVALID_OPTION_VALUE,
                     option_value="udp}",
                     option_name="transport",
-                    allowed_values=("sctp", "udp"),
+                    allowed_values=("udp",),
                     cannot_be_empty=False,
                     forbidden_characters=None,
                 ),
@@ -761,29 +761,6 @@ class AddLink(TestCase):
                     cannot_be_empty=False,
                     forbidden_characters=None,
                 ),
-            ],
-        )
-
-    def test_deprecated_sctp_knet_transport(self):
-        assert_report_item_list_equal(
-            config_validators.add_link(
-                self.new_addrs,
-                {
-                    "transport": "sctp",
-                },
-                self.coro_nodes,
-                self.pcmk_nodes,
-                self.existing_link_list,
-                self.transport,
-                constants.IP_VERSION_64,
-            ),
-            [
-                fixture.deprecation(
-                    report_codes.DEPRECATED_OPTION_VALUE,
-                    option_name="transport",
-                    deprecated_value="sctp",
-                    replaced_by=None,
-                )
             ],
         )
 
@@ -1524,7 +1501,7 @@ class UpdateLinkKnet(TestCase):
                     report_codes.INVALID_OPTION_VALUE,
                     option_name="transport",
                     option_value="t",
-                    allowed_values=("sctp", "udp"),
+                    allowed_values=("udp",),
                     cannot_be_empty=False,
                     forbidden_characters=None,
                 ),
@@ -1846,36 +1823,9 @@ class UpdateLinkKnet(TestCase):
                     report_codes.INVALID_OPTION_VALUE,
                     option_value="udp}",
                     option_name="transport",
-                    allowed_values=("sctp", "udp"),
+                    allowed_values=("udp",),
                     cannot_be_empty=False,
                     forbidden_characters=None,
-                ),
-            ],
-        )
-
-    def test_deprecated_sctp_knet_transport(self):
-        assert_report_item_list_equal(
-            config_validators.update_link(
-                "2",
-                {},
-                {
-                    "transport": "sctp",
-                },
-                {},
-                [],
-                [],
-                [
-                    "2",
-                ],
-                constants.TRANSPORTS_KNET[0],
-                constants.IP_VERSION_64,
-            ),
-            [
-                fixture.deprecation(
-                    report_codes.DEPRECATED_OPTION_VALUE,
-                    option_name="transport",
-                    deprecated_value="sctp",
-                    replaced_by=None,
                 ),
             ],
         )

--- a/pcs_test/tier1/cluster/test_setup_local.py
+++ b/pcs_test/tier1/cluster/test_setup_local.py
@@ -162,7 +162,6 @@ class SetupLocal(AssertPcsMixin, TestCase):
                 "transport knet ip_version=ipv4 link_mode=passive "
                 "link linknumber=2 link_priority=100 mcastport=12345 "
                 "ping_interval=201 ping_precision=2 ping_timeout=203 pong_count=4 "
-                "transport=sctp "
                 "link linknumber=1 transport=udp "
                 "compression level=2 model=zlib threshold=10 "
                 "crypto cipher=aes256 hash=sha512 model=openssl "
@@ -170,11 +169,6 @@ class SetupLocal(AssertPcsMixin, TestCase):
                 "quorum last_man_standing=1 last_man_standing_window=10 "
                 "--overwrite --no-cluster-uuid"
             ).split(),
-            stderr_full=(
-                "Deprecation Warning: Value 'sctp' of option transport is "
-                "deprecated and might be removed in a future release, "
-                "therefore it should not be used\n"
-            ),
         )
         self.assertEqual(
             self.corosync_conf_file.read(),
@@ -207,7 +201,6 @@ class SetupLocal(AssertPcsMixin, TestCase):
                         knet_ping_precision: 2
                         knet_ping_timeout: 203
                         knet_pong_count: 4
-                        knet_transport: sctp
                         linknumber: 2
                         mcastport: 12345
                     }
@@ -283,7 +276,7 @@ class SetupLocal(AssertPcsMixin, TestCase):
                 Deprecation Warning: Disabling cluster traffic encryption is deprecated and will not be possible in a future version
                 Error: invalid link option 'pong__count', allowed options are: 'link_priority', 'linknumber', 'mcastport', 'ping_interval', 'ping_precision', 'ping_timeout', 'pong_count', 'transport'
                 Error: '123450' is not a valid mcastport value, use a port number (1..65535)
-                Deprecation Warning: Value 'sctp' of option transport is deprecated and might be removed in a future release, therefore it should not be used
+                Error: 'sctp' is not a valid transport value, use 'udp'
                 Error: Cannot set options for non-existent link '3', existing links: '0', '1', '2'
                 Error: invalid quorum option 'lst_man_standing', allowed options are: 'auto_tie_breaker', 'last_man_standing', 'last_man_standing_window', 'wait_for_all'
                 Error: If quorum option 'last_man_standing_window' is enabled, quorum option 'last_man_standing' must be enabled as well


### PR DESCRIPTION


<!-- testing-farm = {"lock":"false","comment-id":"5424442533","data":[{"id":"87501e10-5f81-4aa2-9c9d-8f6e5b70afb5","name":"CentOS-Stream-10","runTime":541.58331,"created":"2026-08-26T11:00:33.140265","updated":"2026-08-26T11:00:33.140271","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/87501e10-5f81-4aa2-9c9d-8f6e5b70afb5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/87501e10-5f81-4aa2-9c9d-8f6e5b70afb5/pipeline.log\">pipeline</a>"]}]} -->