### PR TITLE
[pcs-0.12] deprecate udp and udpu transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@
 ### Deprecated
 - Disabling cluster traffic encryption (setting knet transport crypto options
   `cipher` or `hash` to `none`) ([RHEL-218000])
+- UDP and UDPU transports, use knet instead ([RHEL-248861])
 
 [RHEL-214140]: https://redhat.atlassian.net/browse/RHEL-214140
 [RHEL-218000]: https://redhat.atlassian.net/browse/RHEL-218000
+[RHEL-248861]: https://redhat.atlassian.net/browse/RHEL-248861
 
 
 ## [0.12.3] - 2026-07-01

--- a/pcs/lib/corosync/config_validators.py
+++ b/pcs/lib/corosync/config_validators.py
@@ -844,7 +844,7 @@ def _get_link_options_validators_knet(
         validate.ValueNonnegativeInteger("pong_count"),
         validate.ValueIn("transport", ("sctp", "udp")),
         # DEPRECATED in knet 1, to be removed in knet 2.0
-        validate.ValueDeprecated("transport", {"sctp": None}),
+        validate.ValueDeprecated("transport", {"sctp": "udp"}),
     ]
 
     if including_linknumber:

--- a/pcs/lib/corosync/config_validators.py
+++ b/pcs/lib/corosync/config_validators.py
@@ -109,6 +109,14 @@ def create(  # noqa: PLR0912, PLR0915
     validators = _get_cluster_name_validators(force_cluster_name) + [
         validate.ValueIn("transport", constants.TRANSPORTS_ALL),
         validate.ValueCorosyncValue("transport"),
+        # deprecated in Corosync 3, to be removed when traffic encryption
+        # becomes mandatory
+        validate.ValueDeprecated(
+            "transport",
+            dict.fromkeys(
+                constants.TRANSPORTS_UDP, constants.TRANSPORT_DEFAULT
+            ),
+        ),
     ]
     report_items = validate.ValidatorAll(validators).validate(
         {"name": cluster_name, "transport": transport}

--- a/pcs_test/tier0/lib/commands/cluster/test_add_link.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_add_link.py
@@ -117,7 +117,7 @@ class AddLink(TestCase):
                     report_codes.DEPRECATED_OPTION_VALUE,
                     option_name="transport",
                     deprecated_value="sctp",
-                    replaced_by=None,
+                    replaced_by="udp",
                 )
             ]
         )

--- a/pcs_test/tier0/lib/commands/cluster/test_setup.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_setup.py
@@ -82,6 +82,18 @@ INTERFACE_TEMPLATE = """
 INTERFACE_OPTION_TEMPLATE = """
         {option}: {value}\
 """
+_FIXTURE_REPORT_UDP_DEPRECATED = fixture.deprecation(
+    reports.codes.DEPRECATED_OPTION_VALUE,
+    option_name="transport",
+    deprecated_value="udp",
+    replaced_by="knet",
+)
+_FIXTURE_REPORT_UDPU_DEPRECATED = fixture.deprecation(
+    reports.codes.DEPRECATED_OPTION_VALUE,
+    option_name="transport",
+    deprecated_value="udpu",
+    replaced_by="knet",
+)
 
 
 def flat_list(list_of_lists):
@@ -272,13 +284,15 @@ def reports_success_minimal_fixture(
     node_list=None,
     using_known_hosts_addresses=True,
     keys_sync=True,
+    udp_udpu_deprecation_reports=None,
 ):
     node_list = node_list or NODE_LIST
     auth_file_list = ["corosync authkey", "pacemaker authkey"]
     pcsd_settings_file = "pcsd settings"
     corosync_conf_file = "corosync.conf"
     report_list = (
-        [
+        (udp_udpu_deprecation_reports or [])
+        + [
             fixture.info(
                 reports.codes.USING_DEFAULT_ADDRESS_FOR_HOST,
                 host_name=node,
@@ -1243,10 +1257,11 @@ class Validation(TestCase):
         )
         self.env_assist.assert_reports(
             [
+                _FIXTURE_REPORT_UDPU_DEPRECATED,
                 fixture.error(
                     reports.codes.COROSYNC_IP_VERSION_MISMATCH_IN_LINKS,
                     link_numbers=["0"],
-                )
+                ),
             ]
         )
 
@@ -1281,6 +1296,7 @@ class Validation(TestCase):
         )
         self.env_assist.assert_reports(
             [
+                _FIXTURE_REPORT_UDP_DEPRECATED,
                 fixture.error(
                     reports.codes.COROSYNC_ADDRESS_IP_VERSION_WRONG_FOR_LINK,
                     address="::ffff:10:0:0:3",
@@ -1290,7 +1306,9 @@ class Validation(TestCase):
             ]
         )
 
-    def _assert_corosync_validators_udp_udpu(self, transport):
+    def _assert_corosync_validators_udp_udpu(
+        self, transport, udp_udpu_deprecation_report
+    ):
         # The validators have their own tests. In here, we are only concerned
         # about calling the validators so we test that all provided options
         # have been validated.
@@ -1325,6 +1343,7 @@ class Validation(TestCase):
         )
         self.env_assist.assert_reports(
             [
+                udp_udpu_deprecation_report,
                 fixture.error(
                     reports.codes.INVALID_OPTIONS,
                     option_names=["a"],
@@ -1375,10 +1394,16 @@ class Validation(TestCase):
         )
 
     def test_corosync_validators_udp(self):
-        self._assert_corosync_validators_udp_udpu("udp")
+        self._assert_corosync_validators_udp_udpu(
+            "udp",
+            _FIXTURE_REPORT_UDP_DEPRECATED,
+        )
 
     def test_corosync_validators_udpu(self):
-        self._assert_corosync_validators_udp_udpu("udpu")
+        self._assert_corosync_validators_udp_udpu(
+            "udpu",
+            _FIXTURE_REPORT_UDPU_DEPRECATED,
+        )
 
     def test_corosync_validators_knet(self):
         # The validators have their own tests. In here, we are only concerned
@@ -2268,7 +2293,10 @@ class TransportUdpSuccess(TestCase):
             transport_type=self.transport_type,
         )
         self.env_assist.assert_reports(
-            reports_success_minimal_fixture(using_known_hosts_addresses=False)
+            reports_success_minimal_fixture(
+                using_known_hosts_addresses=False,
+                udp_udpu_deprecation_reports=[_FIXTURE_REPORT_UDP_DEPRECATED],
+            )
         )
 
     def test_all_options(self):
@@ -2312,7 +2340,10 @@ class TransportUdpSuccess(TestCase):
             quorum_options=QUORUM_OPTIONS,
         )
         self.env_assist.assert_reports(
-            reports_success_minimal_fixture(using_known_hosts_addresses=False)
+            reports_success_minimal_fixture(
+                using_known_hosts_addresses=False,
+                udp_udpu_deprecation_reports=[_FIXTURE_REPORT_UDP_DEPRECATED],
+            )
         )
 
 

--- a/pcs_test/tier0/lib/commands/cluster/test_setup.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_setup.py
@@ -2195,13 +2195,13 @@ class TransportKnetSuccess(TestCase):
                     reports.codes.DEPRECATED_OPTION_VALUE,
                     option_name="transport",
                     deprecated_value="sctp",
-                    replaced_by=None,
+                    replaced_by="udp",
                 ),
                 fixture.deprecation(
                     reports.codes.DEPRECATED_OPTION_VALUE,
                     option_name="transport",
                     deprecated_value="sctp",
-                    replaced_by=None,
+                    replaced_by="udp",
                 ),
             ]
             + reports_success_minimal_fixture(using_known_hosts_addresses=False)

--- a/pcs_test/tier0/lib/commands/cluster/test_update_link.py
+++ b/pcs_test/tier0/lib/commands/cluster/test_update_link.py
@@ -324,7 +324,7 @@ class UpdateLinkKnet(TestCase):
                     report_codes.DEPRECATED_OPTION_VALUE,
                     option_name="transport",
                     deprecated_value="sctp",
-                    replaced_by=None,
+                    replaced_by="udp",
                 )
             ]
         )

--- a/pcs_test/tier0/lib/corosync/test_config_validators_create.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_create.py
@@ -22,6 +22,13 @@ _FIXTURE_KNET_PING_INTERVAL_TIMEOUT_EXPECTED = (
     "an integer greater than or equal to 200"
 )
 
+_FIXTURE_REPORT_UDP_DEPRECATED = fixture.deprecation(
+    report_codes.DEPRECATED_OPTION_VALUE,
+    option_name="transport",
+    deprecated_value="udp",
+    replaced_by="knet",
+)
+
 
 class Create(TestCase):
     def setUp(self):
@@ -42,7 +49,7 @@ class Create(TestCase):
                 "udp",
                 "ipv4",
             ),
-            [],
+            [_FIXTURE_REPORT_UDP_DEPRECATED],
         )
 
     def test_all_valid_udp(self):
@@ -56,7 +63,7 @@ class Create(TestCase):
                 "udp",
                 "ipv4",
             ),
-            [],
+            [_FIXTURE_REPORT_UDP_DEPRECATED],
         )
 
     def test_all_valid_knet(self):
@@ -121,6 +128,7 @@ class Create(TestCase):
                 "ipv4",
             ),
             [
+                _FIXTURE_REPORT_UDP_DEPRECATED,
                 fixture.error(
                     report_codes.COROSYNC_CLUSTER_NAME_INVALID_FOR_GFS2,
                     force_code=report_codes.FORCE,
@@ -142,6 +150,7 @@ class Create(TestCase):
                 "ipv4",
             ),
             [
+                _FIXTURE_REPORT_UDP_DEPRECATED,
                 fixture.error(
                     report_codes.COROSYNC_CLUSTER_NAME_INVALID_FOR_GFS2,
                     force_code=report_codes.FORCE,
@@ -165,6 +174,7 @@ class Create(TestCase):
                 force_cluster_name=True,
             ),
             [
+                _FIXTURE_REPORT_UDP_DEPRECATED,
                 fixture.warn(
                     report_codes.COROSYNC_CLUSTER_NAME_INVALID_FOR_GFS2,
                     cluster_name=cluster_name,
@@ -177,7 +187,10 @@ class Create(TestCase):
     def test_nodelist_empty(self):
         assert_report_item_list_equal(
             config_validators.create("test-cluster", [], "udp", "ipv4"),
-            [fixture.error(report_codes.COROSYNC_NODES_MISSING)],
+            [
+                _FIXTURE_REPORT_UDP_DEPRECATED,
+                fixture.error(report_codes.COROSYNC_NODES_MISSING),
+            ],
         )
 
     def test_empty_node(self):
@@ -192,6 +205,7 @@ class Create(TestCase):
                 "ipv4",
             ),
             [
+                _FIXTURE_REPORT_UDP_DEPRECATED,
                 fixture.error(
                     report_codes.REQUIRED_OPTIONS_ARE_MISSING,
                     option_names=["name"],
@@ -220,6 +234,7 @@ class Create(TestCase):
                 "ipv4",
             ),
             [
+                _FIXTURE_REPORT_UDP_DEPRECATED,
                 fixture.error(
                     report_codes.INVALID_OPTIONS,
                     option_names=["nonsense"],
@@ -242,6 +257,7 @@ class Create(TestCase):
                 "ipv4",
             ),
             [
+                _FIXTURE_REPORT_UDP_DEPRECATED,
                 fixture.error(
                     report_codes.INVALID_OPTION_VALUE,
                     option_value="",
@@ -276,6 +292,7 @@ class Create(TestCase):
                 "ipv4",
             ),
             [
+                _FIXTURE_REPORT_UDP_DEPRECATED,
                 fixture.error(
                     report_codes.INVALID_OPTION_VALUE,
                     option_value="",
@@ -311,7 +328,8 @@ class Create(TestCase):
                 "udp",
                 "ipv4",
             ),
-            [
+            [_FIXTURE_REPORT_UDP_DEPRECATED]
+            + [
                 fixture.error(
                     report_codes.COROSYNC_BAD_NODE_ADDRESSES_COUNT,
                     actual_count=0,
@@ -361,6 +379,7 @@ class Create(TestCase):
                 "ipv4",
             ),
             [
+                _FIXTURE_REPORT_UDP_DEPRECATED,
                 fixture.error(
                     report_codes.COROSYNC_BAD_NODE_ADDRESSES_COUNT,
                     actual_count=2,
@@ -512,6 +531,7 @@ class Create(TestCase):
                 "ipv4",
             ),
             [
+                _FIXTURE_REPORT_UDP_DEPRECATED,
                 fixture.error(
                     report_codes.COROSYNC_IP_VERSION_MISMATCH_IN_LINKS,
                     link_numbers=["0"],
@@ -538,6 +558,7 @@ class Create(TestCase):
                 "ipv6",
             ),
             [
+                _FIXTURE_REPORT_UDP_DEPRECATED,
                 fixture.error(
                     report_codes.COROSYNC_IP_VERSION_MISMATCH_IN_LINKS,
                     link_numbers=["0"],
@@ -625,6 +646,7 @@ class Create(TestCase):
                 "ipv4",
             ),
             [
+                _FIXTURE_REPORT_UDP_DEPRECATED,
                 fixture.error(
                     report_codes.COROSYNC_BAD_NODE_ADDRESSES_COUNT,
                     actual_count=2,

--- a/pcs_test/tier0/lib/corosync/test_config_validators_create.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_create.py
@@ -1231,7 +1231,7 @@ class CreateLinkListKnet(CreateLinkListCommonMixin, TestCase):
                     report_codes.DEPRECATED_OPTION_VALUE,
                     option_name="transport",
                     deprecated_value="sctp",
-                    replaced_by=None,
+                    replaced_by="udp",
                 )
             ],
         )

--- a/pcs_test/tier0/lib/corosync/test_config_validators_links.py
+++ b/pcs_test/tier0/lib/corosync/test_config_validators_links.py
@@ -782,7 +782,7 @@ class AddLink(TestCase):
                     report_codes.DEPRECATED_OPTION_VALUE,
                     option_name="transport",
                     deprecated_value="sctp",
-                    replaced_by=None,
+                    replaced_by="udp",
                 )
             ],
         )
@@ -1875,7 +1875,7 @@ class UpdateLinkKnet(TestCase):
                     report_codes.DEPRECATED_OPTION_VALUE,
                     option_name="transport",
                     deprecated_value="sctp",
-                    replaced_by=None,
+                    replaced_by="udp",
                 ),
             ],
         )

--- a/pcs_test/tier1/cluster/test_setup_local.py
+++ b/pcs_test/tier1/cluster/test_setup_local.py
@@ -173,7 +173,7 @@ class SetupLocal(AssertPcsMixin, TestCase):
             stderr_full=(
                 "Deprecation Warning: Value 'sctp' of option transport is "
                 "deprecated and might be removed in a future release, "
-                "therefore it should not be used\n"
+                "therefore it should not be used, use 'udp' value instead\n"
             ),
         )
         self.assertEqual(
@@ -283,7 +283,7 @@ class SetupLocal(AssertPcsMixin, TestCase):
                 Deprecation Warning: Disabling cluster traffic encryption is deprecated and will not be possible in a future version
                 Error: invalid link option 'pong__count', allowed options are: 'link_priority', 'linknumber', 'mcastport', 'ping_interval', 'ping_precision', 'ping_timeout', 'pong_count', 'transport'
                 Error: '123450' is not a valid mcastport value, use a port number (1..65535)
-                Deprecation Warning: Value 'sctp' of option transport is deprecated and might be removed in a future release, therefore it should not be used
+                Deprecation Warning: Value 'sctp' of option transport is deprecated and might be removed in a future release, therefore it should not be used, use 'udp' value instead
                 Error: Cannot set options for non-existent link '3', existing links: '0', '1', '2'
                 Error: invalid quorum option 'lst_man_standing', allowed options are: 'auto_tie_breaker', 'last_man_standing', 'last_man_standing_window', 'wait_for_all'
                 Error: If quorum option 'last_man_standing_window' is enabled, quorum option 'last_man_standing' must be enabled as well


### PR DESCRIPTION


<!-- testing-farm = {"lock":"false","comment-id":"5426071592","data":[{"id":"915e2b1a-4784-48fa-9230-3f9314122391","name":"CentOS-Stream-10","runTime":625.772355,"created":"2026-08-26T13:20:22.908954","updated":"2026-08-26T13:20:22.908968","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/915e2b1a-4784-48fa-9230-3f9314122391\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/915e2b1a-4784-48fa-9230-3f9314122391/pipeline.log\">pipeline</a>"]}]} -->